### PR TITLE
Add local inference support with MLX and LM Studio backends

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-macOS menu bar companion app. Lives entirely in the macOS status bar (no dock icon, no main window). Clicking the menu bar icon opens a custom floating panel with companion voice controls. Uses push-to-talk (ctrl+option) to capture voice input, transcribes it via AssemblyAI streaming, and sends the transcript + a screenshot of the user's screen to Claude or to a selectable local backend (`MLX` or `LM Studio`). Responses can be spoken with local macOS speech or ElevenLabs TTS depending on the selected inference mode. A blue cursor overlay can fly to and point at UI elements the assistant references on any connected monitor.
+macOS menu bar companion app. Lives entirely in the macOS status bar (no dock icon, no main window). Clicking the menu bar icon opens a custom floating panel with companion voice controls. Uses push-to-talk (ctrl+option) to capture voice input, transcribes it through the configured provider layer (Apple Speech by default in this repo, with AssemblyAI and OpenAI also supported), and sends the transcript + a screenshot of the user's screen to Claude or to a selectable local backend (`MLX` or `LM Studio`). Responses can be spoken with local macOS speech or ElevenLabs TTS depending on the selected inference mode. A blue cursor overlay can fly to and point at UI elements the assistant references on any connected monitor.
 
 All API keys live on a Cloudflare Worker proxy — nothing sensitive ships in the app.
 
@@ -14,7 +14,7 @@ All API keys live on a Cloudflare Worker proxy — nothing sensitive ships in th
 - **App Type**: Menu bar-only (`LSUIElement=true`), no dock icon or main window
 - **Framework**: SwiftUI (macOS native) with AppKit bridging for menu bar panel and cursor overlay
 - **Pattern**: MVVM with `@StateObject` / `@Published` state management
-- **AI Chat**: Switchable between Claude (Sonnet 4.6 or Opus 4.6) and local inference. Local inference supports the built-in MLX vision model (`Qwen 3 VL 4B`) or any loaded LM Studio model served on `http://localhost:1234` (configurable in the panel).
+- **AI Chat**: Switchable between Claude (Sonnet 4.6 or Opus 4.6) and local inference. Local inference supports the built-in MLX vision model (`Qwen 3 VL 4B`) or an LM Studio model served on `http://localhost:1234` (configurable in the panel). Because Clicky always sends screenshots, LM Studio should use a vision-capable model.
 - **Speech-to-Text**: AssemblyAI real-time streaming (`u3-rt-pro` model) via websocket, with OpenAI and Apple Speech as fallbacks
 - **Text-to-Speech**: ElevenLabs (`eleven_flash_v2_5` model) via Cloudflare Worker proxy in Claude mode, or local macOS speech synthesis in local mode
 - **Screen Capture**: ScreenCaptureKit (macOS 14.2+), multi-monitor support
@@ -68,7 +68,7 @@ Worker vars: `ELEVENLABS_VOICE_ID`
 | `GlobalPushToTalkShortcutMonitor.swift` | ~132 | System-wide push-to-talk monitor. Owns the listen-only `CGEvent` tap and publishes press/release transitions. |
 | `ClaudeAPI.swift` | ~291 | Claude vision API client with streaming (SSE) and non-streaming modes. TLS warmup optimization, image MIME detection, conversation history support. |
 | `Local-AI-Mode/LocalMLXVLMClient.swift` | ~291 | On-device MLX vision-language client. Downloads/caches the fixed `Qwen 3 VL 4B` model, warms it up, streams responses, and exposes progress updates for the panel UI. |
-| `Local-AI-Mode/LMStudioLocalChatClient.swift` | ~441 | Local backend that connects directly to an LM Studio server. Validates the configured server URL, checks for any loaded model from LM Studio's `/api/v1/models` endpoint, and streams screenshot chat through the OpenAI-compatible local chat completions endpoint. |
+| `Local-AI-Mode/LMStudioLocalChatClient.swift` | ~441 | Local backend that connects directly to an LM Studio server. Validates the configured server URL, checks for a loaded model from LM Studio's `/api/v1/models` endpoint, and streams screenshot chat through the OpenAI-compatible local chat completions endpoint. Use a vision-capable LM Studio model, since Clicky includes screenshots in every request. |
 | `Local-AI-Mode/LocalSpeechSynthesizerClient.swift` | ~32 | Lightweight local speech client backed by `AVSpeechSynthesizer` for spoken responses in local inference mode. |
 | `OpenAIAPI.swift` | ~142 | OpenAI GPT vision API client. |
 | `ElevenLabsTTSClient.swift` | ~81 | ElevenLabs TTS client. Sends text to the Worker proxy, plays back audio via `AVAudioPlayer`. Exposes `isPlaying` for transient cursor scheduling. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-macOS menu bar companion app. Lives entirely in the macOS status bar (no dock icon, no main window). Clicking the menu bar icon opens a custom floating panel with companion voice controls. Uses push-to-talk (ctrl+option) to capture voice input, transcribes it via AssemblyAI streaming, and sends the transcript + a screenshot of the user's screen to either a local MLX vision model or Claude. Responses can be spoken with local macOS speech or ElevenLabs TTS depending on the selected inference mode. A blue cursor overlay can fly to and point at UI elements the assistant references on any connected monitor.
+macOS menu bar companion app. Lives entirely in the macOS status bar (no dock icon, no main window). Clicking the menu bar icon opens a custom floating panel with companion voice controls. Uses push-to-talk (ctrl+option) to capture voice input, transcribes it via AssemblyAI streaming, and sends the transcript + a screenshot of the user's screen to Claude or to a selectable local backend (`MLX` or `LM Studio`). Responses can be spoken with local macOS speech or ElevenLabs TTS depending on the selected inference mode. A blue cursor overlay can fly to and point at UI elements the assistant references on any connected monitor.
 
 All API keys live on a Cloudflare Worker proxy — nothing sensitive ships in the app.
 
@@ -14,7 +14,7 @@ All API keys live on a Cloudflare Worker proxy — nothing sensitive ships in th
 - **App Type**: Menu bar-only (`LSUIElement=true`), no dock icon or main window
 - **Framework**: SwiftUI (macOS native) with AppKit bridging for menu bar panel and cursor overlay
 - **Pattern**: MVVM with `@StateObject` / `@Published` state management
-- **AI Chat**: Switchable between local MLX vision inference (`Qwen 3 VL 4B`) and Claude (Sonnet 4.6 or Opus 4.6) via the Cloudflare Worker proxy
+- **AI Chat**: Switchable between Claude (Sonnet 4.6 or Opus 4.6) and local inference. Local inference supports the built-in MLX vision model (`Qwen 3 VL 4B`) or any loaded LM Studio model served on `http://localhost:1234` (configurable in the panel).
 - **Speech-to-Text**: AssemblyAI real-time streaming (`u3-rt-pro` model) via websocket, with OpenAI and Apple Speech as fallbacks
 - **Text-to-Speech**: ElevenLabs (`eleven_flash_v2_5` model) via Cloudflare Worker proxy in Claude mode, or local macOS speech synthesis in local mode
 - **Screen Capture**: ScreenCaptureKit (macOS 14.2+), multi-monitor support
@@ -25,7 +25,7 @@ All API keys live on a Cloudflare Worker proxy — nothing sensitive ships in th
 
 ### API Proxy (Cloudflare Worker)
 
-Claude mode never calls external APIs directly. All cloud requests go through a Cloudflare Worker (`worker/src/index.ts`) that holds the real API keys as secrets. Local MLX mode runs chat and speech synthesis on-device and only relies on the worker for AssemblyAI transcription tokens.
+Claude mode never calls external APIs directly. All cloud requests go through a Cloudflare Worker (`worker/src/index.ts`) that holds the real API keys as secrets. Local MLX mode runs chat and speech synthesis on-device, and LM Studio local mode talks directly to the user's LM Studio server. Both local modes only rely on the worker for AssemblyAI transcription tokens when AssemblyAI is the selected transcription provider.
 
 | Route | Upstream | Purpose |
 |-------|----------|---------|
@@ -53,9 +53,9 @@ Worker vars: `ELEVENLABS_VOICE_ID`
 | File | Lines | Purpose |
 |------|-------|---------|
 | `leanring_buddyApp.swift` | ~89 | Menu bar app entry point. Uses `@NSApplicationDelegateAdaptor` with `CompanionAppDelegate` which creates `MenuBarPanelManager` and starts `CompanionManager`. No main window — the app lives entirely in the status bar. |
-| `CompanionManager.swift` | ~1244 | Central state machine. Owns dictation, shortcut monitoring, screen capture, local-vs-Claude inference routing, local-vs-remote TTS, and overlay management. Tracks voice state (idle/listening/processing/responding), conversation history, model preparation/download state, selected inference mode, and cursor visibility. Coordinates the full push-to-talk → screenshot → model response → TTS → pointing pipeline. |
+| `CompanionManager.swift` | ~1526 | Central state machine. Owns dictation, shortcut monitoring, screen capture, local-vs-Claude inference routing, MLX-vs-LM-Studio local backend selection, local-vs-remote TTS, and overlay management. Tracks voice state (idle/listening/processing/responding), conversation history, backend preparation/connection state, selected inference mode, and cursor visibility. Coordinates the full push-to-talk → screenshot → model response → TTS → pointing pipeline. |
 | `MenuBarPanelManager.swift` | ~243 | NSStatusItem + custom NSPanel lifecycle. Creates the menu bar icon, manages the floating companion panel (show/hide/position), installs click-outside-to-dismiss monitor. |
-| `CompanionPanelView.swift` | ~915 | SwiftUI panel content for the menu bar dropdown. Shows companion status, push-to-talk instructions, local-vs-Claude inference controls, local model download/preparation state, permissions UI, DM feedback button, and quit button. Dark aesthetic using `DS` design system. |
+| `CompanionPanelView.swift` | ~987 | SwiftUI panel content for the menu bar dropdown. Shows companion status, push-to-talk instructions, local-vs-Claude inference controls, MLX-vs-LM-Studio local backend controls, LM Studio server URL input, local backend readiness/download state, permissions UI, DM feedback button, and quit button. Dark aesthetic using `DS` design system. |
 | `OverlayWindow.swift` | ~881 | Full-screen transparent overlay hosting the blue cursor, response text, waveform, and spinner. Handles cursor animation, element pointing with bezier arcs, multi-monitor coordinate mapping, and fade-out transitions. |
 | `CompanionResponseOverlay.swift` | ~217 | SwiftUI view for the response text bubble and waveform displayed next to the cursor in the overlay. |
 | `CompanionScreenCaptureUtility.swift` | ~132 | Multi-monitor screenshot capture using ScreenCaptureKit. Returns labeled image data for each connected display. |
@@ -68,6 +68,7 @@ Worker vars: `ELEVENLABS_VOICE_ID`
 | `GlobalPushToTalkShortcutMonitor.swift` | ~132 | System-wide push-to-talk monitor. Owns the listen-only `CGEvent` tap and publishes press/release transitions. |
 | `ClaudeAPI.swift` | ~291 | Claude vision API client with streaming (SSE) and non-streaming modes. TLS warmup optimization, image MIME detection, conversation history support. |
 | `Local-AI-Mode/LocalMLXVLMClient.swift` | ~291 | On-device MLX vision-language client. Downloads/caches the fixed `Qwen 3 VL 4B` model, warms it up, streams responses, and exposes progress updates for the panel UI. |
+| `Local-AI-Mode/LMStudioLocalChatClient.swift` | ~441 | Local backend that connects directly to an LM Studio server. Validates the configured server URL, checks for any loaded model from LM Studio's `/api/v1/models` endpoint, and streams screenshot chat through the OpenAI-compatible local chat completions endpoint. |
 | `Local-AI-Mode/LocalSpeechSynthesizerClient.swift` | ~32 | Lightweight local speech client backed by `AVSpeechSynthesizer` for spoken responses in local inference mode. |
 | `OpenAIAPI.swift` | ~142 | OpenAI GPT vision API client. |
 | `ElevenLabsTTSClient.swift` | ~81 | ElevenLabs TTS client. Sends text to the Worker proxy, plays back audio via `AVAudioPlayer`. Exposes `isPlaying` for transient cursor scheduling. |

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@
 
 ## Overview
 
-macOS menu bar companion app. Lives entirely in the macOS status bar (no dock icon, no main window). Clicking the menu bar icon opens a custom floating panel with companion voice controls. Uses push-to-talk (ctrl+option) to capture voice input, transcribes it via AssemblyAI streaming, and sends the transcript + a screenshot of the user's screen to Claude. Claude responds with text (streamed via SSE) and voice (ElevenLabs TTS). A blue cursor overlay can fly to and point at UI elements Claude references on any connected monitor.
+macOS menu bar companion app. Lives entirely in the macOS status bar (no dock icon, no main window). Clicking the menu bar icon opens a custom floating panel with companion voice controls. Uses push-to-talk (ctrl+option) to capture voice input, transcribes it via AssemblyAI streaming, and sends the transcript + a screenshot of the user's screen to either a local MLX vision model or Claude. Responses can be spoken with local macOS speech or ElevenLabs TTS depending on the selected inference mode. A blue cursor overlay can fly to and point at UI elements the assistant references on any connected monitor.
 
 All API keys live on a Cloudflare Worker proxy — nothing sensitive ships in the app.
 
@@ -14,18 +14,18 @@ All API keys live on a Cloudflare Worker proxy — nothing sensitive ships in th
 - **App Type**: Menu bar-only (`LSUIElement=true`), no dock icon or main window
 - **Framework**: SwiftUI (macOS native) with AppKit bridging for menu bar panel and cursor overlay
 - **Pattern**: MVVM with `@StateObject` / `@Published` state management
-- **AI Chat**: Claude (Sonnet 4.6 default, Opus 4.6 optional) via Cloudflare Worker proxy with SSE streaming
+- **AI Chat**: Switchable between local MLX vision inference (`Qwen 3 VL 4B`) and Claude (Sonnet 4.6 or Opus 4.6) via the Cloudflare Worker proxy
 - **Speech-to-Text**: AssemblyAI real-time streaming (`u3-rt-pro` model) via websocket, with OpenAI and Apple Speech as fallbacks
-- **Text-to-Speech**: ElevenLabs (`eleven_flash_v2_5` model) via Cloudflare Worker proxy
+- **Text-to-Speech**: ElevenLabs (`eleven_flash_v2_5` model) via Cloudflare Worker proxy in Claude mode, or local macOS speech synthesis in local mode
 - **Screen Capture**: ScreenCaptureKit (macOS 14.2+), multi-monitor support
 - **Voice Input**: Push-to-talk via `AVAudioEngine` + pluggable transcription-provider layer. System-wide keyboard shortcut via listen-only CGEvent tap.
-- **Element Pointing**: Claude embeds `[POINT:x,y:label:screenN]` tags in responses. The overlay parses these, maps coordinates to the correct monitor, and animates the blue cursor along a bezier arc to the target.
+- **Element Pointing**: The selected assistant embeds `[POINT:x,y:label:screenN]` tags in responses. The overlay parses these, maps coordinates to the correct monitor, and animates the blue cursor along a bezier arc to the target.
 - **Concurrency**: `@MainActor` isolation, async/await throughout
 - **Analytics**: PostHog via `ClickyAnalytics.swift`
 
 ### API Proxy (Cloudflare Worker)
 
-The app never calls external APIs directly. All requests go through a Cloudflare Worker (`worker/src/index.ts`) that holds the real API keys as secrets.
+Claude mode never calls external APIs directly. All cloud requests go through a Cloudflare Worker (`worker/src/index.ts`) that holds the real API keys as secrets. Local MLX mode runs chat and speech synthesis on-device and only relies on the worker for AssemblyAI transcription tokens.
 
 | Route | Upstream | Purpose |
 |-------|----------|---------|
