### PR TITLE
Remove sensitive data from debug logs

### DIFF
--- a/leanring-buddy/AssemblyAIStreamingTranscriptionProvider.swift
+++ b/leanring-buddy/AssemblyAIStreamingTranscriptionProvider.swift
@@ -41,7 +41,9 @@ final class AssemblyAIStreamingTranscriptionProvider: BuddyTranscriptionProvider
     ) async throws -> any BuddyStreamingTranscriptionSession {
         // Fetch a fresh temporary token from the proxy before each session
         let temporaryToken = try await fetchTemporaryToken()
-        print("🎙️ AssemblyAI: fetched temporary token (\(temporaryToken.prefix(20))...)")
+        // Log success only — never log any part of the token value.
+        // Even a 20-char prefix narrows brute-force space and confirms a valid token was issued.
+        print("🎙️ AssemblyAI: fetched temporary token (OK)")
 
         let session = AssemblyAIStreamingTranscriptionSession(
             apiKey: nil,

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -519,7 +519,8 @@ final class CompanionManager: ObservableObject {
                     },
                     submitDraftText: { [weak self] finalTranscript in
                         self?.lastTranscript = finalTranscript
-                        print("🗣️ Companion received transcript: \(finalTranscript)")
+                        // Do not log the transcript verbatim — it contains user speech (PII).
+                        print("🗣️ Companion received transcript (\(finalTranscript.count) chars)")
                         ClickyAnalytics.trackUserMessageSent(transcript: finalTranscript)
                         self?.sendTranscriptToClaudeWithScreenshot(transcript: finalTranscript)
                     }
@@ -676,9 +677,10 @@ final class CompanionManager: ObservableObject {
                     detectedElementScreenLocation = globalLocation
                     detectedElementDisplayFrame = displayFrame
                     ClickyAnalytics.trackElementPointed(elementLabel: parseResult.elementLabel)
-                    print("🎯 Element pointing: (\(Int(pointCoordinate.x)), \(Int(pointCoordinate.y))) → \"\(parseResult.elementLabel ?? "element")\"")
+                    // Do not log coordinates or element labels — they reveal what is on the user's screen.
+                    print("🎯 Element pointing: coordinate resolved")
                 } else {
-                    print("🎯 Element pointing: \(parseResult.elementLabel ?? "no element")")
+                    print("🎯 Element pointing: no coordinate, skipping navigation")
                 }
 
                 // Save this exchange to conversation history (with the point tag
@@ -1017,7 +1019,8 @@ final class CompanionManager: ObservableObject {
                 detectedElementBubbleText = parseResult.spokenText
                 detectedElementScreenLocation = globalLocation
                 detectedElementDisplayFrame = displayFrame
-                print("🎯 Onboarding demo: pointing at \"\(parseResult.elementLabel ?? "element")\" — \"\(parseResult.spokenText)\"")
+                // Do not log element labels or spoken text — they reveal screen content.
+                print("🎯 Onboarding demo: pointing at element")
             } catch {
                 print("⚠️ Onboarding demo error: \(error)")
             }

--- a/leanring-buddy/ElementLocationDetector.swift
+++ b/leanring-buddy/ElementLocationDetector.swift
@@ -110,10 +110,7 @@ class ElementLocationDetector {
         // Convert from top-left origin (Computer Use / CoreGraphics) to bottom-left origin (AppKit)
         let scaledYBottomLeftOrigin = CGFloat(displayHeightInPoints) - scaledYTopLeftOrigin
 
-        print("🎯 ElementLocationDetector: mapped (\(Int(clampedX)), \(Int(clampedY))) in " +
-              "\(computerUseResolution.width)x\(computerUseResolution.height) → " +
-              "(\(Int(scaledX)), \(Int(scaledYBottomLeftOrigin))) in " +
-              "\(displayWidthInPoints)x\(displayHeightInPoints) display-local AppKit coords")
+        // Do not log coordinates — they reveal the pixel location of elements on the user's screen.
 
         return CGPoint(x: scaledX, y: scaledYBottomLeftOrigin)
     }
@@ -254,7 +251,7 @@ class ElementLocationDetector {
 
             let x = CGFloat(coordinate[0].doubleValue)
             let y = CGFloat(coordinate[1].doubleValue)
-            print("🎯 ElementLocationDetector: raw coordinate (\(Int(x)), \(Int(y)))")
+            // Do not log coordinate values — they reveal element positions on the user's screen.
             return CGPoint(x: x, y: y)
         }
 


### PR DESCRIPTION
## Feature
Remove PII and security-sensitive values from debug print statements (resolves #44)

## Problem
Seven `print()` calls were writing sensitive runtime data to the system log, visible in Console.app to anyone with local machine access:

| Location | What was leaked |
|---|---|
| `AssemblyAIStreamingTranscriptionProvider.swift:44` | First 20 chars of a live AssemblyAI bearer token |
| `CompanionManager.swift:522` | Full verbatim user speech transcript (every word spoken) |
| `CompanionManager.swift:679` | Exact screen coordinates + human-readable UI element label |
| `CompanionManager.swift:681` | UI element label (no-coordinate path) |
| `CompanionManager.swift:1020` | Element label + Claude's exact spoken response (onboarding) |
| `ElementLocationDetector.swift:113–116` | Raw and scaled pixel coordinates of pointed-at element |
| `ElementLocationDetector.swift:257` | Raw Computer Use coordinate of target element |

## Changes

**`AssemblyAIStreamingTranscriptionProvider.swift`**
- `"fetched temporary token (abc123prefix...)"` → `"fetched temporary token (OK)"`

**`CompanionManager.swift`**  
- `"received transcript: <user's words>"` → `"received transcript (N chars)"`
- Element coordinate + label logs → content-free status messages
- Onboarding demo label + spoken text log → `"pointing at element"`

**`ElementLocationDetector.swift`**
- Coordinate mapping log (raw + scaled pixel values) → single comment explaining the omission
- Raw coordinate log → comment explaining the omission

## What was NOT changed
All low-severity logs (lifecycle events, error descriptions, payload sizes, provider names) are unchanged — they contain no user data and are useful for debugging.

## Testing
- Build and run: Console.app should show no transcript text, no token values, no element labels or coordinates in Clicky output
- Push-to-talk still works normally (logging is additive-only change)

Closes #44