### PR TITLE
Fix blank Settings window with menu bar redirect

### DIFF
--- a/leanring-buddy/leanring_buddyApp.swift
+++ b/leanring-buddy/leanring_buddyApp.swift
@@ -16,11 +16,22 @@ struct leanring_buddyApp: App {
     @NSApplicationDelegateAdaptor(CompanionAppDelegate.self) var appDelegate
 
     var body: some Scene {
-        // The app lives entirely in the menu bar panel managed by the AppDelegate.
-        // This empty Settings scene satisfies SwiftUI's requirement for at least
-        // one scene but is never shown (LSUIElement=true removes the app menu).
+        // SwiftUI requires at least one scene. Users can reach this via
+        // Cmd+, so show a helpful redirect instead of a blank window.
         Settings {
-            EmptyView()
+            VStack(spacing: 12) {
+                Image(systemName: "menubar.arrow.up.rectangle")
+                    .font(.system(size: 32))
+                    .foregroundColor(.secondary)
+
+                Text("Clicky lives in your menu bar")
+                    .font(.system(size: 14, weight: .medium))
+
+                Text("Click the menu bar icon to open controls.")
+                    .font(.system(size: 12))
+                    .foregroundColor(.secondary)
+            }
+            .frame(width: 260, height: 140)
         }
     }
 }


### PR DESCRIPTION
The Settings scene used `EmptyView()` to satisfy SwiftUI's one-scene requirement. But pressing Cmd+, still opens it, leaving users with a blank window (#12).

Replaced with a small view that says "Clicky lives in your menu bar" and points users to the menu bar icon. Uses system SF Symbol and standard secondary text colors.

Single file changed, 15 lines added. No new dependencies, no behavior changes outside the Settings window.

Fixes #12

This contribution was developed with AI assistance (Claude Code).