@@ -53,9 +53,9 @@ Worker vars: `ELEVENLABS_VOICE_ID`
 | File | Lines | Purpose |
 |------|-------|---------|
 | `leanring_buddyApp.swift` | ~89 | Menu bar app entry point. Uses `@NSApplicationDelegateAdaptor` with `CompanionAppDelegate` which creates `MenuBarPanelManager` and starts `CompanionManager`. No main window — the app lives entirely in the status bar. |
-| `CompanionManager.swift` | ~1026 | Central state machine. Owns dictation, shortcut monitoring, screen capture, Claude API, ElevenLabs TTS, and overlay management. Tracks voice state (idle/listening/processing/responding), conversation history, model selection, and cursor visibility. Coordinates the full push-to-talk → screenshot → Claude → TTS → pointing pipeline. |
+| `CompanionManager.swift` | ~1244 | Central state machine. Owns dictation, shortcut monitoring, screen capture, local-vs-Claude inference routing, local-vs-remote TTS, and overlay management. Tracks voice state (idle/listening/processing/responding), conversation history, model preparation/download state, selected inference mode, and cursor visibility. Coordinates the full push-to-talk → screenshot → model response → TTS → pointing pipeline. |
 | `MenuBarPanelManager.swift` | ~243 | NSStatusItem + custom NSPanel lifecycle. Creates the menu bar icon, manages the floating companion panel (show/hide/position), installs click-outside-to-dismiss monitor. |
-| `CompanionPanelView.swift` | ~761 | SwiftUI panel content for the menu bar dropdown. Shows companion status, push-to-talk instructions, model picker (Sonnet/Opus), permissions UI, DM feedback button, and quit button. Dark aesthetic using `DS` design system. |
+| `CompanionPanelView.swift` | ~915 | SwiftUI panel content for the menu bar dropdown. Shows companion status, push-to-talk instructions, local-vs-Claude inference controls, local model download/preparation state, permissions UI, DM feedback button, and quit button. Dark aesthetic using `DS` design system. |
 | `OverlayWindow.swift` | ~881 | Full-screen transparent overlay hosting the blue cursor, response text, waveform, and spinner. Handles cursor animation, element pointing with bezier arcs, multi-monitor coordinate mapping, and fade-out transitions. |
 | `CompanionResponseOverlay.swift` | ~217 | SwiftUI view for the response text bubble and waveform displayed next to the cursor in the overlay. |
 | `CompanionScreenCaptureUtility.swift` | ~132 | Multi-monitor screenshot capture using ScreenCaptureKit. Returns labeled image data for each connected display. |
@@ -67,6 +67,8 @@ Worker vars: `ELEVENLABS_VOICE_ID`
 | `BuddyAudioConversionSupport.swift` | ~108 | Audio conversion helpers. Converts live mic buffers to PCM16 mono audio and builds WAV payloads for upload-based providers. |
 | `GlobalPushToTalkShortcutMonitor.swift` | ~132 | System-wide push-to-talk monitor. Owns the listen-only `CGEvent` tap and publishes press/release transitions. |
 | `ClaudeAPI.swift` | ~291 | Claude vision API client with streaming (SSE) and non-streaming modes. TLS warmup optimization, image MIME detection, conversation history support. |
+| `Local-AI-Mode/LocalMLXVLMClient.swift` | ~291 | On-device MLX vision-language client. Downloads/caches the fixed `Qwen 3 VL 4B` model, warms it up, streams responses, and exposes progress updates for the panel UI. |
+| `Local-AI-Mode/LocalSpeechSynthesizerClient.swift` | ~32 | Lightweight local speech client backed by `AVSpeechSynthesizer` for spoken responses in local inference mode. |
 | `OpenAIAPI.swift` | ~142 | OpenAI GPT vision API client. |
 | `ElevenLabsTTSClient.swift` | ~81 | ElevenLabs TTS client. Sends text to the Worker proxy, plays back audio via `AVAudioPlayer`. Exposes `isPlaying` for transient cursor scheduling. |
 | `ElementLocationDetector.swift` | ~335 | Detects UI element locations in screenshots for cursor pointing. |

--- a/README.md
+++ b/README.md
@@ -117,18 +117,33 @@ If you want to run Clicky fully on-device, use the app's **Local** inference mod
 
 2. Open `leanring-buddy.xcodeproj` in Xcode and let Swift Package Manager resolve the local model dependencies.
 
-   The local path depends on the MLX packages used by the app, including `MLX`, `MLXLMCommon`, and `MLXVLM`. If Xcode shows package resolution issues, run **File > Packages > Resolve Package Versions**.
+   The built-in MLX path depends on the MLX packages used by the app, including `MLX`, `MLXLMCommon`, and `MLXVLM`. If Xcode shows package resolution issues, run **File > Packages > Resolve Package Versions**.
 
 3. Build and run the app.
 
 4. Open the Clicky menu bar panel and switch the inference selector from **Claude** to **Local**.
 
-5. Wait for the local model to finish preparing.
+5. Choose your local backend:
 
-   The first local run may download and prepare the model before it is ready. The panel shows download/progress state while this happens.
+   - **MLX** for the built-in on-device model
+   - **LM Studio** to use any model currently loaded in LM Studio on your Mac
+
+6. If you choose **LM Studio**, enter the server URL in the panel.
+
+   The default is:
+
+   ```
+   http://localhost:1234
+   ```
+
+   Clicky expects LM Studio's local server to be running and any model to already be loaded in LM Studio.
+
+7. Wait for the selected local backend to finish preparing.
+
+   The first MLX run may download and prepare the model before it is ready. LM Studio mode validates the server URL and checks for a loaded model.
 
 In **Local** mode:
-- chat responses come from the on-device MLX vision-language model
+- chat responses come from either the built-in MLX model or LM Studio, depending on the selected local backend
 - speech playback uses the local speech synthesizer client
 - transcription uses Apple Speech when `VoiceTranscriptionProvider` is set to `apple`
 
@@ -137,7 +152,7 @@ In **Claude** mode:
 - transcription can use the configured provider from `Info.plist`
 - speech playback goes through the Worker to ElevenLabs
 
-You do **not** need the Cloudflare Worker, Anthropic, AssemblyAI, or ElevenLabs keys just to run the local MLX path.
+You do **not** need the Cloudflare Worker, Anthropic, AssemblyAI, or ElevenLabs keys just to run the local MLX or LM Studio path.
 
 ### 5. Open in Xcode and run
 
@@ -165,7 +180,7 @@ If you want the full technical breakdown, read `CLAUDE.md`. But here's the short
 
 **Menu bar app** (no dock icon) with two `NSPanel` windows — one for the control panel dropdown, one for the full-screen transparent cursor overlay. Push-to-talk always captures mic audio locally and sends screenshots of your screen into the response pipeline. From there, Clicky can run in two modes:
 
-- **Local**: transcript is captured with Apple Speech, responses come from the on-device MLX model, and speech playback uses the local speech synthesizer
+- **Local**: transcript is captured with Apple Speech, responses come from either the built-in MLX model or an LM Studio local server, and speech playback uses the local speech synthesizer
 - **Claude**: transcript, chat, and TTS use the configured cloud providers, with Claude, AssemblyAI, and ElevenLabs all proxied through the Cloudflare Worker
 
 Claude can embed `[POINT:x,y:label:screenN]` tags in its responses to make the cursor fly to specific UI elements across multiple monitors.
@@ -178,7 +193,7 @@ leanring-buddy/          # Swift source (yes, the typo stays)
   CompanionPanelView.swift  # Menu bar panel UI
   ClaudeAPI.swift           # Claude streaming client
   ElevenLabsTTSClient.swift # Text-to-speech playback
-  Local-AI-Mode/            # On-device MLX chat + local speech synthesis
+  Local-AI-Mode/            # On-device MLX + LM Studio chat backends and local speech synthesis
   OverlayWindow.swift       # Blue cursor overlay
   AssemblyAI*.swift         # Real-time transcription
   BuddyDictation*.swift     # Push-to-talk pipeline

--- a/README.md
+++ b/README.md
@@ -126,7 +126,7 @@ If you want to run Clicky fully on-device, use the app's **Local** inference mod
 5. Choose your local backend:
 
    - **MLX** for the built-in on-device model
-   - **LM Studio** to use any model currently loaded in LM Studio on your Mac
+   - **LM Studio** to use a vision-capable model currently loaded in LM Studio on your Mac
 
 6. If you choose **LM Studio**, enter the server URL in the panel.
 
@@ -136,14 +136,15 @@ If you want to run Clicky fully on-device, use the app's **Local** inference mod
    http://localhost:1234
    ```
 
-   Clicky expects LM Studio's local server to be running and any model to already be loaded in LM Studio.
+   Clicky expects LM Studio's local server to be running and a vision-capable model to already be loaded in LM Studio.
 
 7. Wait for the selected local backend to finish preparing.
 
-   The first MLX run may download and prepare the model before it is ready. LM Studio mode validates the server URL and checks for a loaded model.
+   The first MLX run may download and prepare the model before it is ready. LM Studio mode validates the server URL and checks for a loaded model. Since Clicky always sends screenshots with each request, LM Studio works best with a vision-capable model.
 
 In **Local** mode:
 - chat responses come from either the built-in MLX model or LM Studio, depending on the selected local backend
+- LM Studio should use a vision-capable model, because Clicky always includes screenshots in local requests
 - speech playback uses the local speech synthesizer client
 - transcription uses Apple Speech when `VoiceTranscriptionProvider` is set to `apple`
 
@@ -180,7 +181,7 @@ If you want the full technical breakdown, read `CLAUDE.md`. But here's the short
 
 **Menu bar app** (no dock icon) with two `NSPanel` windows — one for the control panel dropdown, one for the full-screen transparent cursor overlay. Push-to-talk always captures mic audio locally and sends screenshots of your screen into the response pipeline. From there, Clicky can run in two modes:
 
-- **Local**: transcript is captured with Apple Speech, responses come from either the built-in MLX model or an LM Studio local server, and speech playback uses the local speech synthesizer
+- **Local**: transcript is captured with Apple Speech, responses come from either the built-in MLX model or a vision-capable LM Studio local server, and speech playback uses the local speech synthesizer
 - **Claude**: transcript, chat, and TTS use the configured cloud providers, with Claude, AssemblyAI, and ElevenLabs all proxied through the Cloudflare Worker
 
 Claude can embed `[POINT:x,y:label:screenN]` tags in its responses to make the cursor fly to specific UI elements across multiple monitors.

--- a/README.md
+++ b/README.md
@@ -35,13 +35,13 @@ If you want to do it yourself, here's the deal.
 
 - macOS 14.2+ (for ScreenCaptureKit)
 - Xcode 15+
-- Node.js 18+ (for the Cloudflare Worker)
-- A [Cloudflare](https://cloudflare.com) account (free tier works)
-- API keys for: [Anthropic](https://console.anthropic.com), [AssemblyAI](https://www.assemblyai.com), [ElevenLabs](https://elevenlabs.io)
+- For **Claude mode** only: Node.js 18+ (for the Cloudflare Worker)
+- For **Claude mode** only: a [Cloudflare](https://cloudflare.com) account (free tier works)
+- For **Claude mode** only: API keys for [Anthropic](https://console.anthropic.com), [AssemblyAI](https://www.assemblyai.com), and [ElevenLabs](https://elevenlabs.io)
 
-### 1. Set up the Cloudflare Worker
+### 1. Set up the Cloudflare Worker for Claude mode
 
-The Worker is a tiny proxy that holds your API keys. The app talks to the Worker, the Worker talks to the APIs. This way your keys never ship in the app binary.
+If you want to use **Claude** in the app, the Worker is a tiny proxy that holds your API keys. The app talks to the Worker, the Worker talks to the APIs. This way your keys never ship in the app binary.
 
 ```bash
 cd worker
@@ -71,7 +71,7 @@ npx wrangler deploy
 
 It'll give you a URL like `https://your-worker-name.your-subdomain.workers.dev`. Copy that.
 
-### 2. Run the Worker locally (for development)
+### 2. Run the Worker locally for Claude mode development
 
 If you want to test changes to the Worker without deploying:
 
@@ -91,9 +91,9 @@ ELEVENLABS_VOICE_ID=...
 
 Then update the proxy URLs in the Swift code to point to `http://localhost:8787` instead of the deployed Worker URL while developing. Grep for `clicky-proxy` to find them all.
 
-### 3. Update the proxy URLs in the app
+### 3. Update the proxy URLs in the app for Claude mode
 
-The app has the Worker URL hardcoded in a few places. Search for `your-worker-name.your-subdomain.workers.dev` and replace it with your Worker URL:
+The Claude path has the Worker URL hardcoded in a few places. Search for `your-worker-name.your-subdomain.workers.dev` and replace it with your Worker URL:
 
 ```bash
 grep -r "clicky-proxy" leanring-buddy/
@@ -103,7 +103,43 @@ You'll find it in:
 - `CompanionManager.swift` — Claude chat + ElevenLabs TTS
 - `AssemblyAIStreamingTranscriptionProvider.swift` — AssemblyAI token endpoint
 
-### 4. Open in Xcode and run
+### 4. Local model setup
+
+If you want to run Clicky fully on-device, use the app's **Local** inference mode.
+
+1. Open `leanring-buddy/Info.plist` and make sure this key is set:
+
+   ```
+   VoiceTranscriptionProvider = apple
+   ```
+
+   Local mode is intended to use Apple Speech for transcription.
+
+2. Open `leanring-buddy.xcodeproj` in Xcode and let Swift Package Manager resolve the local model dependencies.
+
+   The local path depends on the MLX packages used by the app, including `MLX`, `MLXLMCommon`, and `MLXVLM`. If Xcode shows package resolution issues, run **File > Packages > Resolve Package Versions**.
+
+3. Build and run the app.
+
+4. Open the Clicky menu bar panel and switch the inference selector from **Claude** to **Local**.
+
+5. Wait for the local model to finish preparing.
+
+   The first local run may download and prepare the model before it is ready. The panel shows download/progress state while this happens.
+
+In **Local** mode:
+- chat responses come from the on-device MLX vision-language model
+- speech playback uses the local speech synthesizer client
+- transcription uses Apple Speech when `VoiceTranscriptionProvider` is set to `apple`
+
+In **Claude** mode:
+- chat responses go through the Cloudflare Worker to Claude
+- transcription can use the configured provider from `Info.plist`
+- speech playback goes through the Worker to ElevenLabs
+
+You do **not** need the Cloudflare Worker, Anthropic, AssemblyAI, or ElevenLabs keys just to run the local MLX path.
+
+### 5. Open in Xcode and run
 
 ```bash
 open leanring-buddy.xcodeproj
@@ -127,7 +163,12 @@ The app will appear in your menu bar (not the dock). Click the icon to open the 
 
 If you want the full technical breakdown, read `CLAUDE.md`. But here's the short version:
 
-**Menu bar app** (no dock icon) with two `NSPanel` windows — one for the control panel dropdown, one for the full-screen transparent cursor overlay. Push-to-talk streams audio over a websocket to AssemblyAI, sends the transcript + screenshot to Claude via streaming SSE, and plays the response through ElevenLabs TTS. Claude can embed `[POINT:x,y:label:screenN]` tags in its responses to make the cursor fly to specific UI elements across multiple monitors. All three APIs are proxied through a Cloudflare Worker.
+**Menu bar app** (no dock icon) with two `NSPanel` windows — one for the control panel dropdown, one for the full-screen transparent cursor overlay. Push-to-talk always captures mic audio locally and sends screenshots of your screen into the response pipeline. From there, Clicky can run in two modes:
+
+- **Local**: transcript is captured with Apple Speech, responses come from the on-device MLX model, and speech playback uses the local speech synthesizer
+- **Claude**: transcript, chat, and TTS use the configured cloud providers, with Claude, AssemblyAI, and ElevenLabs all proxied through the Cloudflare Worker
+
+Claude can embed `[POINT:x,y:label:screenN]` tags in its responses to make the cursor fly to specific UI elements across multiple monitors.
 
 ## Project structure
 
