### PR TITLE
feat: Add auto-copy response to clipboard toggle

### DIFF
--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -139,6 +139,15 @@ final class CompanionManager: ObservableObject {
         }
     }
 
+    /// Whether Clicky's responses are automatically copied to the clipboard.
+    /// Defaults to OFF. Persisted to UserDefaults.
+    @Published var isAutoCopyResponseEnabled: Bool = UserDefaults.standard.bool(forKey: "isAutoCopyResponseEnabled")
+
+    func setAutoCopyResponseEnabled(_ enabled: Bool) {
+        isAutoCopyResponseEnabled = enabled
+        UserDefaults.standard.set(enabled, forKey: "isAutoCopyResponseEnabled")
+    }
+
     /// Whether the user has completed onboarding at least once. Persisted
     /// to UserDefaults so the Start button only appears on first launch.
     var hasCompletedOnboarding: Bool {
@@ -679,6 +688,12 @@ final class CompanionManager: ObservableObject {
                     print("🎯 Element pointing: (\(Int(pointCoordinate.x)), \(Int(pointCoordinate.y))) → \"\(parseResult.elementLabel ?? "element")\"")
                 } else {
                     print("🎯 Element pointing: \(parseResult.elementLabel ?? "no element")")
+                }
+
+                // Copy the clean response to the clipboard if the user has enabled auto-copy
+                if isAutoCopyResponseEnabled {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(spokenText, forType: .string)
                 }
 
                 // Save this exchange to conversation history (with the point tag

--- a/leanring-buddy/CompanionPanelView.swift
+++ b/leanring-buddy/CompanionPanelView.swift
@@ -62,6 +62,9 @@ struct CompanionPanelView: View {
                 Spacer()
                     .frame(height: 16)
 
+                autoCopyResponseToggleRow
+                    .padding(.horizontal, 16)
+
                 dmFarzaButton
                     .padding(.horizontal, 16)
             }
@@ -544,6 +547,35 @@ struct CompanionPanelView: View {
     }
 
 
+
+    // MARK: - Auto-Copy Response Toggle
+
+    private var autoCopyResponseToggleRow: some View {
+        HStack {
+            HStack(spacing: 8) {
+                Image(systemName: "doc.on.clipboard")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(DS.Colors.textTertiary)
+                    .frame(width: 16)
+
+                Text("Copy responses")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(DS.Colors.textSecondary)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: Binding(
+                get: { companionManager.isAutoCopyResponseEnabled },
+                set: { companionManager.setAutoCopyResponseEnabled($0) }
+            ))
+            .toggleStyle(.switch)
+            .labelsHidden()
+            .tint(DS.Colors.accent)
+            .scaleEffect(0.8)
+        }
+        .padding(.vertical, 4)
+    }
 
     // MARK: - Show Clicky Cursor Toggle
 


### PR DESCRIPTION
## Summary
- Adds a **"Copy responses"** toggle in the menu bar panel
- When enabled, Clicky's response text is automatically copied to the macOS clipboard after each response
- Uses the clean spoken text (no `[POINT:...]` tags)
- Defaults to OFF, persists via UserDefaults

## Changes
- `CompanionManager.swift` — new `isAutoCopyResponseEnabled` property, setter, and clipboard copy logic
- `CompanionPanelView.swift` — new toggle row in the panel, following the existing "Show Clicky" toggle pattern

## Test plan
- [ ] Build and run in Xcode (Cmd+R)
- [ ] Complete onboarding so the toggle appears
- [ ] Toggle "Copy responses" ON
- [ ] Ask Clicky a question, then Cmd+V to verify the response was copied
- [ ] Toggle OFF, ask another question, verify clipboard was NOT overwritten
- [ ] Quit and relaunch — verify toggle state persists

🤖 Generated with [Claude Code](https://claude.com/claude-code)