### PR TITLE
Remove obsolete Anthropic key from project settings

### DIFF
--- a/leanring-buddy.xcodeproj/project.pbxproj
+++ b/leanring-buddy.xcodeproj/project.pbxproj
@@ -419,7 +419,6 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "leanring-buddy/Info.plist";
-				INFOPLIST_KEY_AnthropicAPIKey = "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";
 				INFOPLIST_KEY_AnthropicAPIURL = "https://api.anthropic.com/v1/messages";
 				INFOPLIST_KEY_AnthropicModel = "claude-sonnet-4-6";
 				INFOPLIST_KEY_CFBundleDisplayName = Clicky;
@@ -460,7 +459,6 @@
 				ENABLE_USER_SELECTED_FILES = readonly;
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = "leanring-buddy/Info.plist";
-				INFOPLIST_KEY_AnthropicAPIKey = "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";
 				INFOPLIST_KEY_AnthropicAPIURL = "https://api.anthropic.com/v1/messages";
 				INFOPLIST_KEY_AnthropicModel = "claude-sonnet-4-6";
 				INFOPLIST_KEY_CFBundleDisplayName = Clicky;


### PR DESCRIPTION
## Summary
- remove the committed `INFOPLIST_KEY_AnthropicAPIKey` value from both Xcode build configurations
- leave the remaining proxy-based Anthropic settings untouched

## Why
- the app routes Anthropic traffic through the Worker now
- keeping a real-looking key in the project file is unnecessary risk and noise

Closes #22

## Verification
- `git grep -n INFOPLIST_KEY_AnthropicAPIKey|sk-ant-api03` returns no matches