@@ -137,6 +178,7 @@ leanring-buddy/          # Swift source (yes, the typo stays)
   CompanionPanelView.swift  # Menu bar panel UI
   ClaudeAPI.swift           # Claude streaming client
   ElevenLabsTTSClient.swift # Text-to-speech playback
+  Local-AI-Mode/            # On-device MLX chat + local speech synthesis
   OverlayWindow.swift       # Blue cursor overlay
   AssemblyAI*.swift         # Real-time transcription
   BuddyDictation*.swift     # Push-to-talk pipeline

--- a/leanring-buddy.xcodeproj/project.pbxproj
+++ b/leanring-buddy.xcodeproj/project.pbxproj
@@ -7,6 +7,9 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		8C1C3F5B2F87A26100547584 /* MLXLLM in Frameworks */ = {isa = PBXBuildFile; productRef = 8C1C3F5A2F87A26100547584 /* MLXLLM */; };
+		8C1C3F5D2F87A26100547584 /* MLXLMCommon in Frameworks */ = {isa = PBXBuildFile; productRef = 8C1C3F5C2F87A26100547584 /* MLXLMCommon */; };
+		8C1C3F5F2F87A26100547584 /* MLXVLM in Frameworks */ = {isa = PBXBuildFile; productRef = 8C1C3F5E2F87A26100547584 /* MLXVLM */; };
 		AA00BB032F6500030039DA55 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = AA00BB022F6500020039DA55 /* Sparkle */; };
 		AA00BB062F6500060039DA55 /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = AA00BB052F6500050039DA55 /* PostHog */; };
 /* End PBXBuildFile section */
@@ -57,7 +60,10 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				8C1C3F5F2F87A26100547584 /* MLXVLM in Frameworks */,
+				8C1C3F5B2F87A26100547584 /* MLXLLM in Frameworks */,
 				AA00BB032F6500030039DA55 /* Sparkle in Frameworks */,
+				8C1C3F5D2F87A26100547584 /* MLXLMCommon in Frameworks */,
 				AA00BB062F6500060039DA55 /* PostHog in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -121,6 +127,9 @@
 			packageProductDependencies = (
 				AA00BB022F6500020039DA55 /* Sparkle */,
 				AA00BB052F6500050039DA55 /* PostHog */,
+				8C1C3F5A2F87A26100547584 /* MLXLLM */,
+				8C1C3F5C2F87A26100547584 /* MLXLMCommon */,
+				8C1C3F5E2F87A26100547584 /* MLXVLM */,
 			);
 			productName = "leanring-buddy";
 			productReference = 28F22CBF2F56440300A0FC59 /* Clicky.app */;
