### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/leanring-buddy/CompanionPanelView.swift
+++ b/leanring-buddy/CompanionPanelView.swift
@@ -12,6 +12,7 @@ import SwiftUI
 
 struct CompanionPanelView: View {
     @ObservedObject var companionManager: CompanionManager
+    @ObservedObject private var themeManager = ThemeManager.shared
     @State private var emailInput: String = ""
 
     var body: some View {
@@ -30,6 +31,12 @@ struct CompanionPanelView: View {
                     .frame(height: 12)
 
                 modelPickerRow
+                    .padding(.horizontal, 16)
+
+                Spacer()
+                    .frame(height: 8)
+
+                themePickerRow
                     .padding(.horizontal, 16)
             }
 
@@ -112,7 +119,7 @@ struct CompanionPanelView: View {
                     .frame(width: 20, height: 20)
                     .background(
                         Circle()
-                            .fill(Color.white.opacity(0.08))
+                            .fill(DS.Colors.surface3)
                     )
             }
             .buttonStyle(.plain)
@@ -194,7 +201,7 @@ struct CompanionPanelView: View {
                         .padding(.vertical, 8)
                         .background(
                             RoundedRectangle(cornerRadius: DS.CornerRadius.medium, style: .continuous)
-                                .fill(Color.white.opacity(0.08))
+                                .fill(DS.Colors.surface2)
                         )
                         .overlay(
                             RoundedRectangle(cornerRadius: DS.CornerRadius.medium, style: .continuous)
@@ -612,7 +619,7 @@ struct CompanionPanelView: View {
             }
             .background(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
-                    .fill(Color.white.opacity(0.06))
+                    .fill(DS.Colors.surface2)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
@@ -634,7 +641,52 @@ struct CompanionPanelView: View {
                 .padding(.vertical, 5)
                 .background(
                     RoundedRectangle(cornerRadius: 5, style: .continuous)
-                        .fill(isSelected ? Color.white.opacity(0.1) : Color.clear)
+                        .fill(isSelected ? DS.Colors.surface3 : Color.clear)
+                )
+        }
+        .buttonStyle(.plain)
+        .pointerCursor()
+    }
+
+    // MARK: - Theme Picker
+
+    private var themePickerRow: some View {
+        HStack {
+            Text("Theme")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(DS.Colors.textSecondary)
+
+            Spacer()
+
+            HStack(spacing: 0) {
+                themeOptionButton(label: "Dark", theme: .dark)
+                themeOptionButton(label: "Light", theme: .light)
+            }
+            .background(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .fill(DS.Colors.surface2)
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 6, style: .continuous)
+                    .stroke(DS.Colors.borderSubtle, lineWidth: 0.5)
+            )
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func themeOptionButton(label: String, theme: AppTheme) -> some View {
+        let isSelected = themeManager.activeTheme == theme
+        return Button(action: {
+            themeManager.setTheme(theme)
+        }) {
+            Text(label)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(isSelected ? DS.Colors.textPrimary : DS.Colors.textTertiary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(isSelected ? DS.Colors.surface3 : Color.clear)
                 )
         }
         .buttonStyle(.plain)
@@ -667,7 +719,7 @@ struct CompanionPanelView: View {
             .padding(.vertical, 10)
             .background(
                 RoundedRectangle(cornerRadius: DS.CornerRadius.medium, style: .continuous)
-                    .fill(Color.white.opacity(0.06))
+                    .fill(DS.Colors.surface2)
             )
             .overlay(
                 RoundedRectangle(cornerRadius: DS.CornerRadius.medium, style: .continuous)
@@ -721,8 +773,14 @@ struct CompanionPanelView: View {
     private var panelBackground: some View {
         RoundedRectangle(cornerRadius: 12, style: .continuous)
             .fill(DS.Colors.background)
-            .shadow(color: Color.black.opacity(0.5), radius: 20, x: 0, y: 10)
-            .shadow(color: Color.black.opacity(0.3), radius: 4, x: 0, y: 2)
+            .shadow(
+                color: Color.black.opacity(themeManager.activeTheme == .dark ? 0.5 : 0.15),
+                radius: 20, x: 0, y: 10
+            )
+            .shadow(
+                color: Color.black.opacity(themeManager.activeTheme == .dark ? 0.3 : 0.08),
+                radius: 4, x: 0, y: 2
+            )
     }
 
     private var statusDotColor: Color {

--- a/leanring-buddy/DesignSystem.swift
+++ b/leanring-buddy/DesignSystem.swift
@@ -10,6 +10,36 @@
 import SwiftUI
 import AppKit
 
+// MARK: - Theme
+
+/// The two theme options available in the app.
+enum AppTheme: String, CaseIterable {
+    case dark
+    case light
+}
+
+/// Observable singleton that holds the active theme and persists the user's
+/// choice to UserDefaults. SwiftUI views that read `DS.Colors` will re-render
+/// when `activeTheme` changes because the color accessors read from this object.
+@MainActor
+final class ThemeManager: ObservableObject {
+    static let shared = ThemeManager()
+
+    private static let userDefaultsKey = "clickyAppThemePreference"
+
+    @Published var activeTheme: AppTheme
+
+    private init() {
+        let storedThemeRawValue = UserDefaults.standard.string(forKey: Self.userDefaultsKey)
+        self.activeTheme = storedThemeRawValue.flatMap(AppTheme.init(rawValue:)) ?? .dark
+    }
+
+    func setTheme(_ theme: AppTheme) {
+        activeTheme = theme
+        UserDefaults.standard.set(theme.rawValue, forKey: Self.userDefaultsKey)
+    }
+}
+
 // MARK: - Design System Namespace
 
 /// The top-level namespace for all design system tokens.
@@ -20,43 +50,71 @@ enum DS {
 
     enum Colors {
 
+        /// Convenience accessor so color properties can check the active theme
+        /// without passing ThemeManager around. This is safe because all UI
+        /// state updates happen on @MainActor.
+        private static var isDarkTheme: Bool {
+            ThemeManager.shared.activeTheme == .dark
+        }
+
         // ── Backgrounds ──────────────────────────────────────────────
         // Layered surfaces from deepest to most elevated.
-        // Higher surfaces are lighter, creating a sense of depth.
+        // Dark: higher surfaces are lighter, creating a sense of depth.
+        // Light: higher surfaces are slightly darker/warmer, creating subtle depth.
 
         /// The deepest background — used for the main app window fill.
-        static let background = Color(hex: "#101211")
+        static var background: Color {
+            isDarkTheme ? Color(hex: "#101211") : Color(hex: "#F5F5F4")
+        }
 
         /// First elevation layer — used for cards, sidebar, top bar backgrounds.
-        static let surface1 = Color(hex: "#171918")
+        static var surface1: Color {
+            isDarkTheme ? Color(hex: "#171918") : Color(hex: "#EEEEEC")
+        }
 
         /// Second elevation layer — used for input fields, elevated cards, chat bubbles.
-        static let surface2 = Color(hex: "#202221")
+        static var surface2: Color {
+            isDarkTheme ? Color(hex: "#202221") : Color(hex: "#E5E5E3")
+        }
 
         /// Third elevation layer — used for hover backgrounds on interactive elements.
-        static let surface3 = Color(hex: "#272A29")
+        static var surface3: Color {
+            isDarkTheme ? Color(hex: "#272A29") : Color(hex: "#DCDCDA")
+        }
 
         /// Fourth elevation layer — used for active/pressed states on interactive elements.
-        static let surface4 = Color(hex: "#2E3130")
+        static var surface4: Color {
+            isDarkTheme ? Color(hex: "#2E3130") : Color(hex: "#D2D2D0")
+        }
 
         // ── Borders ──────────────────────────────────────────────────
 
         /// Subtle border — used for card outlines, dividers, input field borders.
-        static let borderSubtle = Color(hex: "#373B39")
+        static var borderSubtle: Color {
+            isDarkTheme ? Color(hex: "#373B39") : Color(hex: "#D0D0CE")
+        }
 
         /// Strong border — used for focused inputs, hovered card outlines.
-        static let borderStrong = Color(hex: "#444947")
+        static var borderStrong: Color {
+            isDarkTheme ? Color(hex: "#444947") : Color(hex: "#B0B0AE")
+        }
 
         // ── Text ─────────────────────────────────────────────────────
 
         /// Primary text — main body text, titles, headings.
-        static let textPrimary = Color(hex: "#ECEEED")
+        static var textPrimary: Color {
+            isDarkTheme ? Color(hex: "#ECEEED") : Color(hex: "#1A1C1B")
+        }
 
         /// Secondary text — descriptions, hints, muted labels.
-        static let textSecondary = Color(hex: "#ADB5B2")
+        static var textSecondary: Color {
+            isDarkTheme ? Color(hex: "#ADB5B2") : Color(hex: "#4A514E")
+        }
 
         /// Tertiary text — very muted, used for section labels, timestamps, disabled text.
-        static let textTertiary = Color(hex: "#6B736F")
+        static var textTertiary: Color {
+            isDarkTheme ? Color(hex: "#6B736F") : Color(hex: "#8A918D")
+        }
 
         /// Text used on top of the accent fill (#2563eb blue), like the primary button label.
         /// White on #2563eb achieves ~5.1:1 contrast — WCAG AA compliant.
@@ -65,6 +123,8 @@ enum DS {
 
         // ── Tailwind Blue Scale ─────────────────────────────────────
         // Full Tailwind CSS v4 blue palette for consistent blue usage.
+        // These are absolute (theme-independent) since they are used as
+        // building blocks for the accent tokens below.
         //
         // Usage guide:
         //   50–100  → Very subtle tinted backgrounds (selected rows, hover fills on dark surfaces)
@@ -99,9 +159,12 @@ enum DS {
         /// #1d4ed8 → ~6.5:1 contrast with white text (WCAG AA+).
         static let accentHover = blue700
 
-        /// Accent text — bright blue used for accent-colored text and icons
-        /// on dark backgrounds (links, active nav items, highlighted labels).
-        static let accentText = blue400
+        /// Accent text — bright blue used for accent-colored text and icons.
+        /// On dark backgrounds: blue400. On light backgrounds: blue600 for
+        /// enough contrast against the light surface.
+        static var accentText: Color {
+            isDarkTheme ? blue400 : blue600
+        }
 
         /// Very subtle accent tint — used for selected item backgrounds (e.g. current step
         /// in the sidebar). Low opacity so it doesn't overpower.
@@ -115,26 +178,38 @@ enum DS {
         /// Destructive hover state.
         static let destructiveHover = Color(hex: "#F2555A")   // Radix Red 10
 
-        /// Destructive used for text on dark backgrounds (brighter for readability).
-        static let destructiveText = Color(hex: "#FF6369")    // Radix Red 11
+        /// Destructive used for text — brighter on dark, darker on light for readability.
+        static var destructiveText: Color {
+            isDarkTheme ? Color(hex: "#FF6369") : Color(hex: "#CE2C31")
+        }
 
         /// Success — checkmarks, granted status, completion indicators.
         /// Independent green so success states are visually distinct from the blue accent.
-        static let success = Color(hex: "#34D399")      // Tailwind Emerald 400
+        static var success: Color {
+            isDarkTheme ? Color(hex: "#34D399") : Color(hex: "#059669")
+        }
 
         /// Warning — caution messages, manual verification failure explanations.
-        static let warning = Color(hex: "#FFB224")            // Radix Amber 9
+        static var warning: Color {
+            isDarkTheme ? Color(hex: "#FFB224") : Color(hex: "#D97706")
+        }
 
-        /// Warning text — brighter variant for text on dark backgrounds.
-        static let warningText = Color(hex: "#F1A10D")        // Radix Amber 11
+        /// Warning text — variant tuned for readability against the theme's surfaces.
+        static var warningText: Color {
+            isDarkTheme ? Color(hex: "#F1A10D") : Color(hex: "#B45309")
+        }
 
         /// Info/feature highlight — used for prompt card headers, code highlights.
         /// Lighter than accentText so informational elements are visually distinct
         /// from interactive accent-colored elements.
-        static let info = Color(hex: "#70B8FF")               // Radix Blue 9
+        static var info: Color {
+            isDarkTheme ? Color(hex: "#70B8FF") : Color(hex: "#2563EB")
+        }
 
         /// Inline code text color — slightly brighter blue for monospace code snippets.
-        static let codeText = Color(hex: "#9DC2FF")           // Radix Blue 11 variant
+        static var codeText: Color {
+            isDarkTheme ? Color(hex: "#9DC2FF") : Color(hex: "#1D4ED8")
+        }
 
         // ── Overlay Cursor ───────────────────────────────────────────
 
@@ -155,17 +230,23 @@ enum DS {
         // ── Help Chat ──────────────────────────────────────────────
 
         /// User message bubble background in the help chat.
-        /// Blue 800 — deep blue that's clearly distinct from the dark surface
-        /// while keeping white text highly readable (~9:1 contrast).
-        static let helpChatUserBubble = blue800
+        /// Dark: Blue 800 — deep blue distinct from dark surface, white text ~9:1 contrast.
+        /// Light: Blue 100 — subtle blue tint on light surface.
+        static var helpChatUserBubble: Color {
+            isDarkTheme ? blue800 : blue100
+        }
 
         /// Slightly lighter variant for hover/pressed states on user bubbles.
-        static let helpChatUserBubbleHover = blue700
+        static var helpChatUserBubbleHover: Color {
+            isDarkTheme ? blue700 : blue200
+        }
 
         /// Footer/backdrop behind the floating help chat.
-        /// Slightly lighter than the main window background so the chat zone reads
+        /// Slightly different from the main window background so the chat zone reads
         /// as a distinct docked surface even before the pill input is visible.
-        static let helpChatBackdrop = Color(hex: "#212121")
+        static var helpChatBackdrop: Color {
+            isDarkTheme ? Color(hex: "#212121") : Color(hex: "#E8E8E6")
+        }
 
         // ── Disabled State ───────────────────────────────────────────
         // Following Material Design 3's disabled pattern:


### PR DESCRIPTION
Adds a theme toggle in the companion panel that switches between dark and light color palettes. The light theme provides tasteful inversions of the existing dark palette. Persisted via UserDefaults.

Co-Authored-By: Oz <oz-agent@warp.dev>