### PR TITLE
Hide cursor overlay while user is typing

### DIFF
--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -91,6 +91,7 @@ final class CompanionManager: ObservableObject {
     private var shortcutTransitionCancellable: AnyCancellable?
     private var voiceStateCancellable: AnyCancellable?
     private var audioPowerCancellable: AnyCancellable?
+    private var typingStateCancellable: AnyCancellable?
     private var accessibilityCheckTimer: Timer?
     private var pendingKeyboardShortcutStartTask: Task<Void, Never>?
     /// Scheduled hide for transient cursor mode — cancelled if the user
@@ -106,6 +107,11 @@ final class CompanionManager: ObservableObject {
     /// Whether the blue cursor overlay is currently visible on screen.
     /// Used by the panel to show accurate status text ("Active" vs "Ready").
     @Published private(set) var isOverlayVisible: Bool = false
+
+    /// True while the user is actively typing (non-PTT keypress detected).
+    /// Forwarded from GlobalPushToTalkShortcutMonitor and used by BlueCursorView
+    /// to hide the cursor during idle typing, mirroring macOS hide-on-type behavior.
+    @Published private(set) var isUserTyping: Bool = false
 
     /// The Claude model used for voice responses. Persisted to UserDefaults.
     @Published var selectedModel: String = UserDefaults.standard.string(forKey: "selectedClaudeModel") ?? "claude-sonnet-4-6"
@@ -179,6 +185,7 @@ final class CompanionManager: ObservableObject {
         bindVoiceStateObservation()
         bindAudioPowerLevel()
         bindShortcutTransitions()
+        bindTypingState()
         // Eagerly touch the Claude API so its TLS warmup handshake completes
         // well before the onboarding demo fires at ~40s into the video.
         _ = claudeAPI
@@ -298,8 +305,16 @@ final class CompanionManager: ObservableObject {
         shortcutTransitionCancellable?.cancel()
         voiceStateCancellable?.cancel()
         audioPowerCancellable?.cancel()
+        typingStateCancellable?.cancel()
         accessibilityCheckTimer?.invalidate()
         accessibilityCheckTimer = nil
+    }
+
+    /// Called by BlueCursorView's cursor-tracking timer when the mouse moves
+    /// after a period of typing, restoring the cursor — mirrors the "until mouse
+    /// moves" part of NSCursor.setHiddenUntilMouseMoves(true).
+    func resetUserTyping() {
+        isUserTyping = false
     }
 
     func refreshAllPermissions() {
@@ -467,6 +482,16 @@ final class CompanionManager: ObservableObject {
             .receive(on: DispatchQueue.main)
             .sink { [weak self] transition in
                 self?.handleShortcutTransition(transition)
+            }
+    }
+
+    /// Forwards the monitor's isUserTyping flag onto CompanionManager so
+    /// BlueCursorView can observe a single source-of-truth for cursor hiding.
+    private func bindTypingState() {
+        typingStateCancellable = globalPushToTalkShortcutMonitor.$isUserTyping
+            .receive(on: DispatchQueue.main)
+            .sink { [weak self] typing in
+                self?.isUserTyping = typing
             }
     }
 

--- a/leanring-buddy/GlobalPushToTalkShortcutMonitor.swift
+++ b/leanring-buddy/GlobalPushToTalkShortcutMonitor.swift
@@ -23,6 +23,12 @@ final class GlobalPushToTalkShortcutMonitor: ObservableObject {
     /// waiting for the async dictation state pipeline to catch up.
     @Published private(set) var isShortcutCurrentlyPressed = false
 
+    /// True while the user is typing regular keys (non-PTT).
+    /// Used by BlueCursorView to hide the cursor overlay during typing,
+    /// mirroring macOS NSCursor.setHiddenUntilMouseMoves(true) behavior.
+    /// Reset to false when the mouse moves (detected in BlueCursorView's 16ms timer).
+    @Published private(set) var isUserTyping = false
+
     deinit {
         stop()
     }
@@ -85,6 +91,7 @@ final class GlobalPushToTalkShortcutMonitor: ObservableObject {
 
     func stop() {
         isShortcutCurrentlyPressed = false
+        isUserTyping = false
 
         if let globalEventTapRunLoopSource {
             CFRunLoopRemoveSource(CFRunLoopGetMain(), globalEventTapRunLoopSource, .commonModes)
@@ -125,6 +132,15 @@ final class GlobalPushToTalkShortcutMonitor: ObservableObject {
         case .released:
             isShortcutCurrentlyPressed = false
             shortcutTransitionPublisher.send(.released)
+        }
+
+        // When a regular (non-PTT) key is pressed, signal that the user is typing
+        // so the cursor overlay hides — mirroring NSCursor.setHiddenUntilMouseMoves.
+        // The PTT shortcut (ctrl+option) uses .flagsChanged not .keyDown, so it
+        // never reaches this branch. We also guard against PTT-combo keydowns via
+        // shortcutTransition == .none to be safe.
+        if eventType == .keyDown && shortcutTransition == .none {
+            isUserTyping = true
         }
 
         return Unmanaged.passUnretained(event)

--- a/leanring-buddy/OverlayWindow.swift
+++ b/leanring-buddy/OverlayWindow.swift
@@ -122,6 +122,9 @@ struct BlueCursorView: View {
         let localY = screenFrame.height - (mouseLocation.y - screenFrame.origin.y)
         _cursorPosition = State(initialValue: CGPoint(x: localX + 35, y: localY + 25))
         _isCursorOnThisScreen = State(initialValue: screenFrame.contains(mouseLocation))
+        // Seed typing-reset tracker from current mouse location so the first
+        // mouse move after a keypress is detected correctly from the start.
+        _lastMouseLocationForTypingDetection = State(initialValue: mouseLocation)
     }
     @State private var timer: Timer?
     @State private var welcomeText: String = ""
@@ -129,6 +132,9 @@ struct BlueCursorView: View {
     @State private var bubbleSize: CGSize = .zero
     @State private var bubbleOpacity: Double = 1.0
     @State private var cursorOpacity: Double = 0.0
+    /// Tracks the previous mouse location so we can detect movement and reset
+    /// the typing-hide state — matching NSCursor.setHiddenUntilMouseMoves(true).
+    @State private var lastMouseLocationForTypingDetection: CGPoint = .zero
 
     // MARK: - Buddy Navigation State
 
@@ -308,7 +314,7 @@ struct BlueCursorView: View {
                 .rotationEffect(.degrees(triangleRotationDegrees))
                 .shadow(color: DS.Colors.overlayCursorBlue, radius: 8 + (buddyFlightScale - 1.0) * 20, x: 0, y: 0)
                 .scaleEffect(buddyFlightScale)
-                .opacity(buddyIsVisibleOnThisScreen && (companionManager.voiceState == .idle || companionManager.voiceState == .responding) ? cursorOpacity : 0)
+                .opacity(buddyIsVisibleOnThisScreen && !shouldHideForTyping && (companionManager.voiceState == .idle || companionManager.voiceState == .responding) ? cursorOpacity : 0)
                 .position(cursorPosition)
                 .animation(
                     buddyNavigationMode == .followingCursor
@@ -386,6 +392,14 @@ struct BlueCursorView: View {
         }
     }
 
+    /// True when the cursor should be hidden because the user is typing in idle state.
+    /// Mirrors macOS NSCursor.setHiddenUntilMouseMoves(true) — hide on keypress,
+    /// reappear on mouse move. Never hides during voice interaction (listening/
+    /// processing/responding) so the waveform and spinner stay visible.
+    private var shouldHideForTyping: Bool {
+        companionManager.isUserTyping && companionManager.voiceState == .idle
+    }
+
     /// Whether the buddy triangle should be visible on this screen.
     /// True when cursor is on this screen during normal following, or
     /// when navigating/pointing at a target on this screen. When another
@@ -412,6 +426,20 @@ struct BlueCursorView: View {
         timer = Timer.scheduledTimer(withTimeInterval: 0.016, repeats: true) { _ in
             let mouseLocation = NSEvent.mouseLocation
             self.isCursorOnThisScreen = self.screenFrame.contains(mouseLocation)
+
+            // When typing-hide is active, any mouse movement resets it —
+            // mirroring the "until mouse moves" part of NSCursor.setHiddenUntilMouseMoves.
+            // Runs before the navigation early-returns so it fires regardless of buddy mode.
+            if self.companionManager.isUserTyping {
+                let movementDistance = hypot(
+                    mouseLocation.x - self.lastMouseLocationForTypingDetection.x,
+                    mouseLocation.y - self.lastMouseLocationForTypingDetection.y
+                )
+                if movementDistance > 1.0 {
+                    self.companionManager.resetUserTyping()
+                }
+            }
+            self.lastMouseLocationForTypingDetection = mouseLocation
 
             // During forward flight or pointing, the buddy is NOT interrupted by
             // mouse movement — it completes its full animation and return flight.


### PR DESCRIPTION
## Feature
Hide Clicky cursor when user types, matching macOS native behavior (resolves #37)

## Problem
When macOS hides the system cursor on keypress (`NSCursor.setHiddenUntilMouseMoves(true)`), the Clicky blue cursor companion kept rendering at full opacity — floating mid-screen while the system cursor was invisible. Every user who types sees this visual mismatch.

## Root Cause
No typing-detection existed anywhere in the codebase. The `CGEvent` tap in `GlobalPushToTalkShortcutMonitor` already received every `.keyDown` event system-wide (it was already in the event mask), but silently dropped all non-PTT keystrokes.

## Solution
Extend the existing event tap — no new taps, no new permissions needed.

**`GlobalPushToTalkShortcutMonitor.swift`**
- New `@Published var isUserTyping: Bool` 
- In `handleGlobalEventTap`: set `isUserTyping = true` when `eventType == .keyDown && shortcutTransition == .none` (PTT combo uses `.flagsChanged`, never hits this path)

**`CompanionManager.swift`**
- Forwards `isUserTyping` via Combine subscription
- Exposes `resetUserTyping()` for BlueCursorView to call on mouse move

**`OverlayWindow.swift`**
- New `shouldHideForTyping` computed property: `isUserTyping && voiceState == .idle`
- Triangle opacity gate: `&& !shouldHideForTyping` added
- 16ms cursor-tracking timer: detects mouse movement >1pt and calls `resetUserTyping()` — mirrors the "until mouse moves" part of `setHiddenUntilMouseMoves`

## Behavior
| Scenario | Before | After |
|---|---|---|
| User types while cursor is visible (idle) | Cursor stays visible | Cursor hides |
| User moves mouse after typing | Cursor stays hidden | Cursor reappears |
| User presses PTT (ctrl+option) | Voice activates | Voice activates, cursor not hidden |
| Voice active (.listening/.processing/.responding) | Waveform/spinner show | Waveform/spinner stay visible |

## Testing
- GIVEN Clicky cursor visible + voiceState idle, WHEN any key pressed, THEN cursor hides ✓
- GIVEN cursor hidden by typing, WHEN mouse moves, THEN cursor reappears ✓  
- GIVEN user presses ctrl+option (PTT), THEN voice activates normally, no hide ✓
- GIVEN voice active, WHEN user types, THEN waveform/spinner remain visible ✓

Closes #37
