### PR TITLE
Add configurable push-to-talk keyboard shortcut

### DIFF
--- a/leanring-buddy/BuddyDictationManager.swift
+++ b/leanring-buddy/BuddyDictationManager.swift
@@ -14,68 +14,53 @@ import Foundation
 import Speech
 
 enum BuddyPushToTalkShortcut {
-    enum ShortcutOption {
-        case shiftFunction
-        case controlOption
-        case shiftControl
-        case controlOptionSpace
-        case shiftControlSpace
+    /// The UserDefaults key used to persist the user's chosen push-to-talk shortcut.
+    static let userDefaultsKeyForSelectedShortcut = "selectedPushToTalkShortcut"
+
+    enum ShortcutOption: String, CaseIterable, Identifiable {
+        case controlOption = "controlOption"
+        case commandShift = "commandShift"
+        case controlShift = "controlShift"
+        case functionOption = "functionOption"
+
+        var id: String { rawValue }
 
         var displayText: String {
             switch self {
-            case .shiftFunction:
-                return "shift + fn"
             case .controlOption:
                 return "ctrl + option"
-            case .shiftControl:
-                return "shift + control"
-            case .controlOptionSpace:
-                return "ctrl + option + space"
-            case .shiftControlSpace:
-                return "shift + control + space"
+            case .commandShift:
+                return "cmd + shift"
+            case .controlShift:
+                return "ctrl + shift"
+            case .functionOption:
+                return "fn + option"
             }
         }
 
         var keyCapsuleLabels: [String] {
             switch self {
-            case .shiftFunction:
-                return ["shift", "fn"]
             case .controlOption:
                 return ["ctrl", "option"]
-            case .shiftControl:
-                return ["shift", "control"]
-            case .controlOptionSpace:
-                return ["ctrl", "option", "space"]
-            case .shiftControlSpace:
-                return ["shift", "control", "space"]
+            case .commandShift:
+                return ["cmd", "shift"]
+            case .controlShift:
+                return ["ctrl", "shift"]
+            case .functionOption:
+                return ["fn", "option"]
             }
         }
 
-        fileprivate var modifierOnlyFlags: NSEvent.ModifierFlags? {
+        fileprivate var modifierOnlyFlags: NSEvent.ModifierFlags {
             switch self {
-            case .shiftFunction:
-                return [.shift, .function]
             case .controlOption:
                 return [.control, .option]
-            case .shiftControl:
+            case .commandShift:
+                return [.command, .shift]
+            case .controlShift:
                 return [.shift, .control]
-            case .controlOptionSpace, .shiftControlSpace:
-                return nil
-            }
-        }
-
-        fileprivate var spaceShortcutModifierFlags: NSEvent.ModifierFlags? {
-            switch self {
-            case .shiftFunction:
-                return nil
-            case .controlOption:
-                return nil
-            case .shiftControl:
-                return nil
-            case .controlOptionSpace:
-                return [.control, .option]
-            case .shiftControlSpace:
-                return [.shift, .control]
+            case .functionOption:
+                return [.function, .option]
             }
         }
     }
@@ -92,10 +77,23 @@ enum BuddyPushToTalkShortcut {
         case keyUp
     }
 
-    static let currentShortcutOption: ShortcutOption = .controlOption
-    static let pushToTalkKeyCode: UInt16 = 49 // Space
-    static let pushToTalkDisplayText = currentShortcutOption.displayText
-    static let pushToTalkTooltipText = "push to talk (\(pushToTalkDisplayText))"
+    /// Reads the user's selected push-to-talk shortcut from UserDefaults,
+    /// falling back to ctrl+option if no preference has been saved yet.
+    static var currentShortcutOption: ShortcutOption {
+        guard let savedRawValue = UserDefaults.standard.string(forKey: userDefaultsKeyForSelectedShortcut),
+              let savedOption = ShortcutOption(rawValue: savedRawValue) else {
+            return .controlOption
+        }
+        return savedOption
+    }
+
+    /// Persists the user's chosen push-to-talk shortcut to UserDefaults.
+    static func setSelectedShortcutOption(_ shortcutOption: ShortcutOption) {
+        UserDefaults.standard.set(shortcutOption.rawValue, forKey: userDefaultsKeyForSelectedShortcut)
+    }
+
+    static var pushToTalkDisplayText: String { currentShortcutOption.displayText }
+    static var pushToTalkTooltipText: String { "push to talk (\(pushToTalkDisplayText))" }
 
     static func shortcutTransition(
         for event: NSEvent,
@@ -160,38 +158,16 @@ enum BuddyPushToTalkShortcut {
         modifierFlags: NSEvent.ModifierFlags,
         wasShortcutPreviouslyPressed: Bool
     ) -> ShortcutTransition {
-        if let modifierOnlyFlags = currentShortcutOption.modifierOnlyFlags {
-            guard shortcutEventType == .flagsChanged else { return .none }
+        let modifierOnlyFlags = currentShortcutOption.modifierOnlyFlags
+        guard shortcutEventType == .flagsChanged else { return .none }
 
-            let isShortcutCurrentlyPressed = modifierFlags.contains(modifierOnlyFlags)
+        let isShortcutCurrentlyPressed = modifierFlags.contains(modifierOnlyFlags)
 
-            if isShortcutCurrentlyPressed && !wasShortcutPreviouslyPressed {
-                return .pressed
-            }
-
-            if !isShortcutCurrentlyPressed && wasShortcutPreviouslyPressed {
-                return .released
-            }
-
-            return .none
-        }
-
-        guard let pushToTalkModifierFlags = currentShortcutOption.spaceShortcutModifierFlags else {
-            return .none
-        }
-
-        let matchesModifierFlags = modifierFlags.isSuperset(of: pushToTalkModifierFlags)
-
-        if shortcutEventType == .keyDown
-            && keyCode == pushToTalkKeyCode
-            && matchesModifierFlags
-            && !wasShortcutPreviouslyPressed {
+        if isShortcutCurrentlyPressed && !wasShortcutPreviouslyPressed {
             return .pressed
         }
 
-        if shortcutEventType == .keyUp
-            && keyCode == pushToTalkKeyCode
-            && wasShortcutPreviouslyPressed {
+        if !isShortcutCurrentlyPressed && wasShortcutPreviouslyPressed {
             return .released
         }
 

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -116,6 +116,15 @@ final class CompanionManager: ObservableObject {
         claudeAPI.model = model
     }
 
+    /// The user's selected push-to-talk keyboard shortcut. Persisted to UserDefaults
+    /// via BuddyPushToTalkShortcut so the CGEvent tap reads the same value.
+    @Published var selectedPushToTalkShortcut: BuddyPushToTalkShortcut.ShortcutOption = BuddyPushToTalkShortcut.currentShortcutOption
+
+    func setSelectedPushToTalkShortcut(_ shortcutOption: BuddyPushToTalkShortcut.ShortcutOption) {
+        selectedPushToTalkShortcut = shortcutOption
+        BuddyPushToTalkShortcut.setSelectedShortcutOption(shortcutOption)
+    }
+
     /// User preference for whether the Clicky cursor should be shown.
     /// When toggled off, the overlay is hidden and push-to-talk is disabled.
     /// Persisted to UserDefaults so the choice survives app restarts.
@@ -894,7 +903,7 @@ final class CompanionManager: ObservableObject {
     }
 
     private func startOnboardingPromptStream() {
-        let message = "press control + option and introduce yourself"
+        let message = "press \(selectedPushToTalkShortcut.displayText) and introduce yourself"
         onboardingPromptText = ""
         showOnboardingPrompt = true
         onboardingPromptOpacity = 0.0

--- a/leanring-buddy/CompanionPanelView.swift
+++ b/leanring-buddy/CompanionPanelView.swift
@@ -31,6 +31,12 @@ struct CompanionPanelView: View {
 
                 modelPickerRow
                     .padding(.horizontal, 16)
+
+                Spacer()
+                    .frame(height: 8)
+
+                pushToTalkShortcutPickerRow
+                    .padding(.horizontal, 16)
             }
 
             if !companionManager.allPermissionsGranted {
@@ -127,7 +133,7 @@ struct CompanionPanelView: View {
     @ViewBuilder
     private var permissionsCopySection: some View {
         if companionManager.hasCompletedOnboarding && companionManager.allPermissionsGranted {
-            Text("Hold Control+Option to talk.")
+            Text("Hold \(companionManager.selectedPushToTalkShortcut.displayText) to talk.")
                 .font(.system(size: 12, weight: .medium))
                 .foregroundColor(DS.Colors.textSecondary)
                 .frame(maxWidth: .infinity, alignment: .leading)
@@ -639,6 +645,57 @@ struct CompanionPanelView: View {
         }
         .buttonStyle(.plain)
         .pointerCursor()
+    }
+
+    // MARK: - Push-to-Talk Shortcut Picker
+
+    private var pushToTalkShortcutPickerRow: some View {
+        HStack {
+            Text("Shortcut")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(DS.Colors.textSecondary)
+
+            Spacer()
+
+            Menu {
+                ForEach(BuddyPushToTalkShortcut.ShortcutOption.allCases) { shortcutOption in
+                    Button(action: {
+                        companionManager.setSelectedPushToTalkShortcut(shortcutOption)
+                    }) {
+                        HStack {
+                            Text(shortcutOption.displayText)
+                            if shortcutOption == companionManager.selectedPushToTalkShortcut {
+                                Image(systemName: "checkmark")
+                            }
+                        }
+                    }
+                }
+            } label: {
+                HStack(spacing: 4) {
+                    Text(companionManager.selectedPushToTalkShortcut.displayText)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(DS.Colors.textPrimary)
+
+                    Image(systemName: "chevron.up.chevron.down")
+                        .font(.system(size: 8, weight: .semibold))
+                        .foregroundColor(DS.Colors.textTertiary)
+                }
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color.white.opacity(0.06))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(DS.Colors.borderSubtle, lineWidth: 0.5)
+                )
+            }
+            .menuStyle(.borderlessButton)
+            .fixedSize()
+            .pointerCursor()
+        }
+        .padding(.vertical, 4)
     }
 
     // MARK: - DM Farza Button


### PR DESCRIPTION
Adds a shortcut picker in the companion panel letting users choose their push-to-talk shortcut from preset options (ctrl+option, cmd+shift, ctrl+shift, fn+option). Persisted via UserDefaults.

Co-Authored-By: Oz <oz-agent@warp.dev>