### PR TITLE
Add Copy Conversation button to export chat history as markdown

### DIFF
--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -84,6 +84,36 @@ final class CompanionManager: ObservableObject {
     /// Each entry is the user's transcript and Claude's response.
     private var conversationHistory: [(userTranscript: String, assistantResponse: String)] = []
 
+    /// Whether there is at least one exchange in the conversation history.
+    /// Used by the panel to decide whether to show the "Copy Conversation" button.
+    var hasConversationHistory: Bool {
+        !conversationHistory.isEmpty
+    }
+
+    /// Formats the full conversation history as a human-readable markdown string.
+    /// Each user message is prefixed with "**You:**" and each assistant message
+    /// with "**Clicky:**", separated by blank lines for readability.
+    func formatConversationHistoryAsMarkdown() -> String {
+        var markdownLines: [String] = []
+        markdownLines.append("# Clicky Conversation")
+        markdownLines.append("")
+
+        for (exchangeIndex, exchange) in conversationHistory.enumerated() {
+            markdownLines.append("**You:** \(exchange.userTranscript)")
+            markdownLines.append("")
+            markdownLines.append("**Clicky:** \(exchange.assistantResponse)")
+
+            // Add a separator between exchanges, but not after the last one
+            if exchangeIndex < conversationHistory.count - 1 {
+                markdownLines.append("")
+                markdownLines.append("---")
+                markdownLines.append("")
+            }
+        }
+
+        return markdownLines.joined(separator: "\n")
+    }
+
     /// The currently running AI response task, if any. Cancelled when the user
     /// speaks again so a new response can begin immediately.
     private var currentResponseTask: Task<Void, Never>?

--- a/leanring-buddy/CompanionPanelView.swift
+++ b/leanring-buddy/CompanionPanelView.swift
@@ -13,6 +13,9 @@ import SwiftUI
 struct CompanionPanelView: View {
     @ObservedObject var companionManager: CompanionManager
     @State private var emailInput: String = ""
+    /// Briefly set to true after the user copies the conversation, so the
+    /// button label changes to "Copied!" for visual feedback.
+    @State private var hasRecentlyCopiedConversation: Bool = false
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -63,6 +66,14 @@ struct CompanionPanelView: View {
                     .frame(height: 16)
 
                 dmFarzaButton
+                    .padding(.horizontal, 16)
+            }
+
+            if companionManager.hasConversationHistory {
+                Spacer()
+                    .frame(height: 8)
+
+                copyConversationButton
                     .padding(.horizontal, 16)
             }
 
@@ -676,6 +687,46 @@ struct CompanionPanelView: View {
         }
         .buttonStyle(.plain)
         .pointerCursor()
+    }
+
+    // MARK: - Copy Conversation
+
+    private var copyConversationButton: some View {
+        Button(action: {
+            let conversationMarkdown = companionManager.formatConversationHistoryAsMarkdown()
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(conversationMarkdown, forType: .string)
+
+            hasRecentlyCopiedConversation = true
+
+            // Reset the button label back to "Copy Conversation" after 2 seconds
+            DispatchQueue.main.asyncAfter(deadline: .now() + 2.0) {
+                hasRecentlyCopiedConversation = false
+            }
+        }) {
+            HStack(spacing: 8) {
+                Image(systemName: hasRecentlyCopiedConversation ? "checkmark" : "doc.on.doc")
+                    .font(.system(size: 12, weight: .medium))
+
+                Text(hasRecentlyCopiedConversation ? "Copied!" : "Copy Conversation")
+                    .font(.system(size: 12, weight: .semibold))
+            }
+            .foregroundColor(hasRecentlyCopiedConversation ? DS.Colors.success : DS.Colors.textSecondary)
+            .frame(maxWidth: .infinity, alignment: .leading)
+            .padding(.horizontal, 12)
+            .padding(.vertical, 10)
+            .background(
+                RoundedRectangle(cornerRadius: DS.CornerRadius.medium, style: .continuous)
+                    .fill(Color.white.opacity(0.06))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: DS.CornerRadius.medium, style: .continuous)
+                    .stroke(DS.Colors.borderSubtle, lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+        .pointerCursor()
+        .animation(.easeInOut(duration: 0.2), value: hasRecentlyCopiedConversation)
     }
 
     // MARK: - Footer


### PR DESCRIPTION
Adds a button in the companion panel that formats the conversation history as markdown and copies it to the clipboard. Shows 'Copied!' feedback for 2 seconds after copying.

## Changes
- **CompanionManager.swift**: Added `hasConversationHistory` computed property and `formatConversationHistoryAsMarkdown()` method that serializes exchanges as markdown with You/Clicky labels
- **CompanionPanelView.swift**: Added "Copy Conversation" button (visible only when conversation history exists) that copies markdown to clipboard via NSPasteboard, with animated 'Copied!' feedback

Co-Authored-By: Oz <oz-agent@warp.dev>