@@ -207,6 +216,7 @@
 			packageReferences = (
 				AA00BB012F6500010039DA55 /* XCRemoteSwiftPackageReference "Sparkle" */,
 				AA00BB042F6500040039DA55 /* XCRemoteSwiftPackageReference "posthog-ios" */,
+				8C1C3F592F87A26100547584 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 28F22CC02F56440300A0FC59 /* Products */;
@@ -606,6 +616,14 @@
 /* End XCConfigurationList section */
 
 /* Begin XCRemoteSwiftPackageReference section */
+		8C1C3F592F87A26100547584 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */ = {
+			isa = XCRemoteSwiftPackageReference;
+			repositoryURL = "https://github.com/ml-explore/mlx-swift-examples";
+			requirement = {
+				kind = upToNextMajorVersion;
+				minimumVersion = 2.29.1;
+			};
+		};
 		AA00BB012F6500010039DA55 /* XCRemoteSwiftPackageReference "Sparkle" */ = {
 			isa = XCRemoteSwiftPackageReference;
 			repositoryURL = "https://github.com/sparkle-project/Sparkle";
@@ -625,6 +643,21 @@
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
+		8C1C3F5A2F87A26100547584 /* MLXLLM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8C1C3F592F87A26100547584 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
+			productName = MLXLLM;
+		};
+		8C1C3F5C2F87A26100547584 /* MLXLMCommon */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8C1C3F592F87A26100547584 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
+			productName = MLXLMCommon;
+		};
+		8C1C3F5E2F87A26100547584 /* MLXVLM */ = {
+			isa = XCSwiftPackageProductDependency;
+			package = 8C1C3F592F87A26100547584 /* XCRemoteSwiftPackageReference "mlx-swift-examples" */;
+			productName = MLXVLM;
+		};
 		AA00BB022F6500020039DA55 /* Sparkle */ = {
 			isa = XCSwiftPackageProductDependency;
 			package = AA00BB012F6500010039DA55 /* XCRemoteSwiftPackageReference "Sparkle" */;

--- a/leanring-buddy.xcodeproj/project.pbxproj
+++ b/leanring-buddy.xcodeproj/project.pbxproj
@@ -421,7 +421,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 2UDAY4J48G;
+				DEVELOPMENT_TEAM = WAWFDDJJF6;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
@@ -434,14 +434,17 @@
 				INFOPLIST_KEY_AnthropicModel = "claude-sonnet-4-6";
 				INFOPLIST_KEY_CFBundleDisplayName = Clicky;
 				INFOPLIST_KEY_CFBundleName = Clicky;
+				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Clicky uses your microphone so you can talk to it";
 				INFOPLIST_KEY_NSScreenCaptureUsageDescription = "Clicky needs screen recording access to see your screen and help you.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Clicky uses speech recognition to transcribe your voice when you talk to it";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.yourcompany.leanring-buddy";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.consciousengines.leanring-buddy";
 				PRODUCT_NAME = Clicky;
 				REGISTER_APP_GROUPS = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;
@@ -462,7 +465,7 @@
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
-				DEVELOPMENT_TEAM = 2UDAY4J48G;
+				DEVELOPMENT_TEAM = WAWFDDJJF6;
 				ENABLE_APP_SANDBOX = NO;
 				ENABLE_HARDENED_RUNTIME = YES;
 				ENABLE_OUTGOING_NETWORK_CONNECTIONS = YES;
@@ -475,14 +478,17 @@
 				INFOPLIST_KEY_AnthropicModel = "claude-sonnet-4-6";
 				INFOPLIST_KEY_CFBundleDisplayName = Clicky;
 				INFOPLIST_KEY_CFBundleName = Clicky;
+				INFOPLIST_KEY_LSUIElement = YES;
 				INFOPLIST_KEY_NSHumanReadableCopyright = "";
+				INFOPLIST_KEY_NSMicrophoneUsageDescription = "Clicky uses your microphone so you can talk to it";
 				INFOPLIST_KEY_NSScreenCaptureUsageDescription = "Clicky needs screen recording access to see your screen and help you.";
+				INFOPLIST_KEY_NSSpeechRecognitionUsageDescription = "Clicky uses speech recognition to transcribe your voice when you talk to it";
 				LD_RUNPATH_SEARCH_PATHS = (
 					"$(inherited)",
 					"@executable_path/../Frameworks",
 				);
 				MARKETING_VERSION = 1.0;
-				PRODUCT_BUNDLE_IDENTIFIER = "com.yourcompany.leanring-buddy";
+				PRODUCT_BUNDLE_IDENTIFIER = "com.consciousengines.leanring-buddy";
 				PRODUCT_NAME = Clicky;
 				REGISTER_APP_GROUPS = YES;
 				STRING_CATALOG_GENERATE_SYMBOLS = YES;

--- a/leanring-buddy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/leanring-buddy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -1,6 +1,33 @@
 {
-  "originHash" : "3c6fb67fefedcfcd00708e24ca8088151f21dccfc0ade32ea80c406646277e89",
+  "originHash" : "0cea476d0e3a203310b7a6acd9ec718e7e73c60b4d9c25fadcc4407f6c1a6a88",
   "pins" : [
+    {
+      "identity" : "gzipswift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/1024jp/GzipSwift",
+      "state" : {
+        "revision" : "731037f6cc2be2ec01562f6597c1d0aa3fe6fd05",
+        "version" : "6.0.1"
+      }
+    },
+    {
+      "identity" : "mlx-swift",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift",
+      "state" : {
+        "revision" : "072b684acaae80b6a463abab3a103732f33774bf",
+        "version" : "0.29.1"
+      }
+    },
+    {
+      "identity" : "mlx-swift-examples",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/ml-explore/mlx-swift-examples",
+      "state" : {
+        "revision" : "9bff95ca5f0b9e8c021acc4d71a2bbe4a7441631",
+        "version" : "2.29.1"
+      }
+    },
     {
       "identity" : "plcrashreporter",
       "kind" : "remoteSourceControl",
@@ -26,6 +53,42 @@
       "state" : {
         "revision" : "21d8df80440b1ca3b65fa82e40782f1e5a9e6ba2",
         "version" : "2.9.0"
+      }
+    },
+    {
+      "identity" : "swift-collections",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-collections.git",
+      "state" : {
+        "revision" : "6675bc0ff86e61436e615df6fc5174e043e57924",
+        "version" : "1.4.1"
+      }
+    },
+    {
+      "identity" : "swift-jinja",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-jinja.git",
+      "state" : {
+        "revision" : "0aeefadec459ce8e11a333769950fb86183aca43",
+        "version" : "2.3.5"
+      }
+    },
+    {
+      "identity" : "swift-numerics",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/apple/swift-numerics",
+      "state" : {
+        "revision" : "0c0290ff6b24942dadb83a929ffaaa1481df04a2",
+        "version" : "1.1.1"
+      }
+    },
+    {
+      "identity" : "swift-transformers",
+      "kind" : "remoteSourceControl",
+      "location" : "https://github.com/huggingface/swift-transformers",
+      "state" : {
+        "revision" : "a2e184dddb4757bc943e77fbe99ac6786c53f0b2",
+        "version" : "1.0.0"
       }
     }
   ],

--- a/leanring-buddy/AppleSpeechTranscriptionProvider.swift
+++ b/leanring-buddy/AppleSpeechTranscriptionProvider.swift
@@ -33,6 +33,8 @@ final class AppleSpeechTranscriptionProvider: BuddyTranscriptionProvider {
             throw AppleSpeechTranscriptionProviderError(message: "dictation is not available on this mac.")
         }
 
+        print("🎙️ Apple Speech: starting session with locale \(speechRecognizer.locale.identifier)")
+
         return try AppleSpeechTranscriptionSession(
             speechRecognizer: speechRecognizer,
             onTranscriptUpdate: onTranscriptUpdate,
@@ -58,6 +60,9 @@ final class AppleSpeechTranscriptionProvider: BuddyTranscriptionProvider {
 }
 
 private final class AppleSpeechTranscriptionSession: NSObject, BuddyStreamingTranscriptionSession {
+    private static let assistantErrorDomain = "kAFAssistantErrorDomain"
+    private static let noSpeechDetectedErrorCode = 1110
+
     let finalTranscriptFallbackDelaySeconds: TimeInterval = 1.8
 
     private let recognitionRequest: SFSpeechAudioBufferRecognitionRequest
@@ -104,10 +109,12 @@ private final class AppleSpeechTranscriptionSession: NSObject, BuddyStreamingTra
     func requestFinalTranscript() {
         guard !hasRequestedFinalTranscript else { return }
         hasRequestedFinalTranscript = true
+        print("🎙️ Apple Speech: requesting final transcript")
         recognitionRequest.endAudio()
     }
 
     func cancel() {
+        print("🎙️ Apple Speech: cancelling session")
         recognitionTask?.cancel()
         recognitionTask = nil
     }
@@ -128,16 +135,36 @@ private final class AppleSpeechTranscriptionSession: NSObject, BuddyStreamingTra
 
         guard let error else { return }
 
+        if hasRequestedFinalTranscript && shouldTreatAsEmptyFinalTranscript(error) {
+            print("🎙️ Apple Speech: treating no-speech result as empty final transcript")
+            deliverFinalTranscriptIfNeeded(latestRecognizedText)
+            return
+        }
+
         if hasRequestedFinalTranscript && !latestRecognizedText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
             deliverFinalTranscriptIfNeeded(latestRecognizedText)
         } else {
+            print("❌ Apple Speech: recognition error: \(error)")
             onError(error)
         }
+    }
+
+    private func shouldTreatAsEmptyFinalTranscript(_ error: Error) -> Bool {
+        let recognitionError = error as NSError
+
+        if recognitionError.domain == Self.assistantErrorDomain
+            && recognitionError.code == Self.noSpeechDetectedErrorCode {
+            return true
+        }
+
+        return recognitionError.localizedDescription
+            .localizedCaseInsensitiveContains("no speech detected")
     }
 
     private func deliverFinalTranscriptIfNeeded(_ transcriptText: String) {
         guard !hasDeliveredFinalTranscript else { return }
         hasDeliveredFinalTranscript = true
+        print("🎙️ Apple Speech: delivering final transcript: \"\(transcriptText)\"")
         onFinalTranscriptReady(transcriptText)
     }
 

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -37,6 +37,41 @@ enum CompanionInferenceMode: String, CaseIterable, Identifiable {
     }
 }
 
+enum CompanionLocalBackend: String, CaseIterable, Identifiable {
+    case mlx
+    case lmStudio
+
+    var id: String { rawValue }
+
+    var shortLabel: String {
+        switch self {
+        case .mlx:
+            return "MLX"
+        case .lmStudio:
+            return "LM Studio"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .mlx:
+            return LocalMLXVLMClient.fixedModelDisplayName
+        case .lmStudio:
+            return "LM Studio"
+        }
+    }
+}
+
+enum LMStudioConnectionStatus: Equatable {
+    case idle
+    case checking
+    case connected(modelDisplayName: String)
+    case invalidServerURL
+    case serverUnavailable(message: String)
+    case noModelLoaded
+    case error(message: String)
+}
+
 enum CompanionClaudeModelOption: String, CaseIterable, Identifiable {
     case sonnet46 = "claude-sonnet-4-6"
     case opus46 = "claude-opus-4-6"
@@ -111,7 +146,8 @@ final class CompanionManager: ObservableObject {
     // Response text is now displayed inline on the cursor overlay via
     // streamingResponseText, so no separate response overlay manager is needed.
 
-    private let localCompanionChatClient: LocalMLXVLMClient
+    private let localMLXCompanionChatClient: LocalMLXVLMClient
+    private let localLMStudioChatClient: LMStudioLocalChatClient
 
     private lazy var claudeAPI: ClaudeAPI = {
         ClaudeAPI(proxyURL: "\(Self.workerBaseURL)/chat", model: selectedClaudeModel.id)
@@ -158,10 +194,21 @@ final class CompanionManager: ObservableObject {
     @Published private(set) var modelPreparationErrorMessage: String?
     @Published private(set) var isPreparingSelectedModel = false
     @Published private(set) var selectedInferenceMode: CompanionInferenceMode
+    @Published private(set) var selectedLocalBackend: CompanionLocalBackend
     @Published private(set) var selectedClaudeModel: CompanionClaudeModelOption
+    @Published private(set) var lmStudioConnectionStatus: LMStudioConnectionStatus = .idle
+    @Published var lmStudioServerURLDraft: String
 
     var localModelDisplayName: String {
-        LocalMLXVLMClient.fixedModelDisplayName
+        switch selectedLocalBackend {
+        case .mlx:
+            return LocalMLXVLMClient.fixedModelDisplayName
+        case .lmStudio:
+            if case .connected(let modelDisplayName) = lmStudioConnectionStatus {
+                return modelDisplayName
+            }
+            return selectedLocalBackend.displayName
+        }
     }
 
     var claudeModelDisplayName: String {
@@ -172,12 +219,128 @@ final class CompanionManager: ObservableObject {
         selectedInferenceMode == .local
     }
 
+    var isUsingLMStudioLocalBackend: Bool {
+        selectedLocalBackend == .lmStudio
+    }
+
+    var availableLocalBackendOptions: [CompanionLocalBackend] {
+        CompanionLocalBackend.allCases
+    }
+
+    var localModeDescriptionText: String {
+        switch selectedLocalBackend {
+        case .mlx:
+            return "Runs fully on-device with MLX."
+        case .lmStudio:
+            return "Uses the currently loaded LM Studio model on this Mac."
+        }
+    }
+
+    var localModelStatusTitle: String {
+        switch selectedLocalBackend {
+        case .mlx:
+            if modelPreparationErrorMessage != nil {
+                return "Local model error"
+            }
+            if modelDownloadProgress != nil {
+                return "Downloading local model"
+            }
+            if isPreparingSelectedModel {
+                return "Loading local model"
+            }
+            return "Local model ready"
+        case .lmStudio:
+            switch lmStudioConnectionStatus {
+            case .idle:
+                return "LM Studio ready"
+            case .checking:
+                return "Checking LM Studio server"
+            case .connected:
+                return "LM Studio connected"
+            case .invalidServerURL:
+                return "Invalid server URL"
+            case .serverUnavailable:
+                return "LM Studio unavailable"
+            case .noModelLoaded:
+                return "No model loaded"
+            case .error:
+                return "LM Studio error"
+            }
+        }
+    }
+
+    var localModelStatusDetail: String {
+        switch selectedLocalBackend {
+        case .mlx:
+            if let modelPreparationErrorMessage {
+                return modelPreparationErrorMessage
+            }
+            if let modelDownloadProgress {
+                return modelDownloadProgress.localizedDescription
+            }
+            if isPreparingSelectedModel {
+                return "Finishing setup so Clicky can answer on-device."
+            }
+            return "Runs fully on-device with MLX."
+        case .lmStudio:
+            switch lmStudioConnectionStatus {
+            case .idle:
+                return "Enter an LM Studio server URL to connect."
+            case .checking:
+                return "Checking the local server and looking for a loaded model."
+            case .connected(let modelDisplayName):
+                return "Connected to \(modelDisplayName) at \(trimmedLMStudioServerURL)."
+            case .invalidServerURL:
+                return "Enter a valid server URL, for example http://localhost:1234."
+            case .serverUnavailable(let message):
+                return message
+            case .noModelLoaded:
+                return "LM Studio is reachable, but no model is currently loaded. Load any model in LM Studio first."
+            case .error(let message):
+                return message
+            }
+        }
+    }
+
+    var localRetryButtonTitle: String {
+        switch selectedLocalBackend {
+        case .mlx:
+            return "Retry Local Model"
+        case .lmStudio:
+            return "Reconnect LM Studio"
+        }
+    }
+
+    var trimmedLMStudioServerURL: String {
+        let trimmedServerURL = lmStudioServerURLDraft.trimmingCharacters(in: .whitespacesAndNewlines)
+        return trimmedServerURL.isEmpty ? LMStudioLocalChatClient.defaultServerBaseURLString : trimmedServerURL
+    }
+
     var availableClaudeModelOptions: [CompanionClaudeModelOption] {
         CompanionClaudeModelOption.allCases
     }
 
+    private var activeLocalCompanionChatClient: CompanionChatClient {
+        switch selectedLocalBackend {
+        case .mlx:
+            return localMLXCompanionChatClient
+        case .lmStudio:
+            return localLMStudioChatClient
+        }
+    }
+
+    private func offloadInactiveLocalBackendResources() {
+        switch selectedLocalBackend {
+        case .mlx:
+            localLMStudioChatClient.offloadResources()
+        case .lmStudio:
+            localMLXCompanionChatClient.offloadResources()
+        }
+    }
+
     init(
-        localCompanionChatClient: LocalMLXVLMClient? = nil
+        localMLXCompanionChatClient: LocalMLXVLMClient? = nil,
+        localLMStudioChatClient: LMStudioLocalChatClient? = nil
     ) {
         let persistedClaudeModel = UserDefaults.standard.string(forKey: "selectedClaudeModel")
         let resolvedClaudeModel = CompanionClaudeModelOption(rawValue: persistedClaudeModel ?? "") ?? .sonnet46
@@ -187,10 +350,26 @@ final class CompanionManager: ObservableObject {
         let resolvedMode = CompanionInferenceMode(rawValue: persistedMode ?? "") ?? .local
         self.selectedInferenceMode = resolvedMode
 
-        let resolvedLocalCompanionChatClient = localCompanionChatClient
-            ?? LocalMLXVLMClient()
+        let persistedLocalBackend = UserDefaults.standard.string(forKey: "selectedCompanionLocalBackend")
+        let resolvedLocalBackend = CompanionLocalBackend(rawValue: persistedLocalBackend ?? "") ?? .mlx
+        self.selectedLocalBackend = resolvedLocalBackend
 
-        self.localCompanionChatClient = resolvedLocalCompanionChatClient
+        let persistedLMStudioServerURL = UserDefaults.standard.string(forKey: "lmStudioServerURL")
+        let resolvedLMStudioServerURL = persistedLMStudioServerURL?
+            .trimmingCharacters(in: .whitespacesAndNewlines)
+        let defaultedLMStudioServerURL = (resolvedLMStudioServerURL?.isEmpty == false
+            ? resolvedLMStudioServerURL
+            : LMStudioLocalChatClient.defaultServerBaseURLString) ?? LMStudioLocalChatClient.defaultServerBaseURLString
+        self.lmStudioServerURLDraft = defaultedLMStudioServerURL
+
+        let resolvedLocalMLXCompanionChatClient = localMLXCompanionChatClient
+            ?? LocalMLXVLMClient()
+        self.localMLXCompanionChatClient = resolvedLocalMLXCompanionChatClient
+
+        let resolvedLocalLMStudioChatClient = localLMStudioChatClient
+            ?? LMStudioLocalChatClient()
+        resolvedLocalLMStudioChatClient.updateServerBaseURLString(defaultedLMStudioServerURL)
+        self.localLMStudioChatClient = resolvedLocalLMStudioChatClient
     }
 
     func setClaudeModel(_ modelOption: CompanionClaudeModelOption) {
@@ -202,6 +381,29 @@ final class CompanionManager: ObservableObject {
 
         guard selectedInferenceMode == .claude else { return }
         resetActiveResponseUIState()
+    }
+
+    func setLocalBackend(_ localBackend: CompanionLocalBackend) {
+        guard selectedLocalBackend != localBackend else { return }
+
+        selectedLocalBackend = localBackend
+        UserDefaults.standard.set(localBackend.rawValue, forKey: "selectedCompanionLocalBackend")
+
+        resetActiveResponseUIState()
+
+        if selectedInferenceMode == .local {
+            prepareSelectedModelInBackground(forceReloadUIState: true)
+        }
+    }
+
+    func commitLMStudioServerURLDraft() {
+        let sanitizedServerURL = trimmedLMStudioServerURL
+        lmStudioServerURLDraft = sanitizedServerURL
+        UserDefaults.standard.set(sanitizedServerURL, forKey: "lmStudioServerURL")
+        localLMStudioChatClient.updateServerBaseURLString(sanitizedServerURL)
+
+        guard selectedInferenceMode == .local, selectedLocalBackend == .lmStudio else { return }
+        prepareSelectedModelInBackground(forceReloadUIState: true)
     }
 
     func setInferenceMode(_ inferenceMode: CompanionInferenceMode) {
@@ -218,7 +420,9 @@ final class CompanionManager: ObservableObject {
             isPreparingSelectedModel = false
             modelDownloadProgress = nil
             modelPreparationErrorMessage = nil
-            localCompanionChatClient.offloadResources()
+            lmStudioConnectionStatus = .idle
+            localMLXCompanionChatClient.offloadResources()
+            localLMStudioChatClient.offloadResources()
             return
         }
 
@@ -234,6 +438,7 @@ final class CompanionManager: ObservableObject {
         clearDetectedElementLocation()
         voiceState = .idle
         modelDownloadProgress = nil
+        modelPreparationErrorMessage = nil
     }
 
     func retrySelectedModelPreparation() {
@@ -246,6 +451,10 @@ final class CompanionManager: ObservableObject {
         guard selectedInferenceMode == .local else { return }
         modelPreparationTask?.cancel()
 
+        let localBackendToPrepare = selectedLocalBackend
+        let localCompanionChatClientToPrepare = activeLocalCompanionChatClient
+        offloadInactiveLocalBackendResources()
+
         if forceReloadUIState {
             modelDownloadProgress = nil
         }
@@ -255,17 +464,28 @@ final class CompanionManager: ObservableObject {
 
             await MainActor.run {
                 self.isPreparingSelectedModel = true
+                if localBackendToPrepare == .lmStudio {
+                    self.lmStudioConnectionStatus = .checking
+                }
             }
 
             do {
-                try await self.localCompanionChatClient.prepareSelectedModel { progress in
+                try await localCompanionChatClientToPrepare.prepareSelectedModel { progress in
                     self.modelDownloadProgress = progress
                 }
 
                 await MainActor.run {
+                    guard self.selectedInferenceMode == .local,
+                          self.selectedLocalBackend == localBackendToPrepare else {
+                        return
+                    }
                     self.isPreparingSelectedModel = false
                     self.modelPreparationErrorMessage = nil
                     self.modelDownloadProgress = nil
+                    if localBackendToPrepare == .lmStudio {
+                        let connectedModelDisplayName = self.localLMStudioChatClient.connectedModelDisplayName ?? "Loaded model"
+                        self.lmStudioConnectionStatus = .connected(modelDisplayName: connectedModelDisplayName)
+                    }
                 }
             } catch is CancellationError {
                 await MainActor.run {
@@ -273,11 +493,37 @@ final class CompanionManager: ObservableObject {
                 }
             } catch {
                 await MainActor.run {
+                    guard self.selectedInferenceMode == .local,
+                          self.selectedLocalBackend == localBackendToPrepare else {
+                        return
+                    }
                     self.isPreparingSelectedModel = false
                     self.modelPreparationErrorMessage = error.localizedDescription
                     self.modelDownloadProgress = nil
+                    if localBackendToPrepare == .lmStudio {
+                        self.lmStudioConnectionStatus = self.lmStudioConnectionStatus(for: error)
+                    }
                 }
             }
+        }
+    }
+
+    private func lmStudioConnectionStatus(for error: Error) -> LMStudioConnectionStatus {
+        guard let lmStudioError = error as? LMStudioLocalChatClientError else {
+            return .error(message: error.localizedDescription)
+        }
+
+        switch lmStudioError {
+        case .invalidServerURL:
+            return .invalidServerURL
+        case .serverUnavailable(let message):
+            return .serverUnavailable(message: message)
+        case .noModelLoaded:
+            return .noModelLoaded
+        case .invalidModelsResponse:
+            return .error(message: "LM Studio responded, but Clicky could not read the model list.")
+        case .apiError(let message):
+            return .error(message: message)
         }
     }
 
@@ -347,7 +593,8 @@ final class CompanionManager: ObservableObject {
         if selectedInferenceMode == .local {
             prepareSelectedModelInBackground()
         } else {
-            localCompanionChatClient.offloadResources()
+            localMLXCompanionChatClient.offloadResources()
+            localLMStudioChatClient.offloadResources()
             _ = claudeAPI
         }
 
@@ -461,6 +708,8 @@ final class CompanionManager: ObservableObject {
         overlayWindowManager.hideOverlay()
         transientHideTask?.cancel()
         modelPreparationTask?.cancel()
+        localMLXCompanionChatClient.offloadResources()
+        localLMStudioChatClient.offloadResources()
 
         currentResponseTask?.cancel()
         currentResponseTask = nil
@@ -762,6 +1011,8 @@ final class CompanionManager: ObservableObject {
             // Stay in processing (spinner) state — no streaming text displayed
             voiceState = .processing
             let responseMode = self.selectedInferenceMode
+            let localBackendForResponse = self.selectedLocalBackend
+            let localCompanionChatClientForResponse = self.activeLocalCompanionChatClient
 
             if responseMode == .local {
                 modelPreparationErrorMessage = nil
@@ -788,7 +1039,7 @@ final class CompanionManager: ObservableObject {
 
                 let fullResponseText: String
                 if responseMode == .local {
-                    let (localResponseText, _) = try await localCompanionChatClient.analyzeImageStreaming(
+                    let (localResponseText, _) = try await localCompanionChatClientForResponse.analyzeImageStreaming(
                         images: labeledImages,
                         systemPrompt: Self.companionVoiceResponseSystemPrompt,
                         conversationHistory: historyForAPI,
@@ -902,7 +1153,7 @@ final class CompanionManager: ObservableObject {
                         }
                         // speakText returns after player.play() — audio is now playing
                         voiceState = .responding
-                    } catch {
+                } catch {
                         ClickyAnalytics.trackTTSError(error: error.localizedDescription)
                         if responseMode == .local {
                             print("⚠️ Local speech error: \(error)")
@@ -920,6 +1171,9 @@ final class CompanionManager: ObservableObject {
                 print("⚠️ Companion response error: \(error)")
                 if responseMode == .local {
                     modelPreparationErrorMessage = error.localizedDescription
+                    if localBackendForResponse == .lmStudio {
+                        lmStudioConnectionStatus = lmStudioConnectionStatus(for: error)
+                    }
                     speakResponseErrorFallback()
                 } else {
                     speakCreditsErrorFallback()
@@ -1200,10 +1454,11 @@ final class CompanionManager: ObservableObject {
                 let dimensionInfo = " (image dimensions: \(cursorScreenCapture.screenshotWidthInPixels)x\(cursorScreenCapture.screenshotHeightInPixels) pixels)"
                 let labeledImages = [(data: cursorScreenCapture.imageData, label: cursorScreenCapture.label + dimensionInfo)]
                 let responseMode = self.selectedInferenceMode
+                let localCompanionChatClientForResponse = self.activeLocalCompanionChatClient
 
                 let fullResponseText: String
                 if responseMode == .local {
-                    let (localResponseText, _) = try await localCompanionChatClient.analyzeImageStreaming(
+                    let (localResponseText, _) = try await localCompanionChatClientForResponse.analyzeImageStreaming(
                         images: labeledImages,
                         systemPrompt: Self.onboardingDemoSystemPrompt,
                         conversationHistory: [],

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -21,8 +21,51 @@ enum CompanionVoiceState {
     case responding
 }
 
+enum CompanionInferenceMode: String, CaseIterable, Identifiable {
+    case local
+    case claude
+
+    var id: String { rawValue }
+
+    var shortLabel: String {
+        switch self {
+        case .local:
+            return "Local"
+        case .claude:
+            return "Claude"
+        }
+    }
+}
+
+enum CompanionClaudeModelOption: String, CaseIterable, Identifiable {
+    case sonnet46 = "claude-sonnet-4-6"
+    case opus46 = "claude-opus-4-6"
+
+    var id: String { rawValue }
+
+    var shortLabel: String {
+        switch self {
+        case .sonnet46:
+            return "Sonnet"
+        case .opus46:
+            return "Opus"
+        }
+    }
+
+    var displayName: String {
+        switch self {
+        case .sonnet46:
+            return "Claude Sonnet 4.6"
+        case .opus46:
+            return "Claude Opus 4.6"
+        }
+    }
+}
+
 @MainActor
 final class CompanionManager: ObservableObject {
+    private static let workerBaseURL = "https://your-worker-name.your-subdomain.workers.dev"
+
     @Published private(set) var voiceState: CompanionVoiceState = .idle
     @Published private(set) var lastTranscript: String?
     @Published private(set) var currentAudioPowerLevel: CGFloat = 0
@@ -32,7 +75,7 @@ final class CompanionManager: ObservableObject {
     @Published private(set) var hasScreenContentPermission = false
 
     /// Screen location (global AppKit coords) of a detected UI element the
-    /// buddy should fly to and point at. Parsed from Claude's response;
+    /// buddy should fly to and point at. Parsed from the assistant response;
     /// observed by BlueCursorView to trigger the flight animation.
     @Published var detectedElementScreenLocation: CGPoint?
     /// The display frame (global AppKit coords) of the screen the detected
@@ -68,20 +111,22 @@ final class CompanionManager: ObservableObject {
     // Response text is now displayed inline on the cursor overlay via
     // streamingResponseText, so no separate response overlay manager is needed.
 
-    /// Base URL for the Cloudflare Worker proxy. All API requests route
-    /// through this so keys never ship in the app binary.
-    private static let workerBaseURL = "https://your-worker-name.your-subdomain.workers.dev"
+    private let localCompanionChatClient: LocalMLXVLMClient
 
     private lazy var claudeAPI: ClaudeAPI = {
-        return ClaudeAPI(proxyURL: "\(Self.workerBaseURL)/chat", model: selectedModel)
+        ClaudeAPI(proxyURL: "\(Self.workerBaseURL)/chat", model: selectedClaudeModel.id)
     }()
 
     private lazy var elevenLabsTTSClient: ElevenLabsTTSClient = {
-        return ElevenLabsTTSClient(proxyURL: "\(Self.workerBaseURL)/tts")
+        ElevenLabsTTSClient(proxyURL: "\(Self.workerBaseURL)/tts")
     }()
 
-    /// Conversation history so Claude remembers prior exchanges within a session.
-    /// Each entry is the user's transcript and Claude's response.
+    private lazy var localSpeechSynthesizerClient: LocalSpeechSynthesizerClient = {
+        LocalSpeechSynthesizerClient()
+    }()
+
+    /// Conversation history so the selected model remembers prior exchanges within a session.
+    /// Each entry is the user's transcript and the assistant's response.
     private var conversationHistory: [(userTranscript: String, assistantResponse: String)] = []
 
     /// The currently running AI response task, if any. Cancelled when the user
@@ -93,6 +138,7 @@ final class CompanionManager: ObservableObject {
     private var audioPowerCancellable: AnyCancellable?
     private var accessibilityCheckTimer: Timer?
     private var pendingKeyboardShortcutStartTask: Task<Void, Never>?
+    private var modelPreparationTask: Task<Void, Never>?
     /// Scheduled hide for transient cursor mode — cancelled if the user
     /// speaks again before the delay elapses.
     private var transientHideTask: Task<Void, Never>?
@@ -107,13 +153,132 @@ final class CompanionManager: ObservableObject {
     /// Used by the panel to show accurate status text ("Active" vs "Ready").
     @Published private(set) var isOverlayVisible: Bool = false
 
-    /// The Claude model used for voice responses. Persisted to UserDefaults.
-    @Published var selectedModel: String = UserDefaults.standard.string(forKey: "selectedClaudeModel") ?? "claude-sonnet-4-6"
+    /// Local and cloud response mode state used by the panel and response pipeline.
+    @Published private(set) var modelDownloadProgress: Progress?
+    @Published private(set) var modelPreparationErrorMessage: String?
+    @Published private(set) var isPreparingSelectedModel = false
+    @Published private(set) var selectedInferenceMode: CompanionInferenceMode
+    @Published private(set) var selectedClaudeModel: CompanionClaudeModelOption
 
-    func setSelectedModel(_ model: String) {
-        selectedModel = model
-        UserDefaults.standard.set(model, forKey: "selectedClaudeModel")
-        claudeAPI.model = model
+    var localModelDisplayName: String {
+        LocalMLXVLMClient.fixedModelDisplayName
+    }
+
+    var claudeModelDisplayName: String {
+        selectedClaudeModel.displayName
+    }
+
+    var isUsingLocalInference: Bool {
+        selectedInferenceMode == .local
+    }
+
+    var availableClaudeModelOptions: [CompanionClaudeModelOption] {
+        CompanionClaudeModelOption.allCases
+    }
+
+    init(
+        localCompanionChatClient: LocalMLXVLMClient? = nil
+    ) {
+        let persistedClaudeModel = UserDefaults.standard.string(forKey: "selectedClaudeModel")
+        let resolvedClaudeModel = CompanionClaudeModelOption(rawValue: persistedClaudeModel ?? "") ?? .sonnet46
+        self.selectedClaudeModel = resolvedClaudeModel
+
+        let persistedMode = UserDefaults.standard.string(forKey: "selectedCompanionInferenceMode")
+        let resolvedMode = CompanionInferenceMode(rawValue: persistedMode ?? "") ?? .local
+        self.selectedInferenceMode = resolvedMode
+
+        let resolvedLocalCompanionChatClient = localCompanionChatClient
+            ?? LocalMLXVLMClient()
+
+        self.localCompanionChatClient = resolvedLocalCompanionChatClient
+    }
+
+    func setClaudeModel(_ modelOption: CompanionClaudeModelOption) {
+        guard selectedClaudeModel != modelOption else { return }
+
+        selectedClaudeModel = modelOption
+        UserDefaults.standard.set(modelOption.id, forKey: "selectedClaudeModel")
+        claudeAPI.model = modelOption.id
+
+        guard selectedInferenceMode == .claude else { return }
+        resetActiveResponseUIState()
+    }
+
+    func setInferenceMode(_ inferenceMode: CompanionInferenceMode) {
+        guard selectedInferenceMode != inferenceMode else { return }
+
+        selectedInferenceMode = inferenceMode
+        UserDefaults.standard.set(inferenceMode.rawValue, forKey: "selectedCompanionInferenceMode")
+
+        resetActiveResponseUIState()
+
+        if inferenceMode == .claude {
+            claudeAPI.model = selectedClaudeModel.id
+            modelPreparationTask?.cancel()
+            isPreparingSelectedModel = false
+            modelDownloadProgress = nil
+            modelPreparationErrorMessage = nil
+            localCompanionChatClient.offloadResources()
+            return
+        }
+
+        modelPreparationErrorMessage = nil
+        prepareSelectedModelInBackground(forceReloadUIState: true)
+    }
+
+    private func resetActiveResponseUIState() {
+        currentResponseTask?.cancel()
+        currentResponseTask = nil
+        elevenLabsTTSClient.stopPlayback()
+        localSpeechSynthesizerClient.stopPlayback()
+        clearDetectedElementLocation()
+        voiceState = .idle
+        modelDownloadProgress = nil
+    }
+
+    func retrySelectedModelPreparation() {
+        guard selectedInferenceMode == .local else { return }
+        modelPreparationErrorMessage = nil
+        prepareSelectedModelInBackground(forceReloadUIState: true)
+    }
+
+    private func prepareSelectedModelInBackground(forceReloadUIState: Bool = false) {
+        guard selectedInferenceMode == .local else { return }
+        modelPreparationTask?.cancel()
+
+        if forceReloadUIState {
+            modelDownloadProgress = nil
+        }
+
+        modelPreparationTask = Task { [weak self] in
+            guard let self else { return }
+
+            await MainActor.run {
+                self.isPreparingSelectedModel = true
+            }
+
+            do {
+                try await self.localCompanionChatClient.prepareSelectedModel { progress in
+                    self.modelDownloadProgress = progress
+                }
+
+                await MainActor.run {
+                    self.isPreparingSelectedModel = false
+                    self.modelPreparationErrorMessage = nil
+                    self.modelDownloadProgress = nil
+                }
+            } catch is CancellationError {
+                await MainActor.run {
+                    self.isPreparingSelectedModel = false
+                }
+            } catch {
+                await MainActor.run {
+                    self.isPreparingSelectedModel = false
+                    self.modelPreparationErrorMessage = error.localizedDescription
+                    self.modelDownloadProgress = nil
+                }
+            }
+        }
     }
 
     /// User preference for whether the Clicky cursor should be shown.
@@ -179,9 +344,12 @@ final class CompanionManager: ObservableObject {
         bindVoiceStateObservation()
         bindAudioPowerLevel()
         bindShortcutTransitions()
-        // Eagerly touch the Claude API so its TLS warmup handshake completes
-        // well before the onboarding demo fires at ~40s into the video.
-        _ = claudeAPI
+        if selectedInferenceMode == .local {
+            prepareSelectedModelInBackground()
+        } else {
+            localCompanionChatClient.offloadResources()
+            _ = claudeAPI
+        }
 
         // If the user already completed onboarding AND all permissions are
         // still granted, show the cursor overlay immediately. If permissions
@@ -292,6 +460,7 @@ final class CompanionManager: ObservableObject {
         buddyDictationManager.cancelCurrentDictation()
         overlayWindowManager.hideOverlay()
         transientHideTask?.cancel()
+        modelPreparationTask?.cancel()
 
         currentResponseTask?.cancel()
         currentResponseTask = nil
@@ -494,6 +663,7 @@ final class CompanionManager: ObservableObject {
             // Cancel any in-progress response and TTS from a previous utterance
             currentResponseTask?.cancel()
             elevenLabsTTSClient.stopPlayback()
+            localSpeechSynthesizerClient.stopPlayback()
             clearDetectedElementLocation()
 
             // Dismiss the onboarding prompt if it's showing
@@ -521,7 +691,7 @@ final class CompanionManager: ObservableObject {
                         self?.lastTranscript = finalTranscript
                         print("🗣️ Companion received transcript: \(finalTranscript)")
                         ClickyAnalytics.trackUserMessageSent(transcript: finalTranscript)
-                        self?.sendTranscriptToClaudeWithScreenshot(transcript: finalTranscript)
+                        self?.sendTranscriptWithScreenshot(transcript: finalTranscript)
                     }
                 )
             }
@@ -578,18 +748,24 @@ final class CompanionManager: ObservableObject {
 
     // MARK: - AI Response Pipeline
 
-    /// Captures a screenshot, sends it along with the transcript to Claude,
-    /// and plays the response aloud via ElevenLabs TTS. The cursor stays in
+    /// Captures a screenshot, sends it along with the transcript to the selected model,
+    /// and plays the response aloud via local or remote TTS. The cursor stays in
     /// the spinner/processing state until TTS audio begins playing.
-    /// Claude's response may include a [POINT:x,y:label] tag which triggers
+    /// The model response may include a [POINT:x,y:label] tag which triggers
     /// the buddy to fly to that element on screen.
-    private func sendTranscriptToClaudeWithScreenshot(transcript: String) {
+    private func sendTranscriptWithScreenshot(transcript: String) {
         currentResponseTask?.cancel()
         elevenLabsTTSClient.stopPlayback()
+        localSpeechSynthesizerClient.stopPlayback()
 
         currentResponseTask = Task {
             // Stay in processing (spinner) state — no streaming text displayed
             voiceState = .processing
+            let responseMode = self.selectedInferenceMode
+
+            if responseMode == .local {
+                modelPreparationErrorMessage = nil
+            }
 
             do {
                 // Capture all connected screens so the AI has full context
@@ -598,35 +774,53 @@ final class CompanionManager: ObservableObject {
                 guard !Task.isCancelled else { return }
 
                 // Build image labels with the actual screenshot pixel dimensions
-                // so Claude's coordinate space matches the image it sees. We
+                // so the selected model's coordinate space matches the image it sees. We
                 // scale from screenshot pixels to display points ourselves.
                 let labeledImages = screenCaptures.map { capture in
                     let dimensionInfo = " (image dimensions: \(capture.screenshotWidthInPixels)x\(capture.screenshotHeightInPixels) pixels)"
                     return (data: capture.imageData, label: capture.label + dimensionInfo)
                 }
 
-                // Pass conversation history so Claude remembers prior exchanges
+                // Pass conversation history so the selected model remembers prior exchanges
                 let historyForAPI = conversationHistory.map { entry in
                     (userPlaceholder: entry.userTranscript, assistantResponse: entry.assistantResponse)
                 }
 
-                let (fullResponseText, _) = try await claudeAPI.analyzeImageStreaming(
-                    images: labeledImages,
-                    systemPrompt: Self.companionVoiceResponseSystemPrompt,
-                    conversationHistory: historyForAPI,
-                    userPrompt: transcript,
-                    onTextChunk: { _ in
-                        // No streaming text display — spinner stays until TTS plays
-                    }
-                )
+                let fullResponseText: String
+                if responseMode == .local {
+                    let (localResponseText, _) = try await localCompanionChatClient.analyzeImageStreaming(
+                        images: labeledImages,
+                        systemPrompt: Self.companionVoiceResponseSystemPrompt,
+                        conversationHistory: historyForAPI,
+                        userPrompt: transcript,
+                        progressHandler: { progress in
+                            self.modelDownloadProgress = progress
+                        },
+                        onTextChunk: { _ in
+                            // No streaming text display — spinner stays until TTS plays
+                        }
+                    )
+                    fullResponseText = localResponseText
+                } else {
+                    let (claudeResponseText, _) = try await claudeAPI.analyzeImageStreaming(
+                        images: labeledImages,
+                        systemPrompt: Self.companionVoiceResponseSystemPrompt,
+                        conversationHistory: historyForAPI,
+                        userPrompt: transcript,
+                        onTextChunk: { _ in
+                            // No streaming text display — spinner stays until TTS plays
+                        }
+                    )
+                    fullResponseText = claudeResponseText
+                }
 
                 guard !Task.isCancelled else { return }
 
-                // Parse the [POINT:...] tag from Claude's response
+                // Parse the [POINT:...] tag from the model response
                 let parseResult = Self.parsePointingCoordinates(from: fullResponseText)
                 let spokenText = parseResult.spokenText
 
-                // Handle element pointing if Claude returned coordinates.
+                // Handle element pointing if the model returned coordinates.
                 // Switch to idle BEFORE setting the location so the triangle
                 // becomes visible and can fly to the target. Without this, the
                 // spinner hides the triangle and the flight animation is invisible.
@@ -635,7 +829,7 @@ final class CompanionManager: ObservableObject {
                     voiceState = .idle
                 }
 
-                // Pick the screen capture matching Claude's screen number,
+                // Pick the screen capture matching the returned screen number,
                 // falling back to the cursor screen if not specified.
                 let targetScreenCapture: CompanionScreenCapture? = {
                     if let screenNumber = parseResult.screenNumber,
@@ -647,7 +841,7 @@ final class CompanionManager: ObservableObject {
 
                 if let pointCoordinate = parseResult.coordinate,
                    let targetScreenCapture {
-                    // Claude's coordinates are in the screenshot's pixel space
+                    // The model's coordinates are in the screenshot's pixel space
                     // (top-left origin, e.g. 1280x831). Scale to the display's
                     // point space (e.g. 1512x982), then convert to AppKit global coords.
                     let screenshotWidth = CGFloat(targetScreenCapture.screenshotWidthInPixels)
@@ -701,13 +895,22 @@ final class CompanionManager: ObservableObject {
                 // until the audio actually starts playing, then switch to responding.
                 if !spokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
                     do {
-                        try await elevenLabsTTSClient.speakText(spokenText)
+                        if responseMode == .local {
+                            try await localSpeechSynthesizerClient.speakText(spokenText)
+                        } else {
+                            try await elevenLabsTTSClient.speakText(spokenText)
+                        }
                         // speakText returns after player.play() — audio is now playing
                         voiceState = .responding
                     } catch {
                         ClickyAnalytics.trackTTSError(error: error.localizedDescription)
-                        print("⚠️ ElevenLabs TTS error: \(error)")
-                        speakCreditsErrorFallback()
+                        if responseMode == .local {
+                            print("⚠️ Local speech error: \(error)")
+                            speakResponseErrorFallback()
+                        } else {
+                            print("⚠️ ElevenLabs TTS error: \(error)")
+                            speakCreditsErrorFallback()
+                        }
                     }
                 }
             } catch is CancellationError {
@@ -715,11 +918,17 @@ final class CompanionManager: ObservableObject {
             } catch {
                 ClickyAnalytics.trackResponseError(error: error.localizedDescription)
                 print("⚠️ Companion response error: \(error)")
-                speakCreditsErrorFallback()
+                if responseMode == .local {
+                    modelPreparationErrorMessage = error.localizedDescription
+                    speakResponseErrorFallback()
+                } else {
+                    speakCreditsErrorFallback()
+                }
             }
 
             if !Task.isCancelled {
                 voiceState = .idle
+                modelDownloadProgress = nil
                 scheduleTransientHideIfNeeded()
             }
         }
@@ -735,7 +944,7 @@ final class CompanionManager: ObservableObject {
         transientHideTask?.cancel()
         transientHideTask = Task {
             // Wait for TTS audio to finish playing
-            while elevenLabsTTSClient.isPlaying {
+            while elevenLabsTTSClient.isPlaying || localSpeechSynthesizerClient.isPlaying {
                 try? await Task.sleep(nanoseconds: 200_000_000)
                 guard !Task.isCancelled else { return }
             }
@@ -755,6 +964,15 @@ final class CompanionManager: ObservableObject {
         }
     }
 
+    /// Speaks a hardcoded error message using macOS system TTS when the
+    /// local model fails to load or generate.
+    private func speakResponseErrorFallback() {
+        let utterance = "I hit a local model error. Open Clicky and retry the model download."
+        let synthesizer = NSSpeechSynthesizer()
+        synthesizer.startSpeaking(utterance)
+        voiceState = .responding
+    }
+
     /// Speaks a hardcoded error message using macOS system TTS when API
     /// credits run out. Uses NSSpeechSynthesizer so it works even when
     /// ElevenLabs is down.
@@ -767,11 +985,11 @@ final class CompanionManager: ObservableObject {
 
     // MARK: - Point Tag Parsing
 
-    /// Result of parsing a [POINT:...] tag from Claude's response.
+    /// Result of parsing a [POINT:...] tag from an assistant response.
     struct PointingParseResult {
         /// The response text with the [POINT:...] tag removed — this is what gets spoken.
         let spokenText: String
-        /// The parsed pixel coordinate, or nil if Claude said "none" or no tag was found.
+        /// The parsed pixel coordinate, or nil if the assistant said "none" or no tag was found.
         let coordinate: CGPoint?
         /// Short label describing the element (e.g. "run button"), or "none".
         let elementLabel: String?
@@ -779,7 +997,7 @@ final class CompanionManager: ObservableObject {
         let screenNumber: Int?
     }
 
-    /// Parses a [POINT:x,y:label:screenN] or [POINT:none] tag from the end of Claude's response.
+    /// Parses a [POINT:x,y:label:screenN] or [POINT:none] tag from the end of an assistant response.
     /// Returns the spoken text (tag removed) and the optional coordinate + label + screen number.
     static func parsePointingCoordinates(from responseText: String) -> PointingParseResult {
         // Match [POINT:none] or [POINT:123,456:label] or [POINT:123,456:label:screen2]
@@ -961,7 +1179,7 @@ final class CompanionManager: ObservableObject {
     the screenshot images are labeled with their pixel dimensions. use those dimensions as the coordinate space. origin (0,0) is top-left. x increases rightward, y increases downward.
     """
 
-    /// Captures a screenshot and asks Claude to find something interesting to
+    /// Captures a screenshot and asks the selected model to find something interesting to
     /// point at, then triggers the buddy's flight animation. Used during
     /// onboarding to demo the pointing feature while the intro video plays.
     func performOnboardingDemoInteraction() {
@@ -972,7 +1190,7 @@ final class CompanionManager: ObservableObject {
             do {
                 let screenCaptures = try await CompanionScreenCaptureUtility.captureAllScreensAsJPEG()
 
-                // Only send the cursor screen so Claude can't pick something
+                // Only send the cursor screen so the model can't pick something
                 // on a different monitor that we can't point at.
                 guard let cursorScreenCapture = screenCaptures.first(where: { $0.isCursorScreen }) else {
                     print("🎯 Onboarding demo: no cursor screen found")
@@ -981,13 +1199,30 @@ final class CompanionManager: ObservableObject {
 
                 let dimensionInfo = " (image dimensions: \(cursorScreenCapture.screenshotWidthInPixels)x\(cursorScreenCapture.screenshotHeightInPixels) pixels)"
                 let labeledImages = [(data: cursorScreenCapture.imageData, label: cursorScreenCapture.label + dimensionInfo)]
+                let responseMode = self.selectedInferenceMode
 
-                let (fullResponseText, _) = try await claudeAPI.analyzeImageStreaming(
-                    images: labeledImages,
-                    systemPrompt: Self.onboardingDemoSystemPrompt,
-                    userPrompt: "look around my screen and find something interesting to point at",
-                    onTextChunk: { _ in }
-                )
+                let fullResponseText: String
+                if responseMode == .local {
+                    let (localResponseText, _) = try await localCompanionChatClient.analyzeImageStreaming(
+                        images: labeledImages,
+                        systemPrompt: Self.onboardingDemoSystemPrompt,
+                        conversationHistory: [],
+                        userPrompt: "look around my screen and find something interesting to point at",
+                        progressHandler: { progress in
+                            self.modelDownloadProgress = progress
+                        },
+                        onTextChunk: { _ in }
+                    )
+                    fullResponseText = localResponseText
+                } else {
+                    let (claudeResponseText, _) = try await claudeAPI.analyzeImageStreaming(
+                        images: labeledImages,
+                        systemPrompt: Self.onboardingDemoSystemPrompt,
+                        userPrompt: "look around my screen and find something interesting to point at",
+                        onTextChunk: { _ in }
+                    )
+                    fullResponseText = claudeResponseText
+                }
 
                 let parseResult = Self.parsePointingCoordinates(from: fullResponseText)
 
@@ -1012,7 +1247,7 @@ final class CompanionManager: ObservableObject {
                     y: appKitY + displayFrame.origin.y
                 )
 
-                // Set custom bubble text so the pointing animation uses Claude's
+                // Set custom bubble text so the pointing animation uses the model's
                 // comment instead of a random phrase
                 detectedElementBubbleText = parseResult.spokenText
                 detectedElementScreenLocation = globalLocation

--- a/leanring-buddy/CompanionPanelView.swift
+++ b/leanring-buddy/CompanionPanelView.swift
@@ -29,8 +29,22 @@ struct CompanionPanelView: View {
                 Spacer()
                     .frame(height: 12)
 
-                modelPickerRow
+                inferenceModeRow
                     .padding(.horizontal, 16)
+
+                if companionManager.isUsingLocalInference {
+                    Spacer()
+                        .frame(height: 8)
+
+                    modelPickerRow
+                        .padding(.horizontal, 16)
+                } else {
+                    Spacer()
+                        .frame(height: 8)
+
+                    claudeModeInfoRow
+                        .padding(.horizontal, 16)
+                }
             }
 
             if !companionManager.allPermissionsGranted {
@@ -596,19 +610,19 @@ struct CompanionPanelView: View {
         .padding(.vertical, 4)
     }
 
-    // MARK: - Model Picker
+    // MARK: - Inference Mode
 
-    private var modelPickerRow: some View {
+    private var inferenceModeRow: some View {
         HStack {
-            Text("Model")
+            Text("Inference")
                 .font(.system(size: 13, weight: .medium))
                 .foregroundColor(DS.Colors.textSecondary)
 
             Spacer()
 
             HStack(spacing: 0) {
-                modelOptionButton(label: "Sonnet", modelID: "claude-sonnet-4-6")
-                modelOptionButton(label: "Opus", modelID: "claude-opus-4-6")
+                inferenceModeButton(.local)
+                inferenceModeButton(.claude)
             }
             .background(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
@@ -622,12 +636,12 @@ struct CompanionPanelView: View {
         .padding(.vertical, 4)
     }
 
-    private func modelOptionButton(label: String, modelID: String) -> some View {
-        let isSelected = companionManager.selectedModel == modelID
+    private func inferenceModeButton(_ inferenceMode: CompanionInferenceMode) -> some View {
+        let isSelected = companionManager.selectedInferenceMode == inferenceMode
         return Button(action: {
-            companionManager.setSelectedModel(modelID)
+            companionManager.setInferenceMode(inferenceMode)
         }) {
-            Text(label)
+            Text(inferenceMode.shortLabel)
                 .font(.system(size: 11, weight: .medium))
                 .foregroundColor(isSelected ? DS.Colors.textPrimary : DS.Colors.textTertiary)
                 .padding(.horizontal, 10)
@@ -639,6 +653,142 @@ struct CompanionPanelView: View {
         }
         .buttonStyle(.plain)
         .pointerCursor()
+    }
+
+    private var claudeModeInfoRow: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            HStack {
+                Text("Cloud Model")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(DS.Colors.textSecondary)
+
+                Spacer()
+
+                HStack(spacing: 0) {
+                    ForEach(companionManager.availableClaudeModelOptions) { modelOption in
+                        claudeModelButton(modelOption)
+                    }
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color.white.opacity(0.06))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(DS.Colors.borderSubtle, lineWidth: 0.5)
+                )
+            }
+
+            Text(companionManager.claudeModelDisplayName)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(DS.Colors.textTertiary)
+
+            Text("Local MLX model is offloaded to reduce memory usage.")
+                .font(.system(size: 11))
+                .foregroundColor(DS.Colors.textTertiary)
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func claudeModelButton(_ modelOption: CompanionClaudeModelOption) -> some View {
+        let isSelected = companionManager.selectedClaudeModel == modelOption
+        return Button(action: {
+            companionManager.setClaudeModel(modelOption)
+        }) {
+            Text(modelOption.shortLabel)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(isSelected ? DS.Colors.textPrimary : DS.Colors.textTertiary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(isSelected ? Color.white.opacity(0.1) : Color.clear)
+                )
+        }
+        .buttonStyle(.plain)
+        .pointerCursor()
+    }
+
+    // MARK: - Local Model
+
+    private var modelPickerRow: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            HStack {
+                Text("Local Model")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(DS.Colors.textSecondary)
+
+                Spacer()
+
+                Text(companionManager.localModelDisplayName)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(DS.Colors.textPrimary)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .fill(Color.white.opacity(0.06))
+                    )
+                    .overlay(
+                        RoundedRectangle(cornerRadius: 6, style: .continuous)
+                            .stroke(DS.Colors.borderSubtle, lineWidth: 0.5)
+                    )
+            }
+
+            Text("Runs fully on-device with MLX.")
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(DS.Colors.textTertiary)
+
+            if let modelDownloadProgress = companionManager.modelDownloadProgress {
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text("Downloading local model")
+                            .font(.system(size: 11, weight: .medium))
+                            .foregroundColor(DS.Colors.textSecondary)
+
+                        Spacer()
+
+                        Text(modelDownloadProgress.localizedDescription)
+                            .font(.system(size: 10))
+                            .foregroundColor(DS.Colors.textTertiary)
+                    }
+
+                    ProgressView(value: modelDownloadProgress.fractionCompleted)
+                        .progressViewStyle(.linear)
+                        .tint(DS.Colors.accent)
+                }
+            } else if companionManager.isPreparingSelectedModel {
+                Text("loading model...")
+                    .font(.system(size: 11))
+                    .foregroundColor(DS.Colors.textTertiary)
+            }
+
+            if let modelPreparationErrorMessage = companionManager.modelPreparationErrorMessage {
+                VStack(alignment: .leading, spacing: 8) {
+                    Text(modelPreparationErrorMessage)
+                        .font(.system(size: 11))
+                        .foregroundColor(Color(red: 0.9, green: 0.4, blue: 0.4))
+                        .fixedSize(horizontal: false, vertical: true)
+
+                    Button(action: {
+                        companionManager.retrySelectedModelPreparation()
+                    }) {
+                        Text("Retry Download")
+                            .font(.system(size: 11, weight: .semibold))
+                            .foregroundColor(DS.Colors.textOnAccent)
+                            .padding(.horizontal, 10)
+                            .padding(.vertical, 5)
+                            .background(
+                                Capsule()
+                                    .fill(DS.Colors.accent)
+                            )
+                    }
+                    .buttonStyle(.plain)
+                    .pointerCursor()
+                }
+            }
+        }
+        .padding(.vertical, 4)
     }
 
     // MARK: - DM Farza Button
@@ -742,6 +892,10 @@ struct CompanionPanelView: View {
     private var statusText: String {
         if !companionManager.hasCompletedOnboarding || !companionManager.allPermissionsGranted {
             return "Setup"
+        }
+        if companionManager.isUsingLocalInference
+            && (companionManager.modelDownloadProgress != nil || companionManager.isPreparingSelectedModel) {
+            return "Preparing"
         }
         if !companionManager.isOverlayVisible {
             return "Ready"

--- a/leanring-buddy/CompanionPanelView.swift
+++ b/leanring-buddy/CompanionPanelView.swift
@@ -714,9 +714,31 @@ struct CompanionPanelView: View {
     private var modelPickerRow: some View {
         VStack(alignment: .leading, spacing: 8) {
             HStack {
-                Text("Local Model")
+                Text("Local Backend")
                     .font(.system(size: 13, weight: .medium))
                     .foregroundColor(DS.Colors.textSecondary)
+
+                Spacer()
+
+                HStack(spacing: 0) {
+                    ForEach(companionManager.availableLocalBackendOptions) { localBackend in
+                        localBackendButton(localBackend)
+                    }
+                }
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(Color.white.opacity(0.06))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(DS.Colors.borderSubtle, lineWidth: 0.5)
+                )
+            }
+
+            HStack {
+                Text(companionManager.localModeDescriptionText)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(DS.Colors.textTertiary)
 
                 Spacer()
 
@@ -735,45 +757,77 @@ struct CompanionPanelView: View {
                     )
             }
 
-            Text("Runs fully on-device with MLX.")
-                .font(.system(size: 11, weight: .medium))
-                .foregroundColor(DS.Colors.textTertiary)
-
-            if let modelDownloadProgress = companionManager.modelDownloadProgress {
+            if companionManager.isUsingLMStudioLocalBackend {
                 VStack(alignment: .leading, spacing: 6) {
-                    HStack {
-                        Text("Downloading local model")
-                            .font(.system(size: 11, weight: .medium))
-                            .foregroundColor(DS.Colors.textPrimary)
+                    Text("LM Studio Server")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(DS.Colors.textSecondary)
 
-                        Spacer()
+                    TextField("http://localhost:1234", text: $companionManager.lmStudioServerURLDraft)
+                        .textFieldStyle(.plain)
+                        .font(.system(size: 13))
+                        .foregroundColor(DS.Colors.textPrimary)
+                        .padding(.horizontal, 12)
+                        .padding(.vertical, 8)
+                        .background(
+                            RoundedRectangle(cornerRadius: DS.CornerRadius.medium, style: .continuous)
+                                .fill(Color.white.opacity(0.08))
+                        )
+                        .overlay(
+                            RoundedRectangle(cornerRadius: DS.CornerRadius.medium, style: .continuous)
+                                .stroke(DS.Colors.borderSubtle, lineWidth: 0.5)
+                        )
+                        .onSubmit {
+                            companionManager.commitLMStudioServerURLDraft()
+                        }
 
-                        Text(modelDownloadProgress.localizedDescription)
-                            .font(.system(size: 10))
-                            .foregroundColor(DS.Colors.textTertiary)
-                    }
+                    Text("Press return to reconnect. Default: http://localhost:1234")
+                        .font(.system(size: 10))
+                        .foregroundColor(DS.Colors.textTertiary)
+                }
+            }
 
+            VStack(alignment: .leading, spacing: 4) {
+                Text(companionManager.localModelStatusTitle)
+                    .font(.system(size: 11, weight: .semibold))
+                    .foregroundColor(DS.Colors.textPrimary)
+
+                Text(companionManager.localModelStatusDetail)
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(companionManager.modelPreparationErrorMessage == nil ? DS.Colors.textPrimary : Color(red: 0.9, green: 0.4, blue: 0.4))
+                    .opacity(companionManager.modelPreparationErrorMessage == nil ? 0.9 : 1.0)
+                    .fixedSize(horizontal: false, vertical: true)
+            }
+
+            if let modelDownloadProgress = companionManager.modelDownloadProgress,
+               !companionManager.isUsingLMStudioLocalBackend {
+                VStack(alignment: .leading, spacing: 6) {
                     ProgressView(value: modelDownloadProgress.fractionCompleted)
                         .progressViewStyle(.linear)
                         .tint(DS.Colors.accent)
                 }
             } else if companionManager.isPreparingSelectedModel {
-                Text("loading model...")
-                    .font(.system(size: 11))
-                    .foregroundColor(DS.Colors.textPrimary)
+                HStack(spacing: 8) {
+                    ProgressView()
+                        .controlSize(.small)
+                        .tint(DS.Colors.accent)
+
+                    Text(companionManager.isUsingLMStudioLocalBackend ? "Checking LM Studio connection..." : "Loading weights into memory...")
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(DS.Colors.textPrimary)
+                }
             }
 
-            if let modelPreparationErrorMessage = companionManager.modelPreparationErrorMessage {
+            if companionManager.modelPreparationErrorMessage != nil {
                 VStack(alignment: .leading, spacing: 8) {
-                    Text(modelPreparationErrorMessage)
-                        .font(.system(size: 11))
-                        .foregroundColor(Color(red: 0.9, green: 0.4, blue: 0.4))
-                        .fixedSize(horizontal: false, vertical: true)
-
                     Button(action: {
-                        companionManager.retrySelectedModelPreparation()
+                        if companionManager.isUsingLMStudioLocalBackend {
+                            companionManager.commitLMStudioServerURLDraft()
+                        } else {
+                            companionManager.retrySelectedModelPreparation()
+                        }
                     }) {
-                        Text("Retry Download")
+                        Text(companionManager.localRetryButtonTitle)
                             .font(.system(size: 11, weight: .semibold))
                             .foregroundColor(DS.Colors.textOnAccent)
                             .padding(.horizontal, 10)
@@ -789,6 +843,25 @@ struct CompanionPanelView: View {
             }
         }
         .padding(.vertical, 4)
+    }
+
+    private func localBackendButton(_ localBackend: CompanionLocalBackend) -> some View {
+        let isSelected = companionManager.selectedLocalBackend == localBackend
+        return Button(action: {
+            companionManager.setLocalBackend(localBackend)
+        }) {
+            Text(localBackend.shortLabel)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(isSelected ? DS.Colors.textPrimary : DS.Colors.textTertiary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 5, style: .continuous)
+                        .fill(isSelected ? Color.white.opacity(0.1) : Color.clear)
+                )
+        }
+        .buttonStyle(.plain)
+        .pointerCursor()
     }
 
     // MARK: - DM Farza Button
@@ -893,9 +966,8 @@ struct CompanionPanelView: View {
         if !companionManager.hasCompletedOnboarding || !companionManager.allPermissionsGranted {
             return "Setup"
         }
-        if companionManager.isUsingLocalInference
-            && (companionManager.modelDownloadProgress != nil || companionManager.isPreparingSelectedModel) {
-            return "Preparing"
+        if companionManager.isUsingLocalInference && companionManager.isPreparingSelectedModel {
+            return companionManager.isUsingLMStudioLocalBackend ? "Checking" : (companionManager.modelDownloadProgress != nil ? "Downloading" : "Loading")
         }
         if !companionManager.isOverlayVisible {
             return "Ready"

--- a/leanring-buddy/CompanionPanelView.swift
+++ b/leanring-buddy/CompanionPanelView.swift
@@ -744,7 +744,7 @@ struct CompanionPanelView: View {
                     HStack {
                         Text("Downloading local model")
                             .font(.system(size: 11, weight: .medium))
-                            .foregroundColor(DS.Colors.textSecondary)
+                            .foregroundColor(DS.Colors.textPrimary)
 
                         Spacer()
 
@@ -760,7 +760,7 @@ struct CompanionPanelView: View {
             } else if companionManager.isPreparingSelectedModel {
                 Text("loading model...")
                     .font(.system(size: 11))
-                    .foregroundColor(DS.Colors.textTertiary)
+                    .foregroundColor(DS.Colors.textPrimary)
             }
 
             if let modelPreparationErrorMessage = companionManager.modelPreparationErrorMessage {

--- a/leanring-buddy/Info.plist
+++ b/leanring-buddy/Info.plist
@@ -2,19 +2,13 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
-	<key>LSUIElement</key>
-	<true/>
+	<key>NSScreenCaptureUsageDescription</key>
+	<string>Clicky needs screen recording access to see your screen and help you.</string>
 	<key>SUFeedURL</key>
 	<string>https://raw.githubusercontent.com/julianjear/makesomething-mac-app/main/appcast.xml</string>
 	<key>SUPublicEDKey</key>
 	<string>/l3d2rw5ZZFRU3AadP/w2Zf8FHfhA6bKv16BQOV5OSk=</string>
 	<key>VoiceTranscriptionProvider</key>
-	<string>assemblyai</string>
-	<key>NSMicrophoneUsageDescription</key>
-	<string>Clicky uses your microphone so you can talk to it</string>
-	<key>NSScreenCaptureUsageDescription</key>
-	<string>Clicky needs screen recording access to see your screen and help you.</string>
-	<key>NSSpeechRecognitionUsageDescription</key>
-	<string>Clicky uses speech recognition to transcribe your voice when you talk to it</string>
+	<string>apple</string>
 </dict>
 </plist>

--- a/leanring-buddy/Local-AI-Mode/LMStudioLocalChatClient.swift
+++ b/leanring-buddy/Local-AI-Mode/LMStudioLocalChatClient.swift
@@ -1,0 +1,421 @@
+//
+//  LMStudioLocalChatClient.swift
+//  leanring-buddy
+//
+//  Local companion backend that talks directly to an LM Studio server running
+//  on the same machine. Uses any currently loaded LLM from LM Studio.
+//
+
+import Foundation
+
+enum LMStudioLocalChatClientError: LocalizedError {
+    case invalidServerURL
+    case serverUnavailable(message: String)
+    case invalidModelsResponse
+    case noModelLoaded
+    case apiError(message: String)
+
+    var errorDescription: String? {
+        switch self {
+        case .invalidServerURL:
+            return "Enter a valid LM Studio server URL."
+        case .serverUnavailable(let message):
+            return message
+        case .invalidModelsResponse:
+            return "LM Studio responded, but Clicky could not read the model list."
+        case .noModelLoaded:
+            return "LM Studio is running, but no model is loaded."
+        case .apiError(let message):
+            return message
+        }
+    }
+}
+
+private struct LMStudioResolvedModel {
+    let identifier: String
+    let displayName: String
+}
+
+private struct LMStudioModelsResponse: Decodable {
+    let models: [LMStudioModel]
+}
+
+private struct LMStudioModel: Decodable {
+    let type: String
+    let key: String
+    let displayName: String
+    let loadedInstances: [LMStudioLoadedInstance]
+
+    private enum CodingKeys: String, CodingKey {
+        case type
+        case key
+        case displayName = "display_name"
+        case loadedInstances = "loaded_instances"
+    }
+}
+
+private struct LMStudioLoadedInstance: Decodable {
+    let id: String
+}
+
+final class LMStudioLocalChatClient: CompanionChatClient {
+    static let defaultServerBaseURLString = "http://localhost:1234"
+
+    private let stateLock = NSLock()
+    private let session: URLSession
+    private var serverBaseURLString = LMStudioLocalChatClient.defaultServerBaseURLString
+    private var connectedModelDisplayNameStorage: String?
+
+    var connectedModelDisplayName: String? {
+        stateLock.withLock {
+            connectedModelDisplayNameStorage
+        }
+    }
+
+    init() {
+        let configuration = URLSessionConfiguration.default
+        configuration.timeoutIntervalForRequest = 30
+        configuration.timeoutIntervalForResource = 300
+        configuration.waitsForConnectivity = false
+        configuration.urlCache = nil
+        configuration.httpCookieStorage = nil
+        self.session = URLSession(configuration: configuration)
+    }
+
+    func updateServerBaseURLString(_ serverBaseURLString: String) {
+        let trimmedServerBaseURLString = serverBaseURLString.trimmingCharacters(in: .whitespacesAndNewlines)
+
+        stateLock.withLock {
+            self.serverBaseURLString = trimmedServerBaseURLString.isEmpty
+                ? Self.defaultServerBaseURLString
+                : trimmedServerBaseURLString
+            connectedModelDisplayNameStorage = nil
+        }
+    }
+
+    func prepareSelectedModel(
+        progressHandler: @MainActor @escaping (Progress?) -> Void
+    ) async throws {
+        await MainActor.run {
+            progressHandler(nil)
+        }
+
+        let resolvedModel = try await resolveLoadedModel()
+
+        stateLock.withLock {
+            connectedModelDisplayNameStorage = resolvedModel.displayName
+        }
+    }
+
+    func offloadResources() {
+        stateLock.withLock {
+            connectedModelDisplayNameStorage = nil
+        }
+    }
+
+    func analyzeImageStreaming(
+        images: [(data: Data, label: String)],
+        systemPrompt: String,
+        conversationHistory: [(userPlaceholder: String, assistantResponse: String)],
+        userPrompt: String,
+        progressHandler: @MainActor @escaping (Progress?) -> Void,
+        onTextChunk: @MainActor @Sendable (String) -> Void
+    ) async throws -> (text: String, duration: TimeInterval) {
+        await MainActor.run {
+            progressHandler(nil)
+        }
+
+        let resolvedModel = try await resolveLoadedModel()
+        let requestURL = try makeRequestURL(path: "/v1/chat/completions")
+
+        var request = URLRequest(url: requestURL)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 120
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+
+        let requestBody = try buildChatRequestBody(
+            modelIdentifier: resolvedModel.identifier,
+            images: images,
+            systemPrompt: systemPrompt,
+            conversationHistory: conversationHistory,
+            userPrompt: userPrompt
+        )
+
+        request.httpBody = requestBody
+        let payloadMB = Double(requestBody.count) / 1_048_576.0
+        print("🖥️ LM Studio request: \(String(format: "%.1f", payloadMB))MB, \(images.count) image(s)")
+
+        let startTime = Date()
+        let byteStream: URLSession.AsyncBytes
+        let response: URLResponse
+
+        do {
+            (byteStream, response) = try await session.bytes(for: request)
+        } catch {
+            throw mapTransportError(error)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw LMStudioLocalChatClientError.apiError(message: "LM Studio returned an invalid HTTP response.")
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            var errorBodyLines: [String] = []
+            for try await line in byteStream.lines {
+                errorBodyLines.append(line)
+            }
+            let errorBody = errorBodyLines.joined(separator: "\n")
+            throw LMStudioLocalChatClientError.apiError(
+                message: "LM Studio API error (\(httpResponse.statusCode)): \(errorBody)"
+            )
+        }
+
+        var accumulatedResponseText = ""
+
+        for try await line in byteStream.lines {
+            guard line.hasPrefix("data:") else { continue }
+
+            let jsonString: String
+            if line.hasPrefix("data: ") {
+                jsonString = String(line.dropFirst(6))
+            } else {
+                jsonString = String(line.dropFirst(5)).trimmingCharacters(in: .whitespaces)
+            }
+
+            guard jsonString != "[DONE]" else { break }
+            guard let jsonData = jsonString.data(using: .utf8) else { continue }
+            guard let eventPayload = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+                continue
+            }
+
+            let textChunk = extractStreamText(from: eventPayload)
+            guard !textChunk.isEmpty else { continue }
+
+            accumulatedResponseText += textChunk
+            let currentAccumulatedText = accumulatedResponseText
+            await onTextChunk(currentAccumulatedText)
+        }
+
+        let duration = Date().timeIntervalSince(startTime)
+        return (
+            text: accumulatedResponseText.trimmingCharacters(in: .whitespacesAndNewlines),
+            duration: duration
+        )
+    }
+
+    private func resolveLoadedModel() async throws -> LMStudioResolvedModel {
+        let requestURL = try makeRequestURL(path: "/api/v1/models")
+
+        var request = URLRequest(url: requestURL)
+        request.httpMethod = "GET"
+        request.timeoutInterval = 30
+
+        let responseData: Data
+        let response: URLResponse
+
+        do {
+            (responseData, response) = try await session.data(for: request)
+        } catch {
+            throw mapTransportError(error)
+        }
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw LMStudioLocalChatClientError.apiError(message: "LM Studio returned an invalid HTTP response.")
+        }
+
+        guard (200...299).contains(httpResponse.statusCode) else {
+            let errorBody = String(data: responseData, encoding: .utf8) ?? "unknown error"
+            throw LMStudioLocalChatClientError.apiError(
+                message: "LM Studio model list error (\(httpResponse.statusCode)): \(errorBody)"
+            )
+        }
+
+        let modelsResponse: LMStudioModelsResponse
+        do {
+            modelsResponse = try JSONDecoder().decode(LMStudioModelsResponse.self, from: responseData)
+        } catch {
+            throw LMStudioLocalChatClientError.invalidModelsResponse
+        }
+
+        let loadedLanguageModels = modelsResponse.models.filter { model in
+            model.type == "llm" && !model.loadedInstances.isEmpty
+        }
+
+        guard !loadedLanguageModels.isEmpty else {
+            throw LMStudioLocalChatClientError.noModelLoaded
+        }
+
+        guard let selectedLoadedModel = loadedLanguageModels.first,
+              let selectedLoadedInstance = selectedLoadedModel.loadedInstances.first else {
+            throw LMStudioLocalChatClientError.noModelLoaded
+        }
+
+        let resolvedModel = LMStudioResolvedModel(
+            identifier: selectedLoadedInstance.id,
+            displayName: selectedLoadedModel.displayName
+        )
+
+        stateLock.withLock {
+            connectedModelDisplayNameStorage = resolvedModel.displayName
+        }
+
+        return resolvedModel
+    }
+
+    private func buildChatRequestBody(
+        modelIdentifier: String,
+        images: [(data: Data, label: String)],
+        systemPrompt: String,
+        conversationHistory: [(userPlaceholder: String, assistantResponse: String)],
+        userPrompt: String
+    ) throws -> Data {
+        var messages: [[String: Any]] = [
+            [
+                "role": "system",
+                "content": systemPrompt
+            ]
+        ]
+
+        for historyEntry in conversationHistory {
+            messages.append([
+                "role": "user",
+                "content": historyEntry.userPlaceholder
+            ])
+            messages.append([
+                "role": "assistant",
+                "content": historyEntry.assistantResponse
+            ])
+        }
+
+        var userContent: [[String: Any]] = [
+            [
+                "type": "text",
+                "text": buildCurrentUserPrompt(images: images, userPrompt: userPrompt)
+            ]
+        ]
+
+        for image in images {
+            let imageMediaType = detectImageMediaType(for: image.data)
+            userContent.append([
+                "type": "image_url",
+                "image_url": [
+                    "url": "data:\(imageMediaType);base64,\(image.data.base64EncodedString())"
+                ]
+            ])
+        }
+
+        messages.append([
+            "role": "user",
+            "content": userContent
+        ])
+
+        let body: [String: Any] = [
+            "model": modelIdentifier,
+            "stream": true,
+            "max_tokens": 1024,
+            "messages": messages
+        ]
+
+        return try JSONSerialization.data(withJSONObject: body)
+    }
+
+    private func buildCurrentUserPrompt(
+        images: [(data: Data, label: String)],
+        userPrompt: String
+    ) -> String {
+        let orderedImageLabels = images.map(\.label).joined(separator: "\n")
+
+        guard !orderedImageLabels.isEmpty else {
+            return userPrompt
+        }
+
+        return """
+        attached image labels, in the same order as the screenshots:
+        \(orderedImageLabels)
+
+        \(userPrompt)
+        """
+    }
+
+    private func makeRequestURL(path: String) throws -> URL {
+        let currentServerBaseURLString = stateLock.withLock {
+            serverBaseURLString
+        }
+
+        guard var components = URLComponents(string: currentServerBaseURLString) else {
+            throw LMStudioLocalChatClientError.invalidServerURL
+        }
+
+        if components.scheme == nil {
+            components.scheme = "http"
+        }
+
+        if components.host == nil,
+           let pathWithoutLeadingSlashes = components.path.split(separator: "/").first,
+           !pathWithoutLeadingSlashes.isEmpty {
+            components.host = String(pathWithoutLeadingSlashes)
+            components.path = ""
+        }
+
+        guard components.host != nil else {
+            throw LMStudioLocalChatClientError.invalidServerURL
+        }
+
+        components.path = path
+        components.query = nil
+        components.fragment = nil
+
+        guard let url = components.url else {
+            throw LMStudioLocalChatClientError.invalidServerURL
+        }
+
+        return url
+    }
+
+    private func detectImageMediaType(for imageData: Data) -> String {
+        if imageData.count >= 4 {
+            let pngSignature: [UInt8] = [0x89, 0x50, 0x4E, 0x47]
+            let firstFourBytes = [UInt8](imageData.prefix(4))
+            if firstFourBytes == pngSignature {
+                return "image/png"
+            }
+        }
+
+        return "image/jpeg"
+    }
+
+    private func extractStreamText(from eventPayload: [String: Any]) -> String {
+        guard let choices = eventPayload["choices"] as? [[String: Any]],
+              let firstChoice = choices.first,
+              let delta = firstChoice["delta"] as? [String: Any] else {
+            return ""
+        }
+
+        if let textChunk = delta["content"] as? String {
+            return textChunk
+        }
+
+        if let contentBlocks = delta["content"] as? [[String: Any]] {
+            return contentBlocks.compactMap { block in
+                block["text"] as? String
+            }.joined()
+        }
+
+        return ""
+    }
+
+    private func mapTransportError(_ error: Error) -> LMStudioLocalChatClientError {
+        let errorDescription = (error as NSError).localizedDescription
+        return LMStudioLocalChatClientError.serverUnavailable(
+            message: "Could not reach LM Studio at \(stateLock.withLock { serverBaseURLString }). \(errorDescription)"
+        )
+    }
+}
+
+private extension NSLock {
+    func withLock<Result>(_ body: () throws -> Result) rethrows -> Result {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}

--- a/leanring-buddy/Local-AI-Mode/LocalMLXVLMClient.swift
+++ b/leanring-buddy/Local-AI-Mode/LocalMLXVLMClient.swift
@@ -1,0 +1,291 @@
+//
+//  LocalMLXVLMClient.swift
+//  leanring-buddy
+//
+//  Created by MD Sahil AK on 09/04/26.
+//
+
+import CoreImage
+import Foundation
+@preconcurrency import Hub
+import MLX
+import MLXLMCommon
+import MLXVLM
+
+protocol CompanionChatClient: AnyObject {
+    func prepareSelectedModel(
+        progressHandler: @MainActor @escaping (Progress?) -> Void
+    ) async throws
+
+    func offloadResources()
+
+    func analyzeImageStreaming(
+        images: [(data: Data, label: String)],
+        systemPrompt: String,
+        conversationHistory: [(userPlaceholder: String, assistantResponse: String)],
+        userPrompt: String,
+        progressHandler: @MainActor @escaping (Progress?) -> Void,
+        onTextChunk: @MainActor @Sendable (String) -> Void
+    ) async throws -> (text: String, duration: TimeInterval)
+}
+
+final class LocalMLXVLMClient: CompanionChatClient {
+    static let fixedModelDisplayName = "Qwen 3 VL 4B"
+
+    private let fixedModelIdentifier = "qwen3-vl-4b"
+    private let fixedModelConfiguration = VLMRegistry.qwen3VL4BInstruct4Bit
+    private let modelCache = NSCache<NSString, ModelContainer>()
+    private let stateLock = NSLock()
+    private var inFlightLoadTask: Task<ModelContainer, Error>?
+    private var hasWarmedFixedModel = false
+    private let hub: HubApi
+
+    init() {
+        let applicationSupportDirectory = FileManager.default.urls(
+            for: .applicationSupportDirectory,
+            in: .userDomainMask
+        ).first ?? URL(fileURLWithPath: NSTemporaryDirectory(), isDirectory: true)
+
+        let modelDownloadDirectory = applicationSupportDirectory
+            .appendingPathComponent("Clicky", isDirectory: true)
+            .appendingPathComponent("Models", isDirectory: true)
+            .appendingPathComponent("v1", isDirectory: true)
+            .appendingPathComponent("huggingface", isDirectory: true)
+
+        try? FileManager.default.createDirectory(
+            at: modelDownloadDirectory,
+            withIntermediateDirectories: true,
+            attributes: nil
+        )
+
+        self.hub = HubApi(downloadBase: modelDownloadDirectory)
+    }
+
+    func prepareSelectedModel(
+        progressHandler: @MainActor @escaping (Progress?) -> Void
+    ) async throws {
+        let modelContainer = try await loadModelContainer(progressHandler: progressHandler)
+        let hasAlreadyWarmedModel = stateLock.withLock { hasWarmedFixedModel }
+
+        guard !hasAlreadyWarmedModel else { return }
+
+        let warmupImage = CIImage(color: CIColor(red: 0, green: 0, blue: 0))
+            .cropped(to: CGRect(x: 0, y: 0, width: 64, height: 64))
+
+        let warmupMessages: [Chat.Message] = [
+            .system("you are clicky, a concise local desktop assistant."),
+            .user("reply with one word.", images: [.ciImage(warmupImage)])
+        ]
+
+        let warmupInput = UserInput(
+            chat: warmupMessages,
+            processing: .init(resize: CGSize(width: 768, height: 768))
+        )
+
+        _ = try await modelContainer.perform { context in
+            let preparedInput = try await context.processor.prepare(input: warmupInput)
+            let generationStream = try MLXLMCommon.generate(
+                input: preparedInput,
+                parameters: GenerateParameters(maxTokens: 1, temperature: 0),
+                context: context
+            )
+
+            for await _ in generationStream {
+                if Task.isCancelled {
+                    break
+                }
+            }
+        }
+
+        stateLock.withLock {
+            hasWarmedFixedModel = true
+        }
+    }
+
+    func offloadResources() {
+        stateLock.withLock {
+            inFlightLoadTask?.cancel()
+            inFlightLoadTask = nil
+            hasWarmedFixedModel = false
+        }
+        modelCache.removeAllObjects()
+        // Force MLX to release cached buffers as aggressively as possible while
+        // Claude mode is active, then restore a working cache limit on next load.
+        MLX.GPU.set(cacheLimit: 0)
+    }
+
+    func analyzeImageStreaming(
+        images: [(data: Data, label: String)],
+        systemPrompt: String,
+        conversationHistory: [(userPlaceholder: String, assistantResponse: String)],
+        userPrompt: String,
+        progressHandler: @MainActor @escaping (Progress?) -> Void,
+        onTextChunk: @MainActor @Sendable (String) -> Void
+    ) async throws -> (text: String, duration: TimeInterval) {
+        let modelContainer = try await loadModelContainer(progressHandler: progressHandler)
+
+        let startTime = Date()
+
+        let chatMessages = try buildChatMessages(
+            images: images,
+            systemPrompt: systemPrompt,
+            conversationHistory: conversationHistory,
+            userPrompt: userPrompt
+        )
+
+        let userInput = UserInput(
+            chat: chatMessages,
+            processing: .init(resize: CGSize(width: 1024, height: 1024))
+        )
+
+        var accumulatedResponseText = ""
+
+        let generationStream = try await modelContainer.perform { context in
+            let preparedInput = try await context.processor.prepare(input: userInput)
+
+            return try MLXLMCommon.generate(
+                input: preparedInput,
+                parameters: GenerateParameters(maxTokens: 1024),
+                context: context
+            )
+        }
+
+        for await generation in generationStream {
+            if Task.isCancelled {
+                break
+            }
+
+            switch generation {
+            case .chunk(let textChunk):
+                accumulatedResponseText += textChunk
+                let currentAccumulatedText = accumulatedResponseText
+                await MainActor.run {
+                    onTextChunk(currentAccumulatedText)
+                }
+            case .info:
+                break
+            case .toolCall:
+                break
+            }
+        }
+
+        let duration = Date().timeIntervalSince(startTime)
+        return (text: accumulatedResponseText.trimmingCharacters(in: .whitespacesAndNewlines), duration: duration)
+    }
+
+    private func buildChatMessages(
+        images: [(data: Data, label: String)],
+        systemPrompt: String,
+        conversationHistory: [(userPlaceholder: String, assistantResponse: String)],
+        userPrompt: String
+    ) throws -> [Chat.Message] {
+        var chatMessages: [Chat.Message] = [
+            .system(systemPrompt)
+        ]
+
+        for historyEntry in conversationHistory {
+            chatMessages.append(.user(historyEntry.userPlaceholder))
+            chatMessages.append(.assistant(historyEntry.assistantResponse))
+        }
+
+        let imageInputs = try images.map { image in
+            guard let ciImage = CIImage(data: image.data) else {
+                throw NSError(
+                    domain: "LocalMLXVLMClient",
+                    code: -1,
+                    userInfo: [NSLocalizedDescriptionKey: "Unable to decode screenshot data for local model input."]
+                )
+            }
+            return UserInput.Image.ciImage(ciImage)
+        }
+
+        let currentUserMessageContent = buildClaudeEquivalentUserMessageContent(
+            images: images,
+            userPrompt: userPrompt
+        )
+
+        chatMessages.append(.user(currentUserMessageContent, images: imageInputs))
+        return chatMessages
+    }
+
+    private func buildClaudeEquivalentUserMessageContent(
+        images: [(data: Data, label: String)],
+        userPrompt: String
+    ) -> String {
+        let orderedImageLabels = images.map(\.label).joined(separator: "\n")
+
+        guard !orderedImageLabels.isEmpty else {
+            return userPrompt
+        }
+
+        return """
+        attached image labels, in the same order as the screenshots:
+        \(orderedImageLabels)
+
+        \(userPrompt)
+        """
+    }
+
+    private func loadModelContainer(
+        progressHandler: @MainActor @escaping (Progress?) -> Void
+    ) async throws -> ModelContainer {
+        if let cachedModelContainer = modelCache.object(forKey: fixedModelIdentifier as NSString) {
+            await MainActor.run {
+                progressHandler(nil)
+            }
+            return cachedModelContainer
+        }
+
+        let loadTask: Task<ModelContainer, Error> = stateLock.withLock {
+            if let existingTask = inFlightLoadTask {
+                return existingTask
+            }
+
+            let newTask = Task { [hub] in
+                MLX.GPU.set(cacheLimit: 20 * 1024 * 1024)
+
+                let modelContainer = try await VLMModelFactory.shared.loadContainer(
+                    hub: hub,
+                    configuration: fixedModelConfiguration
+                ) { progress in
+                    Task { @MainActor in
+                        progressHandler(progress)
+                    }
+                }
+
+                return modelContainer
+            }
+
+            inFlightLoadTask = newTask
+            return newTask
+        }
+
+        do {
+            let modelContainer = try await loadTask.value
+            stateLock.withLock {
+                inFlightLoadTask = nil
+            }
+            modelCache.setObject(modelContainer, forKey: fixedModelIdentifier as NSString)
+            await MainActor.run {
+                progressHandler(nil)
+            }
+            return modelContainer
+        } catch {
+            stateLock.withLock {
+                inFlightLoadTask = nil
+            }
+            await MainActor.run {
+                progressHandler(nil)
+            }
+            throw error
+        }
+    }
+}
+
+private extension NSLock {
+    func withLock<Result>(_ body: () throws -> Result) rethrows -> Result {
+        lock()
+        defer { unlock() }
+        return try body()
+    }
+}

--- a/leanring-buddy/Local-AI-Mode/LocalSpeechSynthesizerClient.swift
+++ b/leanring-buddy/Local-AI-Mode/LocalSpeechSynthesizerClient.swift
@@ -1,0 +1,32 @@
+//
+//  LocalSpeechSynthesizerClient.swift
+//  leanring-buddy
+//
+//  Created by MD Sahil AK on 09/04/26.
+//
+
+import AVFoundation
+import Foundation
+
+@MainActor
+final class LocalSpeechSynthesizerClient {
+    private let speechSynthesizer = AVSpeechSynthesizer()
+
+    func speakText(_ text: String) async throws {
+        try Task.checkCancellation()
+
+        let utterance = AVSpeechUtterance(string: text)
+        utterance.voice = AVSpeechSynthesisVoice(language: "en-US")
+        utterance.rate = AVSpeechUtteranceDefaultSpeechRate
+
+        speechSynthesizer.speak(utterance)
+    }
+
+    var isPlaying: Bool {
+        speechSynthesizer.isSpeaking
+    }
+
+    func stopPlayback() {
+        speechSynthesizer.stopSpeaking(at: .immediate)
+    }
+}


### PR DESCRIPTION
This PR adds a full local inference path to Clicky alongside the existing Claude mode.

Clicky can now run in:
- `Claude` mode using the existing Cloudflare Worker + Claude + ElevenLabs flow
- `Local` mode using either:
  - the built-in MLX backend
  - an LM Studio local server backend

Local mode also uses local macOS speech synthesis for spoken responses, and this repo now defaults transcription to Apple Speech via `VoiceTranscriptionProvider = apple`.

## What changed

- Added built-in MLX local chat support
- Added LM Studio local chat support with a configurable server URL in the panel
- Added local backend selection inside Local mode (`MLX` vs `LM Studio`)
- Added local speech synthesis for local inference responses
- Updated `CompanionManager` to route between Claude and local inference paths
- Updated the panel UI to show:
  - Claude vs Local mode
  - MLX vs LM Studio backend selection
  - LM Studio server URL input
  - Clearer local model loading / download / connection states
- Added Apple Speech logging to make dictation behavior easier to debug
- Updated project packages to include the MLX dependencies
- Updated docs (`README.md`, `AGENTS.md`) to reflect the new local flow