### PR TITLE
Fix cursor overlay invisible on secondary monitors

### DIFF
--- a/leanring-buddy/OverlayWindow.swift
+++ b/leanring-buddy/OverlayWindow.swift
@@ -799,7 +799,12 @@ class OverlayWindowManager {
             )
 
             let hostingView = NSHostingView(rootView: contentView)
-            hostingView.frame = screen.frame
+            // Use window-local coordinates (origin .zero), not global screen coordinates.
+            // The NSPanel is already positioned at screen.frame.origin via OverlayWindow.init.
+            // NSView.frame is relative to the window's content area, which always starts at (0,0).
+            // Using screen.frame here (with non-zero origin on secondary monitors) would offset
+            // the hosting view outside the window bounds, making the overlay invisible.
+            hostingView.frame = CGRect(origin: .zero, size: screen.frame.size)
             window.contentView = hostingView
 
             overlayWindows.append(window)


### PR DESCRIPTION
## Feature
Fix multi-monitor cursor overlay rendering (resolves #24)

## Summary
- The blue cursor companion was invisible on any monitor that is not the primary display
- Root cause: `NSHostingView.frame` uses **window-local** coordinates (always origin 0,0), but was being assigned `screen.frame` which has a non-zero origin for secondary monitors (e.g. `{x:1920, y:0}`)
- For a secondary monitor at x=1920, this placed the hosting view 1920pt to the right *inside* the window — completely off-screen

## Changes
**`leanring-buddy/OverlayWindow.swift`** — one line in `OverlayWindowManager.showOverlay()`:

```swift
// Before (broken for secondary monitors):
hostingView.frame = screen.frame

// After (correct — window-local coordinates):
hostingView.frame = CGRect(origin: .zero, size: screen.frame.size)
```

The `NSPanel` window itself is already positioned correctly at `screen.frame.origin` via `OverlayWindow.init` — only the content view frame needed fixing.

## Why only the primary monitor worked before
Primary monitor has `screen.frame.origin = (0,0)`, so `screen.frame` accidentally produced the correct window-local rect. Every secondary monitor has a non-zero origin and was broken.

## Testing
- GIVEN two monitors connected, WHEN ctrl+option pressed with mouse on secondary display, THEN cursor appears on that display ✓
- GIVEN Claude responds with `[POINT:x,y:label:screen2]`, THEN cursor animates to correct position on secondary display ✓
- GIVEN only primary monitor, THEN behavior unchanged (origin 0,0 produces identical rect) ✓

## Review Notes
All downstream coordinate math (`convertScreenPointToSwiftUICoordinates`, `isCursorOnThisScreen`, `startNavigatingToElement`) was already correct and required no changes. Verified by tracing the full coordinate pipeline across 3 independent passes.

Closes #24