### PR TITLE
Add Gemini provider and Windows port (M1 foundation)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 worker/node_modules/
 worker/.dev.vars
+worker/.secrets.local
 .DS_Store
 *.xcuserstate
 build/

--- a/.gitignore
+++ b/.gitignore
@@ -6,3 +6,8 @@ build/
 releases/
 .claude/
 coding-plans/
+
+# Windows / .NET build output
+windows/**/bin/
+windows/**/obj/
+*.user

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,16 +5,24 @@
 
 ## Overview
 
-macOS menu bar companion app. Lives entirely in the macOS status bar (no dock icon, no main window). Clicking the menu bar icon opens a custom floating panel with companion voice controls. Uses push-to-talk (ctrl+option) to capture voice input, transcribes it via AssemblyAI streaming, and sends the transcript + a screenshot of the user's screen to Claude. Claude responds with text (streamed via SSE) and voice (ElevenLabs TTS). A blue cursor overlay can fly to and point at UI elements Claude references on any connected monitor.
+Cross-platform companion app. Lives entirely in the OS's system tray / menu bar (no dock icon, no main window). Clicking the tray icon opens a custom floating panel with companion voice controls. Uses push-to-talk (ctrl+option on macOS, ctrl+alt on Windows) to capture voice input, transcribes it via AssemblyAI streaming, and sends the transcript + a screenshot of the user's screen to the active AI provider (Claude or Gemini). The AI responds with text (streamed via SSE) and voice (ElevenLabs TTS). A blue cursor overlay can fly to and point at UI elements the AI references on any connected monitor.
 
-All API keys live on a Cloudflare Worker proxy — nothing sensitive ships in the app.
+All API keys live on a Cloudflare Worker proxy — nothing sensitive ships in either app.
+
+## Repository layout
+
+| Folder | Purpose |
+|--------|---------|
+| `leanring-buddy/` + `leanring-buddy.xcodeproj` | macOS menu bar app. Swift + SwiftUI + AppKit. Ships first, most features live here. |
+| `windows/` | Windows port. C# + WPF on .NET 8. Currently at Milestone 1 (foundation). See `windows/README.md` for milestone progress. |
+| `worker/` | Cloudflare Worker proxy. Shared by both apps unchanged — same routes, same secrets. |
 
 ## Architecture
 
 - **App Type**: Menu bar-only (`LSUIElement=true`), no dock icon or main window
 - **Framework**: SwiftUI (macOS native) with AppKit bridging for menu bar panel and cursor overlay
 - **Pattern**: MVVM with `@StateObject` / `@Published` state management
-- **AI Chat**: Claude (Sonnet 4.6 default, Opus 4.6 optional) via Cloudflare Worker proxy with SSE streaming
+- **AI Chat**: User-selectable provider — Claude (Sonnet 4.6 default, Opus 4.6 optional) or Gemini (2.5 Flash, 2.5 Pro). Both route through the Cloudflare Worker proxy with SSE streaming.
 - **Speech-to-Text**: AssemblyAI real-time streaming (`u3-rt-pro` model) via websocket, with OpenAI and Apple Speech as fallbacks
 - **Text-to-Speech**: ElevenLabs (`eleven_flash_v2_5` model) via Cloudflare Worker proxy
 - **Screen Capture**: ScreenCaptureKit (macOS 14.2+), multi-monitor support
@@ -30,10 +38,11 @@ The app never calls external APIs directly. All requests go through a Cloudflare
 | Route | Upstream | Purpose |
 |-------|----------|---------|
 | `POST /chat` | `api.anthropic.com/v1/messages` | Claude vision + streaming chat |
+| `POST /chat-gemini` | `generativelanguage.googleapis.com/v1beta/models/{model}:streamGenerateContent` | Gemini vision + streaming chat. The `model` field in the request body is used to build the upstream URL path. |
 | `POST /tts` | `api.elevenlabs.io/v1/text-to-speech/{voiceId}` | ElevenLabs TTS audio |
 | `POST /transcribe-token` | `streaming.assemblyai.com/v3/token` | Fetches a short-lived (480s) AssemblyAI websocket token |
 
-Worker secrets: `ANTHROPIC_API_KEY`, `ASSEMBLYAI_API_KEY`, `ELEVENLABS_API_KEY`
+Worker secrets: `ANTHROPIC_API_KEY`, `GEMINI_API_KEY`, `ASSEMBLYAI_API_KEY`, `ELEVENLABS_API_KEY`
 Worker vars: `ELEVENLABS_VOICE_ID`
 
 ### Key Architecture Decisions
@@ -67,6 +76,7 @@ Worker vars: `ELEVENLABS_VOICE_ID`
 | `BuddyAudioConversionSupport.swift` | ~108 | Audio conversion helpers. Converts live mic buffers to PCM16 mono audio and builds WAV payloads for upload-based providers. |
 | `GlobalPushToTalkShortcutMonitor.swift` | ~132 | System-wide push-to-talk monitor. Owns the listen-only `CGEvent` tap and publishes press/release transitions. |
 | `ClaudeAPI.swift` | ~291 | Claude vision API client with streaming (SSE) and non-streaming modes. TLS warmup optimization, image MIME detection, conversation history support. |
+| `GeminiAPI.swift` | ~240 | Google Gemini vision API client. Mirrors `ClaudeAPI`'s public streaming signature so `CompanionManager` can swap providers transparently. Translates the Gemini-specific request shape (`contents`/`parts`/`inline_data`, `systemInstruction`, `role: "model"`) and parses Gemini's SSE events. Routes through the Worker `/chat-gemini` route — the model ID travels in the body and the Worker plugs it into the upstream URL path. |
 | `OpenAIAPI.swift` | ~142 | OpenAI GPT vision API client. |
 | `ElevenLabsTTSClient.swift` | ~81 | ElevenLabs TTS client. Sends text to the Worker proxy, plays back audio via `AVAudioPlayer`. Exposes `isPlaying` for transient cursor scheduling. |
 | `ElementLocationDetector.swift` | ~335 | Detects UI element locations in screenshots for cursor pointing. |
@@ -98,6 +108,7 @@ npm install
 
 # Add secrets
 npx wrangler secret put ANTHROPIC_API_KEY
+npx wrangler secret put GEMINI_API_KEY
 npx wrangler secret put ASSEMBLYAI_API_KEY
 npx wrangler secret put ELEVENLABS_API_KEY
 

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -73,8 +73,26 @@ final class CompanionManager: ObservableObject {
     private static let workerBaseURL = "https://your-worker-name.your-subdomain.workers.dev"
 
     private lazy var claudeAPI: ClaudeAPI = {
-        return ClaudeAPI(proxyURL: "\(Self.workerBaseURL)/chat", model: selectedModel)
+        // Default to Sonnet when the current selection is a Gemini model so
+        // the Claude client ships with a valid Anthropic model ID even when
+        // Gemini is the active provider.
+        let initialClaudeModel = Self.isGeminiModelID(selectedModel) ? "claude-sonnet-4-6" : selectedModel
+        return ClaudeAPI(proxyURL: "\(Self.workerBaseURL)/chat", model: initialClaudeModel)
     }()
+
+    private lazy var geminiAPI: GeminiAPI = {
+        // Default to Flash when the current selection is a Claude model so
+        // the Gemini client ships with a valid Gemini model ID even when
+        // Claude is the active provider.
+        let initialGeminiModel = Self.isGeminiModelID(selectedModel) ? selectedModel : "gemini-2.5-flash"
+        return GeminiAPI(proxyURL: "\(Self.workerBaseURL)/chat-gemini", model: initialGeminiModel)
+    }()
+
+    /// Returns true when the given model ID belongs to the Gemini provider.
+    /// Used throughout the manager to route requests to the correct client.
+    static func isGeminiModelID(_ modelID: String) -> Bool {
+        return modelID.hasPrefix("gemini")
+    }
 
     private lazy var elevenLabsTTSClient: ElevenLabsTTSClient = {
         return ElevenLabsTTSClient(proxyURL: "\(Self.workerBaseURL)/tts")
@@ -107,13 +125,23 @@ final class CompanionManager: ObservableObject {
     /// Used by the panel to show accurate status text ("Active" vs "Ready").
     @Published private(set) var isOverlayVisible: Bool = false
 
-    /// The Claude model used for voice responses. Persisted to UserDefaults.
+    /// The model used for voice responses. May be a Claude ID (e.g. "claude-sonnet-4-6")
+    /// or a Gemini ID (e.g. "gemini-2.5-flash"). Persisted to UserDefaults.
+    /// The UserDefaults key is still "selectedClaudeModel" for backwards compatibility
+    /// with installs from before Gemini support existed.
     @Published var selectedModel: String = UserDefaults.standard.string(forKey: "selectedClaudeModel") ?? "claude-sonnet-4-6"
 
     func setSelectedModel(_ model: String) {
         selectedModel = model
         UserDefaults.standard.set(model, forKey: "selectedClaudeModel")
-        claudeAPI.model = model
+        // Route the new model ID to whichever provider owns it. We leave the
+        // other provider's model untouched — the next time the user flips back,
+        // that provider still remembers its previously-selected model.
+        if Self.isGeminiModelID(model) {
+            geminiAPI.model = model
+        } else {
+            claudeAPI.model = model
+        }
     }
 
     /// User preference for whether the Clicky cursor should be shown.
@@ -179,9 +207,13 @@ final class CompanionManager: ObservableObject {
         bindVoiceStateObservation()
         bindAudioPowerLevel()
         bindShortcutTransitions()
-        // Eagerly touch the Claude API so its TLS warmup handshake completes
-        // well before the onboarding demo fires at ~40s into the video.
-        _ = claudeAPI
+        // Eagerly touch the active AI provider so its TLS warmup handshake
+        // completes well before the onboarding demo fires at ~40s into the video.
+        if Self.isGeminiModelID(selectedModel) {
+            _ = geminiAPI
+        } else {
+            _ = claudeAPI
+        }
 
         // If the user already completed onboarding AND all permissions are
         // still granted, show the cursor overlay immediately. If permissions
@@ -578,11 +610,40 @@ final class CompanionManager: ObservableObject {
 
     // MARK: - AI Response Pipeline
 
-    /// Captures a screenshot, sends it along with the transcript to Claude,
-    /// and plays the response aloud via ElevenLabs TTS. The cursor stays in
-    /// the spinner/processing state until TTS audio begins playing.
-    /// Claude's response may include a [POINT:x,y:label] tag which triggers
-    /// the buddy to fly to that element on screen.
+    /// Dispatches a streaming vision request to whichever provider owns the
+    /// currently selected model. Both Claude and Gemini expose an identical
+    /// streaming signature, so call sites don't need to care which one runs.
+    private func runStreamingVisionRequest(
+        images: [(data: Data, label: String)],
+        systemPrompt: String,
+        conversationHistory: [(userPlaceholder: String, assistantResponse: String)],
+        userPrompt: String,
+        onTextChunk: @MainActor @Sendable (String) -> Void
+    ) async throws -> (text: String, duration: TimeInterval) {
+        if Self.isGeminiModelID(selectedModel) {
+            return try await geminiAPI.analyzeImageStreaming(
+                images: images,
+                systemPrompt: systemPrompt,
+                conversationHistory: conversationHistory,
+                userPrompt: userPrompt,
+                onTextChunk: onTextChunk
+            )
+        } else {
+            return try await claudeAPI.analyzeImageStreaming(
+                images: images,
+                systemPrompt: systemPrompt,
+                conversationHistory: conversationHistory,
+                userPrompt: userPrompt,
+                onTextChunk: onTextChunk
+            )
+        }
+    }
+
+    /// Captures a screenshot, sends it along with the transcript to the
+    /// selected AI provider (Claude or Gemini), and plays the response aloud
+    /// via ElevenLabs TTS. The cursor stays in the spinner/processing state
+    /// until TTS audio begins playing. The response may include a
+    /// [POINT:x,y:label] tag which triggers the buddy to fly to that element.
     private func sendTranscriptToClaudeWithScreenshot(transcript: String) {
         currentResponseTask?.cancel()
         elevenLabsTTSClient.stopPlayback()
@@ -610,7 +671,7 @@ final class CompanionManager: ObservableObject {
                     (userPlaceholder: entry.userTranscript, assistantResponse: entry.assistantResponse)
                 }
 
-                let (fullResponseText, _) = try await claudeAPI.analyzeImageStreaming(
+                let (fullResponseText, _) = try await runStreamingVisionRequest(
                     images: labeledImages,
                     systemPrompt: Self.companionVoiceResponseSystemPrompt,
                     conversationHistory: historyForAPI,
@@ -982,9 +1043,10 @@ final class CompanionManager: ObservableObject {
                 let dimensionInfo = " (image dimensions: \(cursorScreenCapture.screenshotWidthInPixels)x\(cursorScreenCapture.screenshotHeightInPixels) pixels)"
                 let labeledImages = [(data: cursorScreenCapture.imageData, label: cursorScreenCapture.label + dimensionInfo)]
 
-                let (fullResponseText, _) = try await claudeAPI.analyzeImageStreaming(
+                let (fullResponseText, _) = try await runStreamingVisionRequest(
                     images: labeledImages,
                     systemPrompt: Self.onboardingDemoSystemPrompt,
+                    conversationHistory: [],
                     userPrompt: "look around my screen and find something interesting to point at",
                     onTextChunk: { _ in }
                 )

--- a/leanring-buddy/CompanionPanelView.swift
+++ b/leanring-buddy/CompanionPanelView.swift
@@ -599,16 +599,42 @@ struct CompanionPanelView: View {
     // MARK: - Model Picker
 
     private var modelPickerRow: some View {
+        // Two provider rows stacked vertically — Claude and Gemini. Four buttons
+        // in a single row would be too cramped in the menu bar panel width.
+        VStack(alignment: .leading, spacing: 8) {
+            modelProviderRow(
+                providerLabel: "Claude",
+                options: [
+                    (displayLabel: "Sonnet", modelID: "claude-sonnet-4-6"),
+                    (displayLabel: "Opus", modelID: "claude-opus-4-6")
+                ]
+            )
+            modelProviderRow(
+                providerLabel: "Gemini",
+                options: [
+                    (displayLabel: "Flash", modelID: "gemini-2.5-flash"),
+                    (displayLabel: "Pro", modelID: "gemini-2.5-pro")
+                ]
+            )
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func modelProviderRow(
+        providerLabel: String,
+        options: [(displayLabel: String, modelID: String)]
+    ) -> some View {
         HStack {
-            Text("Model")
+            Text(providerLabel)
                 .font(.system(size: 13, weight: .medium))
                 .foregroundColor(DS.Colors.textSecondary)
 
             Spacer()
 
             HStack(spacing: 0) {
-                modelOptionButton(label: "Sonnet", modelID: "claude-sonnet-4-6")
-                modelOptionButton(label: "Opus", modelID: "claude-opus-4-6")
+                ForEach(options, id: \.modelID) { option in
+                    modelOptionButton(label: option.displayLabel, modelID: option.modelID)
+                }
             }
             .background(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
@@ -619,7 +645,6 @@ struct CompanionPanelView: View {
                     .stroke(DS.Colors.borderSubtle, lineWidth: 0.5)
             )
         }
-        .padding(.vertical, 4)
     }
 
     private func modelOptionButton(label: String, modelID: String) -> some View {

--- a/leanring-buddy/GeminiAPI.swift
+++ b/leanring-buddy/GeminiAPI.swift
@@ -1,0 +1,273 @@
+//
+//  GeminiAPI.swift
+//  Google Gemini API Implementation with streaming support
+//
+//  Mirrors ClaudeAPI's public interface so CompanionManager can route to
+//  either provider without the caller caring which one is active. The
+//  request/response translation layer is Gemini-specific (different field
+//  names, different SSE event shape, different role vocabulary).
+//
+
+import Foundation
+
+/// Gemini API helper with streaming for progressive text display.
+/// Routes through the Cloudflare Worker proxy so the Gemini API key never
+/// ships in the app.
+class GeminiAPI {
+    private static let tlsWarmupLock = NSLock()
+    private static var hasStartedTLSWarmup = false
+
+    private let apiURL: URL
+    var model: String
+    private let session: URLSession
+
+    init(proxyURL: String, model: String = "gemini-2.5-flash") {
+        self.apiURL = URL(string: proxyURL)!
+        self.model = model
+
+        // Use .default instead of .ephemeral so TLS session tickets are cached.
+        // Ephemeral sessions do a full TLS handshake on every request, which causes
+        // transient -1200 (errSSLPeerHandshakeFail) errors with large image payloads.
+        // Disable URL/cookie caching to avoid storing responses or credentials on disk.
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 120
+        config.timeoutIntervalForResource = 300
+        config.waitsForConnectivity = true
+        config.urlCache = nil
+        config.httpCookieStorage = nil
+        self.session = URLSession(configuration: config)
+
+        // Fire a lightweight HEAD request in the background to pre-establish the TLS
+        // connection. This caches the TLS session ticket so the first real API call
+        // (which carries a large image payload) doesn't need a cold TLS handshake.
+        warmUpTLSConnectionIfNeeded()
+    }
+
+    private func makeAPIRequest() -> URLRequest {
+        var request = URLRequest(url: apiURL)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 120
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        return request
+    }
+
+    /// Detects the MIME type of image data by inspecting the first bytes.
+    /// Screen captures from ScreenCaptureKit are JPEG, but pasted images from the
+    /// clipboard are PNG. Gemini rejects requests where the declared mime_type
+    /// doesn't match the actual image format.
+    private func detectImageMediaType(for imageData: Data) -> String {
+        // PNG files start with the 8-byte signature: 89 50 4E 47 0D 0A 1A 0A
+        if imageData.count >= 4 {
+            let pngSignature: [UInt8] = [0x89, 0x50, 0x4E, 0x47]
+            let firstFourBytes = [UInt8](imageData.prefix(4))
+            if firstFourBytes == pngSignature {
+                return "image/png"
+            }
+        }
+        // Default to JPEG — screen captures use JPEG compression
+        return "image/jpeg"
+    }
+
+    /// Sends a no-op HEAD request to the Worker to establish and cache a TLS session.
+    /// Failures are silently ignored — this is purely an optimization.
+    private func warmUpTLSConnectionIfNeeded() {
+        Self.tlsWarmupLock.lock()
+        let shouldStartTLSWarmup = !Self.hasStartedTLSWarmup
+        if shouldStartTLSWarmup {
+            Self.hasStartedTLSWarmup = true
+        }
+        Self.tlsWarmupLock.unlock()
+
+        guard shouldStartTLSWarmup else { return }
+
+        guard var warmupURLComponents = URLComponents(url: apiURL, resolvingAgainstBaseURL: false) else {
+            return
+        }
+
+        warmupURLComponents.path = "/"
+        warmupURLComponents.query = nil
+        warmupURLComponents.fragment = nil
+
+        guard let warmupURL = warmupURLComponents.url else {
+            return
+        }
+
+        var warmupRequest = URLRequest(url: warmupURL)
+        warmupRequest.httpMethod = "HEAD"
+        warmupRequest.timeoutInterval = 10
+        session.dataTask(with: warmupRequest) { _, _, _ in
+            // Response doesn't matter — the TLS handshake is the goal
+        }.resume()
+    }
+
+    /// Builds the Gemini-shaped request body for a vision + streaming call.
+    /// Gemini uses `contents` with `parts` (text + inline_data), a separate
+    /// `systemInstruction` field, and "model" as the assistant role.
+    private func buildGeminiRequestBody(
+        images: [(data: Data, label: String)],
+        systemPrompt: String,
+        conversationHistory: [(userPlaceholder: String, assistantResponse: String)],
+        userPrompt: String,
+        maxOutputTokens: Int
+    ) -> [String: Any] {
+        var contents: [[String: Any]] = []
+
+        for (userPlaceholder, assistantResponse) in conversationHistory {
+            contents.append([
+                "role": "user",
+                "parts": [["text": userPlaceholder]]
+            ])
+            contents.append([
+                "role": "model",
+                "parts": [["text": assistantResponse]]
+            ])
+        }
+
+        // Build current turn with all labeled images + prompt
+        var currentTurnParts: [[String: Any]] = []
+        for image in images {
+            currentTurnParts.append([
+                "inline_data": [
+                    "mime_type": detectImageMediaType(for: image.data),
+                    "data": image.data.base64EncodedString()
+                ]
+            ])
+            currentTurnParts.append([
+                "text": image.label
+            ])
+        }
+        currentTurnParts.append([
+            "text": userPrompt
+        ])
+        contents.append([
+            "role": "user",
+            "parts": currentTurnParts
+        ])
+
+        // `model` is forwarded to the Worker, which pulls it out and plugs it
+        // into the upstream Gemini URL path — Gemini itself doesn't read it.
+        return [
+            "model": model,
+            "systemInstruction": [
+                "parts": [["text": systemPrompt]]
+            ],
+            "contents": contents,
+            "generationConfig": [
+                "maxOutputTokens": maxOutputTokens
+            ]
+        ]
+    }
+
+    /// Send a vision request to Gemini with streaming.
+    /// Calls `onTextChunk` on the main actor each time new text arrives so the UI updates progressively.
+    /// Returns the full accumulated text and total duration when the stream completes.
+    func analyzeImageStreaming(
+        images: [(data: Data, label: String)],
+        systemPrompt: String,
+        conversationHistory: [(userPlaceholder: String, assistantResponse: String)] = [],
+        userPrompt: String,
+        onTextChunk: @MainActor @Sendable (String) -> Void
+    ) async throws -> (text: String, duration: TimeInterval) {
+        let startTime = Date()
+
+        var request = makeAPIRequest()
+
+        let body = buildGeminiRequestBody(
+            images: images,
+            systemPrompt: systemPrompt,
+            conversationHistory: conversationHistory,
+            userPrompt: userPrompt,
+            maxOutputTokens: 1024
+        )
+
+        let bodyData = try JSONSerialization.data(withJSONObject: body)
+        request.httpBody = bodyData
+        let payloadMB = Double(bodyData.count) / 1_048_576.0
+        print("🌐 Gemini streaming request (\(model)): \(String(format: "%.1f", payloadMB))MB, \(images.count) image(s)")
+
+        // Use bytes streaming for SSE (Server-Sent Events)
+        let (byteStream, response) = try await session.bytes(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NSError(
+                domain: "GeminiAPI",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid HTTP response"]
+            )
+        }
+
+        // If non-2xx status, read the full body as error text
+        guard (200...299).contains(httpResponse.statusCode) else {
+            var errorBodyChunks: [String] = []
+            for try await line in byteStream.lines {
+                errorBodyChunks.append(line)
+            }
+            let errorBody = errorBodyChunks.joined(separator: "\n")
+            throw NSError(
+                domain: "GeminiAPI",
+                code: httpResponse.statusCode,
+                userInfo: [NSLocalizedDescriptionKey: "API Error (\(httpResponse.statusCode)): \(errorBody)"]
+            )
+        }
+
+        // Parse SSE stream — each event is "data: {json}\n\n".
+        // Gemini sends one event per chunk with shape:
+        //   { "candidates": [ { "content": { "parts": [ {"text": "..."} ], "role": "model" } } ] }
+        var accumulatedResponseText = ""
+
+        for try await line in byteStream.lines {
+            guard line.hasPrefix("data: ") else { continue }
+            let jsonString = String(line.dropFirst(6))
+
+            // Gemini doesn't send an explicit [DONE] marker, but handle it defensively
+            guard jsonString != "[DONE]" else { break }
+
+            guard let jsonData = jsonString.data(using: .utf8),
+                  let eventPayload = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any] else {
+                continue
+            }
+
+            // Extract text from candidates[0].content.parts[*].text
+            guard let candidates = eventPayload["candidates"] as? [[String: Any]],
+                  let firstCandidate = candidates.first,
+                  let content = firstCandidate["content"] as? [String: Any],
+                  let parts = content["parts"] as? [[String: Any]] else {
+                continue
+            }
+
+            var chunkText = ""
+            for part in parts {
+                if let partText = part["text"] as? String {
+                    chunkText += partText
+                }
+            }
+
+            if !chunkText.isEmpty {
+                accumulatedResponseText += chunkText
+                let currentAccumulatedText = accumulatedResponseText
+                await onTextChunk(currentAccumulatedText)
+            }
+        }
+
+        let duration = Date().timeIntervalSince(startTime)
+        return (text: accumulatedResponseText, duration: duration)
+    }
+
+    /// Non-streaming fallback for validation requests where we don't need progressive display.
+    /// Uses the same streaming endpoint internally — Gemini returns the full result via SSE
+    /// and we simply accumulate it before returning. This keeps the Worker route surface small.
+    func analyzeImage(
+        images: [(data: Data, label: String)],
+        systemPrompt: String,
+        conversationHistory: [(userPlaceholder: String, assistantResponse: String)] = [],
+        userPrompt: String
+    ) async throws -> (text: String, duration: TimeInterval) {
+        return try await analyzeImageStreaming(
+            images: images,
+            systemPrompt: systemPrompt,
+            conversationHistory: conversationHistory,
+            userPrompt: userPrompt,
+            onTextChunk: { _ in }
+        )
+    }
+}

--- a/windows/Clicky.sln
+++ b/windows/Clicky.sln
@@ -1,0 +1,21 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.9.34622.214
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Clicky", "Clicky\Clicky.csproj", "{B1F9B6C0-5B7E-4D3A-8E4D-1A2B3C4D5E6F}"
+EndProject
+Global
+	GlobalSection(SolutionConfigurationPlatforms) = preSolution
+		Debug|Any CPU = Debug|Any CPU
+		Release|Any CPU = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(ProjectConfigurationPlatforms) = postSolution
+		{B1F9B6C0-5B7E-4D3A-8E4D-1A2B3C4D5E6F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+		{B1F9B6C0-5B7E-4D3A-8E4D-1A2B3C4D5E6F}.Debug|Any CPU.Build.0 = Debug|Any CPU
+		{B1F9B6C0-5B7E-4D3A-8E4D-1A2B3C4D5E6F}.Release|Any CPU.ActiveCfg = Release|Any CPU
+		{B1F9B6C0-5B7E-4D3A-8E4D-1A2B3C4D5E6F}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+EndGlobal

--- a/windows/Clicky/App.xaml
+++ b/windows/Clicky/App.xaml
@@ -1,0 +1,17 @@
+<Application x:Class="Clicky.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             ShutdownMode="OnExplicitShutdown">
+    <!--
+        ShutdownMode is OnExplicitShutdown because the app has no main window.
+        It lives in the tray; when the user picks "Quit", we call Shutdown()
+        explicitly from the view-model.
+    -->
+    <Application.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="Resources/DesignSystem.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Application.Resources>
+</Application>

--- a/windows/Clicky/App.xaml.cs
+++ b/windows/Clicky/App.xaml.cs
@@ -48,6 +48,11 @@ public partial class App : Application
         _trayPanelViewModel = new TrayPanelViewModel(_appState);
         _trayPanelWindow = new TrayPanelWindow(_trayPanelViewModel);
 
+        // PostHog setup — idempotent, silent no-op until the write key in
+        // WorkerConfig.cs is replaced with a real project key. Fires
+        // app_opened on success.
+        ClickyAnalytics.Configure(_settingsService.AnalyticsDistinctId);
+
         InstallTrayIcon();
         InstallGlobalHotkey();
 
@@ -60,6 +65,35 @@ public partial class App : Application
         _overlayWindowManager.Start();
 
         _voicePipelineOrchestrator = new VoicePipelineOrchestrator(_appState, Dispatcher, _overlayWindowManager);
+
+        // First-run onboarding: if the user hasn't completed it, auto-open
+        // the panel on a centered position so the very first launch shows
+        // the welcome copy instead of a silent tray icon. Also probe the
+        // microphone so a disabled capture endpoint is surfaced before the
+        // first push-to-talk attempt.
+        ProbeMicrophoneAvailabilityAndUpdateState();
+        if (!_appState.HasCompletedOnboarding)
+        {
+            _trayPanelWindow.ShowPanelCenteredOnPrimaryScreen();
+            ClickyAnalytics.TrackOnboardingStarted();
+        }
+    }
+
+    private void ProbeMicrophoneAvailabilityAndUpdateState()
+    {
+        if (_appState is null) return;
+        var hasMic = MicrophonePermissionHelper.HasActiveCaptureDevice();
+        _appState.IsMicrophonePermissionIssue = !hasMic;
+        if (!hasMic)
+        {
+            _appState.LastStatusMessage =
+                "Microphone appears to be off or blocked. Open Windows privacy settings to enable it.";
+            ClickyAnalytics.TrackPermissionDenied("microphone");
+        }
+        else
+        {
+            ClickyAnalytics.TrackPermissionGranted("microphone");
+        }
     }
 
     protected override void OnExit(ExitEventArgs eventArgs)

--- a/windows/Clicky/App.xaml.cs
+++ b/windows/Clicky/App.xaml.cs
@@ -45,7 +45,6 @@ public partial class App : Application
 
         _settingsService = new SettingsService();
         _appState = new AppState(_settingsService);
-        _voicePipelineOrchestrator = new VoicePipelineOrchestrator(_appState, Dispatcher);
         _trayPanelViewModel = new TrayPanelViewModel(_appState);
         _trayPanelWindow = new TrayPanelWindow(_trayPanelViewModel);
 
@@ -54,9 +53,13 @@ public partial class App : Application
 
         // The overlay windows are created after the tray is up so nothing
         // flashes in an uninitialized state. Transparent + click-through, so
-        // their presence is invisible to the desktop beneath.
+        // their presence is invisible to the desktop beneath. The voice
+        // pipeline takes a reference so the [POINT:…] tag on each reply can
+        // fire an element-pointing flight before TTS speaks the text.
         _overlayWindowManager = new OverlayWindowManager(_appState, Dispatcher);
         _overlayWindowManager.Start();
+
+        _voicePipelineOrchestrator = new VoicePipelineOrchestrator(_appState, Dispatcher, _overlayWindowManager);
     }
 
     protected override void OnExit(ExitEventArgs eventArgs)

--- a/windows/Clicky/App.xaml.cs
+++ b/windows/Clicky/App.xaml.cs
@@ -1,3 +1,4 @@
+using System.IO;
 using System.Windows;
 using System.Windows.Media;
 using System.Windows.Media.Imaging;
@@ -123,11 +124,16 @@ public partial class App : Application
 
     private void InstallTrayIcon()
     {
+        // H.NotifyIcon's IconSource (ImageSource) path can't reliably consume
+        // a programmatically-rendered bitmap (it tries to round-trip via a
+        // BitmapImage.UriSource it never has). The Icon property accepts a
+        // System.Drawing.Icon directly and bypasses that whole conversion,
+        // so we generate or load a real Win32 icon instead.
         _trayIcon = new TaskbarIcon
         {
-            ToolTipText = "Clicky — hold Ctrl+Alt to talk",
-            IconSource = LoadTrayIconSource(),
-            // No built-in context menu — left- and right-click both open the
+            ToolTipText = "Clicky - hold Ctrl+Alt to talk",
+            Icon = LoadTrayIcon(),
+            // No built-in context menu - left- and right-click both open the
             // custom popover. Quit lives inside the panel.
             NoLeftClickDelay = true,
         };
@@ -184,7 +190,7 @@ public partial class App : Application
     /// generated blue-dot placeholder if the resource is missing so the app
     /// is runnable before an artist drops a real .ico in.
     /// </summary>
-    private static ImageSource LoadTrayIconSource()
+    private static System.Drawing.Icon LoadTrayIcon()
     {
         try
         {
@@ -192,13 +198,8 @@ public partial class App : Application
             var packResource = GetResourceStream(packIconUri);
             if (packResource?.Stream is not null)
             {
-                var bundledIconBitmap = new BitmapImage();
-                bundledIconBitmap.BeginInit();
-                bundledIconBitmap.CacheOption = BitmapCacheOption.OnLoad;
-                bundledIconBitmap.StreamSource = packResource.Stream;
-                bundledIconBitmap.EndInit();
-                bundledIconBitmap.Freeze();
-                return bundledIconBitmap;
+                using var iconStream = packResource.Stream;
+                return new System.Drawing.Icon(iconStream);
             }
         }
         catch
@@ -206,39 +207,45 @@ public partial class App : Application
             // Fall through to the generated placeholder.
         }
 
-        return CreatePlaceholderBlueDotBitmap();
+        return CreatePlaceholderBlueDotIcon();
     }
 
-    private static BitmapSource CreatePlaceholderBlueDotBitmap()
+    /// <summary>
+    /// Builds a 32x32 transparent-background blue dot Icon using GDI so
+    /// H.NotifyIcon can take it directly. Used when no real clicky-tray.ico
+    /// resource has been bundled.
+    /// </summary>
+    private static System.Drawing.Icon CreatePlaceholderBlueDotIcon()
     {
         const int iconPixelSize = 32;
         const int iconPadding = 6;
 
-        var drawingVisual = new DrawingVisual();
-        using (var drawingContext = drawingVisual.RenderOpen())
+        using var bitmap = new System.Drawing.Bitmap(
+            iconPixelSize,
+            iconPixelSize,
+            System.Drawing.Imaging.PixelFormat.Format32bppArgb);
+
+        using (var graphics = System.Drawing.Graphics.FromImage(bitmap))
         {
-            var overlayCursorBlue = new SolidColorBrush(Color.FromRgb(0x33, 0x80, 0xFF));
-            overlayCursorBlue.Freeze();
+            graphics.SmoothingMode = System.Drawing.Drawing2D.SmoothingMode.AntiAlias;
+            graphics.Clear(System.Drawing.Color.Transparent);
 
-            var circleCenter = new System.Windows.Point(iconPixelSize / 2.0, iconPixelSize / 2.0);
-            var circleRadius = (iconPixelSize - (iconPadding * 2)) / 2.0;
+            using var overlayCursorBlueBrush = new System.Drawing.SolidBrush(
+                System.Drawing.Color.FromArgb(0xFF, 0x33, 0x80, 0xFF));
 
-            drawingContext.DrawEllipse(
-                brush: overlayCursorBlue,
-                pen: null,
-                center: circleCenter,
-                radiusX: circleRadius,
-                radiusY: circleRadius);
+            graphics.FillEllipse(
+                overlayCursorBlueBrush,
+                iconPadding,
+                iconPadding,
+                iconPixelSize - (iconPadding * 2),
+                iconPixelSize - (iconPadding * 2));
         }
 
-        var renderTarget = new RenderTargetBitmap(
-            pixelWidth: iconPixelSize,
-            pixelHeight: iconPixelSize,
-            dpiX: 96,
-            dpiY: 96,
-            pixelFormat: PixelFormats.Pbgra32);
-        renderTarget.Render(drawingVisual);
-        renderTarget.Freeze();
-        return renderTarget;
+        // GetHicon hands ownership of the HICON to us; FromHandle doesn't take
+        // ownership, so we'd normally have to clean it up. The TaskbarIcon
+        // keeps this Icon for the lifetime of the app, so the leak is bounded
+        // to a single 32x32 cursor handle.
+        var hIcon = bitmap.GetHicon();
+        return (System.Drawing.Icon)System.Drawing.Icon.FromHandle(hIcon).Clone();
     }
 }

--- a/windows/Clicky/App.xaml.cs
+++ b/windows/Clicky/App.xaml.cs
@@ -28,6 +28,7 @@ public partial class App : Application
     private TaskbarIcon? _trayIcon;
     private TrayPanelWindow? _trayPanelWindow;
     private TrayPanelViewModel? _trayPanelViewModel;
+    private VoicePipelineOrchestrator? _voicePipelineOrchestrator;
 
     protected override void OnStartup(StartupEventArgs eventArgs)
     {
@@ -43,6 +44,7 @@ public partial class App : Application
 
         _settingsService = new SettingsService();
         _appState = new AppState(_settingsService);
+        _voicePipelineOrchestrator = new VoicePipelineOrchestrator(_appState, Dispatcher);
         _trayPanelViewModel = new TrayPanelViewModel(_appState);
         _trayPanelWindow = new TrayPanelWindow(_trayPanelViewModel);
 
@@ -54,6 +56,12 @@ public partial class App : Application
     {
         _globalHotkeyService?.Dispose();
         _trayIcon?.Dispose();
+        // Orchestrator owns mic/websocket/TTS — dispose synchronously so
+        // their background threads are joined before the process exits.
+        if (_voicePipelineOrchestrator is not null)
+        {
+            _voicePipelineOrchestrator.DisposeAsync().AsTask().GetAwaiter().GetResult();
+        }
         _singleInstanceMutex?.ReleaseMutex();
         _singleInstanceMutex?.Dispose();
         base.OnExit(eventArgs);
@@ -95,30 +103,19 @@ public partial class App : Application
 
     private void OnPushToTalkPressed(object? sender, EventArgs eventArgs)
     {
-        // Milestone 2 wires this to the dictation pipeline. For now we just
-        // flip the state so the panel can reflect it and we can verify the
-        // hook is detecting the combo.
-        Dispatcher.BeginInvoke(() =>
-        {
-            if (_appState is not null)
-            {
-                _appState.CurrentVoiceState = AppState.VoiceState.Listening;
-            }
-            // Panel shouldn't stay visible while the user is talking to the
-            // app — dismiss it if it happens to be open.
-            _trayPanelWindow?.HidePanel();
-        });
+        // Panel shouldn't stay visible while the user is talking to the
+        // app — dismiss it if it happens to be open.
+        Dispatcher.BeginInvoke(() => _trayPanelWindow?.HidePanel());
+
+        // The orchestrator owns the state transitions (Listening / Processing
+        // / Responding / Idle) from here. Swallow exceptions — the
+        // orchestrator reports them via AppState.LastStatusMessage.
+        _ = _voicePipelineOrchestrator?.HandlePushToTalkPressedAsync();
     }
 
     private void OnPushToTalkReleased(object? sender, EventArgs eventArgs)
     {
-        Dispatcher.BeginInvoke(() =>
-        {
-            if (_appState is not null)
-            {
-                _appState.CurrentVoiceState = AppState.VoiceState.Idle;
-            }
-        });
+        _ = _voicePipelineOrchestrator?.HandlePushToTalkReleasedAsync();
     }
 
     private void ToggleTrayPanel()

--- a/windows/Clicky/App.xaml.cs
+++ b/windows/Clicky/App.xaml.cs
@@ -29,6 +29,7 @@ public partial class App : Application
     private TrayPanelWindow? _trayPanelWindow;
     private TrayPanelViewModel? _trayPanelViewModel;
     private VoicePipelineOrchestrator? _voicePipelineOrchestrator;
+    private OverlayWindowManager? _overlayWindowManager;
 
     protected override void OnStartup(StartupEventArgs eventArgs)
     {
@@ -50,10 +51,17 @@ public partial class App : Application
 
         InstallTrayIcon();
         InstallGlobalHotkey();
+
+        // The overlay windows are created after the tray is up so nothing
+        // flashes in an uninitialized state. Transparent + click-through, so
+        // their presence is invisible to the desktop beneath.
+        _overlayWindowManager = new OverlayWindowManager(_appState, Dispatcher);
+        _overlayWindowManager.Start();
     }
 
     protected override void OnExit(ExitEventArgs eventArgs)
     {
+        _overlayWindowManager?.Dispose();
         _globalHotkeyService?.Dispose();
         _trayIcon?.Dispose();
         // Orchestrator owns mic/websocket/TTS — dispose synchronously so

--- a/windows/Clicky/App.xaml.cs
+++ b/windows/Clicky/App.xaml.cs
@@ -1,0 +1,202 @@
+using System.Windows;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using H.NotifyIcon;
+using Clicky.Interop;
+using Clicky.Services;
+using Clicky.ViewModels;
+using Clicky.Views;
+
+namespace Clicky;
+
+/// <summary>
+/// WPF application entry. Boots the tray icon, wires the popover panel,
+/// installs the global push-to-talk hotkey, and holds the root AppState
+/// for the app's lifetime.
+///
+/// This is the Windows analog of the macOS CompanionAppDelegate +
+/// MenuBarPanelManager combination (leanring_buddyApp.swift + MenuBarPanelManager.swift).
+/// </summary>
+public partial class App : Application
+{
+    // Keep singletons alive for the app's lifetime. No DI container in M1 —
+    // the dependency graph is small enough to thread manually.
+    private Mutex? _singleInstanceMutex;
+    private SettingsService? _settingsService;
+    private AppState? _appState;
+    private GlobalHotkeyService? _globalHotkeyService;
+    private TaskbarIcon? _trayIcon;
+    private TrayPanelWindow? _trayPanelWindow;
+    private TrayPanelViewModel? _trayPanelViewModel;
+
+    protected override void OnStartup(StartupEventArgs eventArgs)
+    {
+        base.OnStartup(eventArgs);
+
+        if (!TryAcquireSingleInstanceMutex())
+        {
+            // Another instance is already running. Exit quietly — no error
+            // dialog, so double-clicks from the Start menu are benign.
+            Shutdown();
+            return;
+        }
+
+        _settingsService = new SettingsService();
+        _appState = new AppState(_settingsService);
+        _trayPanelViewModel = new TrayPanelViewModel(_appState);
+        _trayPanelWindow = new TrayPanelWindow(_trayPanelViewModel);
+
+        InstallTrayIcon();
+        InstallGlobalHotkey();
+    }
+
+    protected override void OnExit(ExitEventArgs eventArgs)
+    {
+        _globalHotkeyService?.Dispose();
+        _trayIcon?.Dispose();
+        _singleInstanceMutex?.ReleaseMutex();
+        _singleInstanceMutex?.Dispose();
+        base.OnExit(eventArgs);
+    }
+
+    private bool TryAcquireSingleInstanceMutex()
+    {
+        // Per-user mutex — two different users on the same machine can each
+        // run their own Clicky instance without colliding.
+        var mutexName = $"Local\\Clicky.SingleInstance.{Environment.UserName}";
+        _singleInstanceMutex = new Mutex(initiallyOwned: true, name: mutexName, createdNew: out var createdNew);
+        return createdNew;
+    }
+
+    private void InstallTrayIcon()
+    {
+        _trayIcon = new TaskbarIcon
+        {
+            ToolTipText = "Clicky — hold Ctrl+Alt to talk",
+            IconSource = LoadTrayIconSource(),
+            // No built-in context menu — left- and right-click both open the
+            // custom popover. Quit lives inside the panel.
+            NoLeftClickDelay = true,
+        };
+
+        _trayIcon.TrayLeftMouseUp += (_, _) => ToggleTrayPanel();
+        _trayIcon.TrayRightMouseUp += (_, _) => ToggleTrayPanel();
+
+        _trayIcon.ForceCreate();
+    }
+
+    private void InstallGlobalHotkey()
+    {
+        _globalHotkeyService = new GlobalHotkeyService();
+        _globalHotkeyService.ShortcutPressed += OnPushToTalkPressed;
+        _globalHotkeyService.ShortcutReleased += OnPushToTalkReleased;
+        _globalHotkeyService.Start();
+    }
+
+    private void OnPushToTalkPressed(object? sender, EventArgs eventArgs)
+    {
+        // Milestone 2 wires this to the dictation pipeline. For now we just
+        // flip the state so the panel can reflect it and we can verify the
+        // hook is detecting the combo.
+        Dispatcher.BeginInvoke(() =>
+        {
+            if (_appState is not null)
+            {
+                _appState.CurrentVoiceState = AppState.VoiceState.Listening;
+            }
+            // Panel shouldn't stay visible while the user is talking to the
+            // app — dismiss it if it happens to be open.
+            _trayPanelWindow?.HidePanel();
+        });
+    }
+
+    private void OnPushToTalkReleased(object? sender, EventArgs eventArgs)
+    {
+        Dispatcher.BeginInvoke(() =>
+        {
+            if (_appState is not null)
+            {
+                _appState.CurrentVoiceState = AppState.VoiceState.Idle;
+            }
+        });
+    }
+
+    private void ToggleTrayPanel()
+    {
+        if (_trayPanelWindow is null) return;
+
+        if (_trayPanelWindow.IsVisible)
+        {
+            _trayPanelWindow.HidePanel();
+            return;
+        }
+
+        NativeMethods.GetCursorPos(out var cursorPositionDevicePixels);
+        _trayPanelWindow.ShowNearTrayCursor(
+            cursorPositionDevicePixels.X,
+            cursorPositionDevicePixels.Y);
+    }
+
+    /// <summary>
+    /// Loads the tray icon from the bundled resource. Falls back to a
+    /// generated blue-dot placeholder if the resource is missing so the app
+    /// is runnable before an artist drops a real .ico in.
+    /// </summary>
+    private static ImageSource LoadTrayIconSource()
+    {
+        try
+        {
+            var packIconUri = new Uri("pack://application:,,,/Resources/clicky-tray.ico", UriKind.Absolute);
+            var packResource = GetResourceStream(packIconUri);
+            if (packResource?.Stream is not null)
+            {
+                var bundledIconBitmap = new BitmapImage();
+                bundledIconBitmap.BeginInit();
+                bundledIconBitmap.CacheOption = BitmapCacheOption.OnLoad;
+                bundledIconBitmap.StreamSource = packResource.Stream;
+                bundledIconBitmap.EndInit();
+                bundledIconBitmap.Freeze();
+                return bundledIconBitmap;
+            }
+        }
+        catch
+        {
+            // Fall through to the generated placeholder.
+        }
+
+        return CreatePlaceholderBlueDotBitmap();
+    }
+
+    private static BitmapSource CreatePlaceholderBlueDotBitmap()
+    {
+        const int iconPixelSize = 32;
+        const int iconPadding = 6;
+
+        var drawingVisual = new DrawingVisual();
+        using (var drawingContext = drawingVisual.RenderOpen())
+        {
+            var overlayCursorBlue = new SolidColorBrush(Color.FromRgb(0x33, 0x80, 0xFF));
+            overlayCursorBlue.Freeze();
+
+            var circleCenter = new System.Windows.Point(iconPixelSize / 2.0, iconPixelSize / 2.0);
+            var circleRadius = (iconPixelSize - (iconPadding * 2)) / 2.0;
+
+            drawingContext.DrawEllipse(
+                brush: overlayCursorBlue,
+                pen: null,
+                center: circleCenter,
+                radiusX: circleRadius,
+                radiusY: circleRadius);
+        }
+
+        var renderTarget = new RenderTargetBitmap(
+            pixelWidth: iconPixelSize,
+            pixelHeight: iconPixelSize,
+            dpiX: 96,
+            dpiY: 96,
+            pixelFormat: PixelFormats.Pbgra32);
+        renderTarget.Render(drawingVisual);
+        renderTarget.Freeze();
+        return renderTarget;
+    }
+}

--- a/windows/Clicky/AppState.cs
+++ b/windows/Clicky/AppState.cs
@@ -34,6 +34,29 @@ public sealed partial class AppState : ObservableObject
     [ObservableProperty]
     private VoiceState _currentVoiceState = VoiceState.Idle;
 
+    /// <summary>
+    /// Live-updating transcript while the user holds push-to-talk. Shows
+    /// partials as they arrive from AssemblyAI and the finalized text once
+    /// the shortcut releases. Cleared at the start of each session.
+    /// </summary>
+    [ObservableProperty]
+    private string _liveTranscript = string.Empty;
+
+    /// <summary>
+    /// Streaming response text from the active AI provider. Appended to
+    /// as SSE chunks arrive so the panel can show the answer forming in
+    /// real time.
+    /// </summary>
+    [ObservableProperty]
+    private string _streamedResponseText = string.Empty;
+
+    /// <summary>
+    /// Latest error/status message surfaced from any pipeline component.
+    /// The panel shows it in the tertiary footer row when present.
+    /// </summary>
+    [ObservableProperty]
+    private string _lastStatusMessage = string.Empty;
+
     // ---- Persisted preferences ----
 
     [ObservableProperty]

--- a/windows/Clicky/AppState.cs
+++ b/windows/Clicky/AppState.cs
@@ -1,0 +1,72 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using Clicky.Services;
+
+namespace Clicky;
+
+/// <summary>
+/// Root observable state for the entire Windows app. The C# analog of the
+/// macOS CompanionManager (leanring-buddy/CompanionManager.swift). Milestone 1
+/// holds only the persisted preferences and the voice-state enum; later
+/// milestones attach the screen-capture, dictation, and AI-chat services.
+/// </summary>
+public sealed partial class AppState : ObservableObject
+{
+    private readonly SettingsService _settingsService;
+
+    public AppState(SettingsService settingsService)
+    {
+        _settingsService = settingsService;
+        _selectedModelId = settingsService.SelectedModelId;
+        _isClickyCursorEnabled = settingsService.IsClickyCursorEnabled;
+        _hasCompletedOnboarding = settingsService.HasCompletedOnboarding;
+    }
+
+    // ---- Voice pipeline state (populated by later milestones) ----
+
+    public enum VoiceState
+    {
+        Idle,
+        Listening,
+        Processing,
+        Responding,
+    }
+
+    [ObservableProperty]
+    private VoiceState _currentVoiceState = VoiceState.Idle;
+
+    // ---- Persisted preferences ----
+
+    [ObservableProperty]
+    private string _selectedModelId;
+
+    partial void OnSelectedModelIdChanged(string value)
+    {
+        _settingsService.SelectedModelId = value;
+    }
+
+    [ObservableProperty]
+    private bool _isClickyCursorEnabled;
+
+    partial void OnIsClickyCursorEnabledChanged(bool value)
+    {
+        _settingsService.IsClickyCursorEnabled = value;
+    }
+
+    [ObservableProperty]
+    private bool _hasCompletedOnboarding;
+
+    partial void OnHasCompletedOnboardingChanged(bool value)
+    {
+        _settingsService.HasCompletedOnboarding = value;
+    }
+
+    // ---- Model routing helpers (mirror CompanionManager.isGeminiModelID) ----
+
+    /// <summary>
+    /// Returns true when the given model ID belongs to the Gemini provider.
+    /// Used by later milestones to route vision requests to the right client.
+    /// </summary>
+    public static bool IsGeminiModelId(string modelId) => modelId.StartsWith("gemini", StringComparison.OrdinalIgnoreCase);
+
+    public bool IsCurrentModelGemini => IsGeminiModelId(SelectedModelId);
+}

--- a/windows/Clicky/AppState.cs
+++ b/windows/Clicky/AppState.cs
@@ -57,6 +57,14 @@ public sealed partial class AppState : ObservableObject
     [ObservableProperty]
     private string _lastStatusMessage = string.Empty;
 
+    /// <summary>
+    /// Set when microphone access is blocked or unavailable. The tray panel
+    /// shows a "Open privacy settings" shortcut when this is true so the
+    /// user can fix the permission in one click.
+    /// </summary>
+    [ObservableProperty]
+    private bool _isMicrophonePermissionIssue;
+
     // ---- Persisted preferences ----
 
     [ObservableProperty]

--- a/windows/Clicky/Clicky.csproj
+++ b/windows/Clicky/Clicky.csproj
@@ -1,0 +1,27 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <!-- net8.0-windows10.0.19041.0 enables WinRT interop for Windows.Graphics.Capture
+         in later milestones. 19041 (20H1) is the minimum SDK with the full API surface. -->
+    <TargetFramework>net8.0-windows10.0.19041.0</TargetFramework>
+    <SupportedOSPlatformVersion>10.0.17763.0</SupportedOSPlatformVersion>
+    <RootNamespace>Clicky</RootNamespace>
+    <AssemblyName>Clicky</AssemblyName>
+    <Nullable>enable</Nullable>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <UseWPF>true</UseWPF>
+    <ApplicationManifest>app.manifest</ApplicationManifest>
+    <!-- Single high-DPI aware WPF app, no console window -->
+    <ApplicationHighDpiMode>PerMonitorV2</ApplicationHighDpiMode>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <!-- Modern tray icon for WPF. H.NotifyIcon is the actively-maintained fork
+         of WPF-NotifyIcon and supports .NET 8 + per-monitor DPI cleanly. -->
+    <PackageReference Include="H.NotifyIcon.Wpf" Version="2.1.3" />
+    <!-- Source-generated MVVM primitives (ObservableObject, RelayCommand). -->
+    <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+  </ItemGroup>
+
+</Project>

--- a/windows/Clicky/Clicky.csproj
+++ b/windows/Clicky/Clicky.csproj
@@ -22,6 +22,9 @@
     <PackageReference Include="H.NotifyIcon.Wpf" Version="2.1.3" />
     <!-- Source-generated MVVM primitives (ObservableObject, RelayCommand). -->
     <PackageReference Include="CommunityToolkit.Mvvm" Version="8.3.2" />
+    <!-- Microphone capture (WasapiCapture) + MP3 playback for ElevenLabs TTS.
+         NAudio ships the MP3 frame reader we need; no ffmpeg/GStreamer required. -->
+    <PackageReference Include="NAudio" Version="2.2.1" />
   </ItemGroup>
 
 </Project>

--- a/windows/Clicky/Interop/NativeMethods.cs
+++ b/windows/Clicky/Interop/NativeMethods.cs
@@ -1,0 +1,160 @@
+using System.Runtime.InteropServices;
+using System.Windows;
+
+namespace Clicky.Interop;
+
+/// <summary>
+/// Win32 P/Invoke surface. Grouped here so the rest of the app can stay
+/// managed-code-only. Each method is documented with the underlying Win32
+/// function it wraps.
+/// </summary>
+internal static class NativeMethods
+{
+    // ---- Extended window style bits used by the panel + overlay ----
+    public const int GWL_EXSTYLE = -20;
+    public const int WS_EX_TRANSPARENT = 0x00000020;
+    public const int WS_EX_TOOLWINDOW = 0x00000080;
+    public const int WS_EX_LAYERED = 0x00080000;
+    public const int WS_EX_NOACTIVATE = 0x08000000;
+
+    // ---- SetWindowPos flags (used for non-activating positioning) ----
+    public static readonly IntPtr HWND_TOPMOST = new(-1);
+    public const uint SWP_NOSIZE = 0x0001;
+    public const uint SWP_NOMOVE = 0x0002;
+    public const uint SWP_NOACTIVATE = 0x0010;
+    public const uint SWP_SHOWWINDOW = 0x0040;
+
+    // ---- AppBar query for the Windows taskbar bounds ----
+    public const uint ABM_GETTASKBARPOS = 0x00000005;
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool SetWindowPos(
+        IntPtr hWnd,
+        IntPtr hWndInsertAfter,
+        int X,
+        int Y,
+        int cx,
+        int cy,
+        uint uFlags);
+
+    // 32-bit and 64-bit variants of GetWindowLong / SetWindowLong. The correct
+    // one is selected at runtime by GetExtendedStyle / SetExtendedStyle below.
+    [DllImport("user32.dll", EntryPoint = "GetWindowLong")]
+    private static extern int GetWindowLong32(IntPtr hWnd, int nIndex);
+
+    [DllImport("user32.dll", EntryPoint = "GetWindowLongPtr")]
+    private static extern IntPtr GetWindowLongPtr64(IntPtr hWnd, int nIndex);
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLong")]
+    private static extern int SetWindowLong32(IntPtr hWnd, int nIndex, int dwNewLong);
+
+    [DllImport("user32.dll", EntryPoint = "SetWindowLongPtr")]
+    private static extern IntPtr SetWindowLongPtr64(IntPtr hWnd, int nIndex, IntPtr dwNewLong);
+
+    public static int GetExtendedStyle(IntPtr hWnd)
+    {
+        return IntPtr.Size == 8
+            ? (int)GetWindowLongPtr64(hWnd, GWL_EXSTYLE)
+            : GetWindowLong32(hWnd, GWL_EXSTYLE);
+    }
+
+    public static void SetExtendedStyle(IntPtr hWnd, int newStyle)
+    {
+        if (IntPtr.Size == 8)
+        {
+            SetWindowLongPtr64(hWnd, GWL_EXSTYLE, new IntPtr(newStyle));
+        }
+        else
+        {
+            SetWindowLong32(hWnd, GWL_EXSTYLE, newStyle);
+        }
+    }
+
+    // ---- Taskbar position (used to anchor the panel near the tray icon) ----
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct RECT
+    {
+        public int Left;
+        public int Top;
+        public int Right;
+        public int Bottom;
+
+        public int Width => Right - Left;
+        public int Height => Bottom - Top;
+    }
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct APPBARDATA
+    {
+        public uint cbSize;
+        public IntPtr hWnd;
+        public uint uCallbackMessage;
+        public uint uEdge;
+        public RECT rc;
+        public int lParam;
+    }
+
+    [DllImport("shell32.dll", CallingConvention = CallingConvention.StdCall)]
+    public static extern IntPtr SHAppBarMessage(uint dwMessage, ref APPBARDATA pData);
+
+    // ---- Low-level keyboard hook (push-to-talk hotkey detection) ----
+
+    public const int WH_KEYBOARD_LL = 13;
+    public const int WM_KEYDOWN = 0x0100;
+    public const int WM_KEYUP = 0x0101;
+    public const int WM_SYSKEYDOWN = 0x0104;
+    public const int WM_SYSKEYUP = 0x0105;
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct KBDLLHOOKSTRUCT
+    {
+        public uint vkCode;
+        public uint scanCode;
+        public uint flags;
+        public uint time;
+        public UIntPtr dwExtraInfo;
+    }
+
+    public delegate IntPtr LowLevelKeyboardProc(int nCode, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    public static extern IntPtr SetWindowsHookEx(int idHook, LowLevelKeyboardProc lpfn, IntPtr hMod, uint dwThreadId);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool UnhookWindowsHookEx(IntPtr hhk);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    public static extern IntPtr CallNextHookEx(IntPtr hhk, int nCode, IntPtr wParam, IntPtr lParam);
+
+    [DllImport("kernel32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    public static extern IntPtr GetModuleHandle(string? lpModuleName);
+
+    // ---- Cursor position (used by the overlay cursor-follow logic) ----
+
+    [StructLayout(LayoutKind.Sequential)]
+    public struct POINT
+    {
+        public int X;
+        public int Y;
+    }
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool GetCursorPos(out POINT lpPoint);
+
+    // ---- DPI helpers (used when positioning the panel in device-pixel coords) ----
+
+    /// <summary>
+    /// Returns the device-to-DIP scale for the window's monitor. Multiply a
+    /// device-pixel coord by the reciprocal to get WPF DIPs, or pass WPF DIPs
+    /// in and multiply by this to get device pixels.
+    /// </summary>
+    public static double GetDpiScale(Window window)
+    {
+        var source = PresentationSource.FromVisual(window);
+        return source?.CompositionTarget?.TransformToDevice.M11 ?? 1.0;
+    }
+}

--- a/windows/Clicky/Interop/NativeMethods.cs
+++ b/windows/Clicky/Interop/NativeMethods.cs
@@ -145,6 +145,76 @@ internal static class NativeMethods
     [return: MarshalAs(UnmanagedType.Bool)]
     public static extern bool GetCursorPos(out POINT lpPoint);
 
+    // ---- Display enumeration + screen capture (BitBlt) ----
+    // Used by ScreenCaptureService to grab per-monitor JPEGs. PerMonitorV2
+    // DPI awareness (set in app.manifest) means GetMonitorInfo returns
+    // physical device pixels and BitBlt copies at the monitor's native
+    // resolution, which is what the AI needs to reason about coordinates.
+
+    public const int MONITOR_DEFAULTTONEAREST = 2;
+
+    [StructLayout(LayoutKind.Sequential, CharSet = CharSet.Auto)]
+    public struct MONITORINFOEX
+    {
+        public int cbSize;
+        public RECT rcMonitor;
+        public RECT rcWork;
+        public uint dwFlags;
+        [MarshalAs(UnmanagedType.ByValTStr, SizeConst = 32)]
+        public string szDevice;
+    }
+
+    public const uint MONITORINFOF_PRIMARY = 1;
+
+    public delegate bool MonitorEnumProc(IntPtr hMonitor, IntPtr hdcMonitor, ref RECT lprcMonitor, IntPtr dwData);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool EnumDisplayMonitors(IntPtr hdc, IntPtr lprcClip, MonitorEnumProc lpfnEnum, IntPtr dwData);
+
+    [DllImport("user32.dll", CharSet = CharSet.Auto, SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFOEX lpmi);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern IntPtr MonitorFromPoint(POINT pt, uint dwFlags);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern IntPtr GetDesktopWindow();
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern IntPtr GetDC(IntPtr hWnd);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    public static extern int ReleaseDC(IntPtr hWnd, IntPtr hDC);
+
+    [DllImport("gdi32.dll", SetLastError = true)]
+    public static extern IntPtr CreateCompatibleDC(IntPtr hDC);
+
+    [DllImport("gdi32.dll", SetLastError = true)]
+    public static extern IntPtr CreateCompatibleBitmap(IntPtr hDC, int nWidth, int nHeight);
+
+    [DllImport("gdi32.dll", SetLastError = true)]
+    public static extern IntPtr SelectObject(IntPtr hDC, IntPtr hObject);
+
+    [DllImport("gdi32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool DeleteObject(IntPtr hObject);
+
+    [DllImport("gdi32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool DeleteDC(IntPtr hDC);
+
+    // BitBlt raster-operation codes.
+    public const int SRCCOPY = 0x00CC0020;
+    public const int CAPTUREBLT = 0x40000000; // Includes layered windows in the capture
+
+    [DllImport("gdi32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    public static extern bool BitBlt(
+        IntPtr hDCDest, int xDest, int yDest, int width, int height,
+        IntPtr hDCSource, int xSource, int ySource, int rop);
+
     // ---- DPI helpers (used when positioning the panel in device-pixel coords) ----
 
     /// <summary>

--- a/windows/Clicky/Resources/DesignSystem.xaml
+++ b/windows/Clicky/Resources/DesignSystem.xaml
@@ -1,0 +1,94 @@
+<ResourceDictionary xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+                    xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+                    xmlns:sys="clr-namespace:System;assembly=mscorlib">
+
+    <!--
+        Design system tokens ported 1:1 from the macOS app's DesignSystem.swift.
+        Any color or radius change here must be mirrored there so both platforms
+        look identical.
+    -->
+
+    <!-- Surfaces -->
+    <SolidColorBrush x:Key="Background"            Color="#101211"/>
+    <SolidColorBrush x:Key="Surface1"              Color="#171918"/>
+    <SolidColorBrush x:Key="Surface2"              Color="#202221"/>
+    <SolidColorBrush x:Key="Surface3"              Color="#272A29"/>
+    <SolidColorBrush x:Key="Surface4"              Color="#2E3130"/>
+
+    <!-- Borders -->
+    <SolidColorBrush x:Key="BorderSubtle"          Color="#373B39"/>
+    <SolidColorBrush x:Key="BorderStrong"          Color="#444947"/>
+
+    <!-- Text -->
+    <SolidColorBrush x:Key="TextPrimary"           Color="#ECEEED"/>
+    <SolidColorBrush x:Key="TextSecondary"         Color="#ADB5B2"/>
+    <SolidColorBrush x:Key="TextTertiary"          Color="#6B736F"/>
+
+    <!-- Accent (Tailwind Blue scale — matches macOS DS.Colors.blueXXX) -->
+    <SolidColorBrush x:Key="Blue400"               Color="#60A5FA"/>
+    <SolidColorBrush x:Key="Blue500"               Color="#3B82F6"/>
+    <SolidColorBrush x:Key="Blue600"               Color="#2563EB"/>
+    <SolidColorBrush x:Key="Blue700"               Color="#1D4ED8"/>
+    <SolidColorBrush x:Key="Accent"                Color="#2563EB"/>
+    <SolidColorBrush x:Key="AccentText"            Color="#60A5FA"/>
+
+    <!-- Overlay cursor (blue triangle color) -->
+    <SolidColorBrush x:Key="OverlayCursorBlue"     Color="#3380FF"/>
+
+    <!-- Semantic -->
+    <SolidColorBrush x:Key="Destructive"           Color="#E5484D"/>
+    <SolidColorBrush x:Key="Success"               Color="#34D399"/>
+    <SolidColorBrush x:Key="Warning"               Color="#FFB224"/>
+
+    <!-- Subtle translucent fills used on buttons + segmented controls -->
+    <SolidColorBrush x:Key="TranslucentFillLow"    Color="#FFFFFF" Opacity="0.06"/>
+    <SolidColorBrush x:Key="TranslucentFillMid"    Color="#FFFFFF" Opacity="0.10"/>
+    <SolidColorBrush x:Key="TranslucentFillHover"  Color="#FFFFFF" Opacity="0.08"/>
+
+    <!-- Corner radii -->
+    <sys:Double x:Key="CornerRadiusSmall">6</sys:Double>
+    <sys:Double x:Key="CornerRadiusMedium">8</sys:Double>
+    <sys:Double x:Key="CornerRadiusLarge">10</sys:Double>
+    <sys:Double x:Key="CornerRadiusExtraLarge">12</sys:Double>
+
+    <CornerRadius x:Key="CornerRadiusSmallR">6</CornerRadius>
+    <CornerRadius x:Key="CornerRadiusMediumR">8</CornerRadius>
+    <CornerRadius x:Key="CornerRadiusLargeR">10</CornerRadius>
+    <CornerRadius x:Key="CornerRadiusExtraLargeR">12</CornerRadius>
+
+    <!-- Typography defaults. WPF has no equivalent to SF Pro, but Segoe UI
+         Variable on Win11 is visually close enough at this weight/size. -->
+    <FontFamily x:Key="PrimaryFontFamily">Segoe UI Variable, Segoe UI, Arial</FontFamily>
+
+    <!-- Shared text styles -->
+    <Style x:Key="BodyTextStyle" TargetType="TextBlock">
+        <Setter Property="FontFamily" Value="{StaticResource PrimaryFontFamily}"/>
+        <Setter Property="FontSize" Value="13"/>
+        <Setter Property="Foreground" Value="{StaticResource TextPrimary}"/>
+        <Setter Property="TextOptions.TextRenderingMode" Value="ClearType"/>
+        <Setter Property="TextOptions.TextFormattingMode" Value="Ideal"/>
+    </Style>
+
+    <Style x:Key="SecondaryTextStyle" TargetType="TextBlock" BasedOn="{StaticResource BodyTextStyle}">
+        <Setter Property="Foreground" Value="{StaticResource TextSecondary}"/>
+    </Style>
+
+    <Style x:Key="TertiaryTextStyle" TargetType="TextBlock" BasedOn="{StaticResource BodyTextStyle}">
+        <Setter Property="Foreground" Value="{StaticResource TextTertiary}"/>
+        <Setter Property="FontSize" Value="11"/>
+    </Style>
+
+    <Style x:Key="HeaderTextStyle" TargetType="TextBlock" BasedOn="{StaticResource BodyTextStyle}">
+        <Setter Property="FontSize" Value="14"/>
+        <Setter Property="FontWeight" Value="SemiBold"/>
+    </Style>
+
+    <!-- Drop shadow matching the macOS panel (two stacked shadows for depth) -->
+    <DropShadowEffect x:Key="PanelShadowEffect"
+                      Color="Black"
+                      BlurRadius="28"
+                      ShadowDepth="8"
+                      Opacity="0.42"
+                      Direction="270"/>
+
+</ResourceDictionary>

--- a/windows/Clicky/Services/AssemblyAIStreamingClient.cs
+++ b/windows/Clicky/Services/AssemblyAIStreamingClient.cs
@@ -1,0 +1,276 @@
+using System.IO;
+using System.Net.Http;
+using System.Net.WebSockets;
+using System.Text;
+using System.Text.Json;
+using System.Threading.Channels;
+
+namespace Clicky.Services;
+
+/// <summary>
+/// Streaming AssemblyAI realtime transcription over WebSocket (v3).
+/// Port of <c>AssemblyAIStreamingTranscriptionProvider.swift</c>.
+///
+/// Lifecycle:
+///   1. <see cref="StartAsync"/>  — fetches a temporary token from the
+///      Worker, opens the websocket with the required query params, and
+///      spawns a background receive loop.
+///   2. <see cref="AppendAudio"/> — caller pushes raw PCM16 little-endian
+///      16-kHz mono frames; they're forwarded as binary websocket messages.
+///   3. <see cref="RequestFinalTranscriptAsync"/> — sends <c>ForceEndpoint</c>
+///      to flush the partial into a final turn.
+///   4. <see cref="StopAsync"/>  — sends <c>Terminate</c>, closes the socket.
+///
+/// The class raises two events on a worker thread. Marshal to the UI thread
+/// at the call site if needed.
+/// </summary>
+public sealed class AssemblyAIStreamingClient : IAsyncDisposable
+{
+    private const int SampleRateHz = 16_000;
+    private const string SpeechModel = "u3-rt-pro";
+
+    private readonly HttpClient _tokenHttpClient = new() { Timeout = TimeSpan.FromSeconds(20) };
+    private ClientWebSocket? _webSocket;
+    private Task? _receiveLoopTask;
+    private Task? _sendLoopTask;
+    private CancellationTokenSource? _lifetimeCts;
+    private Channel<ReadOnlyMemory<byte>>? _audioChannel;
+
+    /// <summary>Partial or final transcript text — fires on every Turn message.</summary>
+    public event EventHandler<TranscriptEventArgs>? TranscriptUpdated;
+
+    /// <summary>Fires once when AssemblyAI signals end-of-turn (final transcript).</summary>
+    public event EventHandler<TranscriptEventArgs>? FinalTranscriptReady;
+
+    /// <summary>Fires if the session errors out (network, upstream rejection).</summary>
+    public event EventHandler<Exception>? SessionFaulted;
+
+    public bool IsRunning => _webSocket?.State == WebSocketState.Open;
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        var temporaryToken = await FetchTemporaryTokenAsync(cancellationToken).ConfigureAwait(false);
+        var websocketUri = BuildWebsocketUri(temporaryToken);
+
+        _lifetimeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _webSocket = new ClientWebSocket();
+        await _webSocket.ConnectAsync(websocketUri, _lifetimeCts.Token).ConfigureAwait(false);
+
+        _audioChannel = Channel.CreateUnbounded<ReadOnlyMemory<byte>>(new UnboundedChannelOptions
+        {
+            SingleReader = true,
+            SingleWriter = false,
+            AllowSynchronousContinuations = false,
+        });
+
+        _receiveLoopTask = Task.Run(() => RunReceiveLoopAsync(_lifetimeCts.Token));
+        _sendLoopTask = Task.Run(() => RunSendLoopAsync(_lifetimeCts.Token));
+    }
+
+    /// <summary>
+    /// Enqueue a PCM16 frame for transmission. Non-blocking — frames are
+    /// buffered in an unbounded channel and flushed by the background sender.
+    /// </summary>
+    public void AppendAudio(ReadOnlyMemory<byte> pcm16LittleEndianBytes)
+    {
+        _audioChannel?.Writer.TryWrite(pcm16LittleEndianBytes);
+    }
+
+    /// <summary>
+    /// Tells AssemblyAI to cut the current partial into a final turn without
+    /// waiting for natural silence. Used when the user releases push-to-talk.
+    /// </summary>
+    public async Task RequestFinalTranscriptAsync(CancellationToken cancellationToken)
+    {
+        if (_webSocket?.State != WebSocketState.Open) return;
+        var forceEndpointJson = Encoding.UTF8.GetBytes("{\"type\":\"ForceEndpoint\"}");
+        await _webSocket.SendAsync(forceEndpointJson, WebSocketMessageType.Text, endOfMessage: true, cancellationToken)
+            .ConfigureAwait(false);
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (_webSocket is null) return;
+
+        try
+        {
+            if (_webSocket.State == WebSocketState.Open)
+            {
+                var terminateJson = Encoding.UTF8.GetBytes("{\"type\":\"Terminate\"}");
+                await _webSocket.SendAsync(terminateJson, WebSocketMessageType.Text, endOfMessage: true, cancellationToken)
+                    .ConfigureAwait(false);
+                await _webSocket.CloseOutputAsync(WebSocketCloseStatus.NormalClosure, "client-terminate", cancellationToken)
+                    .ConfigureAwait(false);
+            }
+        }
+        catch (WebSocketException) { /* socket already closed — ignore */ }
+        catch (OperationCanceledException) { /* shutdown during cancel — ignore */ }
+
+        _lifetimeCts?.Cancel();
+        _audioChannel?.Writer.TryComplete();
+
+        try { if (_sendLoopTask is not null) await _sendLoopTask.ConfigureAwait(false); }
+        catch (OperationCanceledException) { /* expected */ }
+
+        try { if (_receiveLoopTask is not null) await _receiveLoopTask.ConfigureAwait(false); }
+        catch (OperationCanceledException) { /* expected */ }
+
+        _webSocket.Dispose();
+        _webSocket = null;
+    }
+
+    private async Task<string> FetchTemporaryTokenAsync(CancellationToken cancellationToken)
+    {
+        using var tokenRequest = new HttpRequestMessage(HttpMethod.Post, WorkerConfig.TranscribeTokenUrl);
+        using var tokenResponse = await _tokenHttpClient.SendAsync(tokenRequest, cancellationToken).ConfigureAwait(false);
+        tokenResponse.EnsureSuccessStatusCode();
+
+        var responseBody = await tokenResponse.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+        using var parsedDocument = JsonDocument.Parse(responseBody);
+        if (!parsedDocument.RootElement.TryGetProperty("token", out var tokenProperty))
+        {
+            throw new InvalidOperationException($"Token proxy response missing 'token' field: {responseBody}");
+        }
+
+        var tokenValue = tokenProperty.GetString();
+        if (string.IsNullOrWhiteSpace(tokenValue))
+        {
+            throw new InvalidOperationException("Token proxy returned an empty token.");
+        }
+        return tokenValue;
+    }
+
+    private static Uri BuildWebsocketUri(string temporaryToken)
+    {
+        var encodedToken = Uri.EscapeDataString(temporaryToken);
+        var queryString =
+            $"sample_rate={SampleRateHz}" +
+            $"&encoding=pcm_s16le" +
+            $"&format_turns=true" +
+            $"&speech_model={SpeechModel}" +
+            $"&token={encodedToken}";
+        return new Uri($"wss://streaming.assemblyai.com/v3/ws?{queryString}");
+    }
+
+    private async Task RunSendLoopAsync(CancellationToken cancellationToken)
+    {
+        if (_audioChannel is null || _webSocket is null) return;
+        var channelReader = _audioChannel.Reader;
+
+        try
+        {
+            while (await channelReader.WaitToReadAsync(cancellationToken).ConfigureAwait(false))
+            {
+                while (channelReader.TryRead(out var pcmFrame))
+                {
+                    if (_webSocket.State != WebSocketState.Open) return;
+                    await _webSocket.SendAsync(pcmFrame, WebSocketMessageType.Binary, endOfMessage: true, cancellationToken)
+                        .ConfigureAwait(false);
+                }
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown — ignore */ }
+        catch (WebSocketException webSocketException)
+        {
+            SessionFaulted?.Invoke(this, webSocketException);
+        }
+    }
+
+    private async Task RunReceiveLoopAsync(CancellationToken cancellationToken)
+    {
+        if (_webSocket is null) return;
+        var receiveBuffer = new byte[16 * 1024];
+        var messageBuffer = new MemoryStream();
+
+        try
+        {
+            while (_webSocket.State == WebSocketState.Open && !cancellationToken.IsCancellationRequested)
+            {
+                messageBuffer.SetLength(0);
+                WebSocketReceiveResult receiveResult;
+                do
+                {
+                    receiveResult = await _webSocket
+                        .ReceiveAsync(new ArraySegment<byte>(receiveBuffer), cancellationToken)
+                        .ConfigureAwait(false);
+
+                    if (receiveResult.MessageType == WebSocketMessageType.Close)
+                    {
+                        return;
+                    }
+
+                    messageBuffer.Write(receiveBuffer, 0, receiveResult.Count);
+                } while (!receiveResult.EndOfMessage);
+
+                if (receiveResult.MessageType != WebSocketMessageType.Text) continue;
+
+                var messageText = Encoding.UTF8.GetString(messageBuffer.GetBuffer(), 0, (int)messageBuffer.Length);
+                HandleIncomingMessage(messageText);
+            }
+        }
+        catch (OperationCanceledException) { /* shutdown — ignore */ }
+        catch (WebSocketException webSocketException)
+        {
+            SessionFaulted?.Invoke(this, webSocketException);
+        }
+    }
+
+    /// <summary>
+    /// Parses an AssemblyAI v3 realtime message. We only act on
+    /// <c>Turn</c> messages; session lifecycle (<c>Begin</c>,
+    /// <c>Termination</c>) doesn't need caller notification here.
+    /// </summary>
+    private void HandleIncomingMessage(string messageText)
+    {
+        try
+        {
+            using var parsedDocument = JsonDocument.Parse(messageText);
+            var rootObject = parsedDocument.RootElement;
+            if (!rootObject.TryGetProperty("type", out var typeProperty)) return;
+
+            var messageType = typeProperty.GetString();
+            if (messageType != "Turn") return;
+
+            var transcriptText = rootObject.TryGetProperty("transcript", out var transcriptProperty)
+                ? transcriptProperty.GetString() ?? string.Empty
+                : string.Empty;
+
+            var isEndOfTurn = rootObject.TryGetProperty("end_of_turn", out var endOfTurnProperty)
+                && endOfTurnProperty.ValueKind == JsonValueKind.True;
+            var isFormatted = rootObject.TryGetProperty("turn_is_formatted", out var formattedProperty)
+                && formattedProperty.ValueKind == JsonValueKind.True;
+            var isFinal = isEndOfTurn || isFormatted;
+
+            var eventArgs = new TranscriptEventArgs(transcriptText, isFinal);
+            TranscriptUpdated?.Invoke(this, eventArgs);
+            if (isFinal)
+            {
+                FinalTranscriptReady?.Invoke(this, eventArgs);
+            }
+        }
+        catch (JsonException)
+        {
+            // Malformed message — ignore rather than fault the session;
+            // AssemblyAI occasionally emits empty keepalive frames.
+        }
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync(CancellationToken.None).ConfigureAwait(false);
+        _lifetimeCts?.Dispose();
+        _tokenHttpClient.Dispose();
+    }
+}
+
+public sealed class TranscriptEventArgs : EventArgs
+{
+    public TranscriptEventArgs(string transcript, bool isFinal)
+    {
+        Transcript = transcript;
+        IsFinal = isFinal;
+    }
+
+    public string Transcript { get; }
+    public bool IsFinal { get; }
+}

--- a/windows/Clicky/Services/ClaudeClient.cs
+++ b/windows/Clicky/Services/ClaudeClient.cs
@@ -142,7 +142,10 @@ public sealed class ClaudeClient : IChatClient, IDisposable
             messageArray.Add(new { role = "assistant", content = historicalTurn.AssistantMessage });
         }
 
-        var latestUserContentParts = new List<object>(images.Count + 1);
+        // Each image is followed by a text part carrying its label so the
+        // model can distinguish multiple screens (e.g. "screen 1 of 2 — …").
+        // Mirrors the macOS ClaudeAPI.analyzeImageStreaming payload shape.
+        var latestUserContentParts = new List<object>(images.Count * 2 + 1);
         foreach (var image in images)
         {
             latestUserContentParts.Add(new
@@ -155,6 +158,10 @@ public sealed class ClaudeClient : IChatClient, IDisposable
                     data = Convert.ToBase64String(image.Data),
                 },
             });
+            if (!string.IsNullOrEmpty(image.Label))
+            {
+                latestUserContentParts.Add(new { type = "text", text = image.Label });
+            }
         }
         latestUserContentParts.Add(new { type = "text", text = userPrompt });
         messageArray.Add(new { role = "user", content = latestUserContentParts });

--- a/windows/Clicky/Services/ClaudeClient.cs
+++ b/windows/Clicky/Services/ClaudeClient.cs
@@ -1,0 +1,178 @@
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Clicky.Services;
+
+/// <summary>
+/// Streaming Anthropic Messages client. Talks to the Cloudflare Worker's
+/// <c>/chat</c> route — the Worker injects the API key and forwards the
+/// SSE stream unchanged. Port of <c>ClaudeAPI.swift</c>.
+/// </summary>
+public sealed class ClaudeClient : IChatClient, IDisposable
+{
+    public const string DefaultModel = "claude-sonnet-4-6";
+    private const int MaxOutputTokens = 1024;
+
+    private readonly HttpClient _httpClient;
+    private readonly bool _ownsHttpClient;
+
+    public string Model { get; set; }
+
+    public ClaudeClient(string model = DefaultModel, HttpClient? httpClient = null)
+    {
+        Model = model;
+        if (httpClient is null)
+        {
+            _httpClient = new HttpClient { Timeout = Timeout.InfiniteTimeSpan };
+            _ownsHttpClient = true;
+        }
+        else
+        {
+            _httpClient = httpClient;
+            _ownsHttpClient = false;
+        }
+    }
+
+    public async Task<ChatStreamResult> StreamChatAsync(
+        string systemPrompt,
+        IReadOnlyList<ConversationTurn> conversationHistory,
+        string userPrompt,
+        IReadOnlyList<InlineImage> images,
+        Action<string> onTextChunk,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        var requestPayload = BuildRequestPayload(systemPrompt, conversationHistory, userPrompt, images);
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Post, WorkerConfig.ChatClaudeUrl)
+        {
+            Content = new StringContent(requestPayload, Encoding.UTF8, "application/json"),
+        };
+        requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        using var responseMessage = await _httpClient
+            .SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!responseMessage.IsSuccessStatusCode)
+        {
+            var errorBody = await responseMessage.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            throw new HttpRequestException(
+                $"Claude proxy returned {(int)responseMessage.StatusCode}: {errorBody}");
+        }
+
+        await using var responseStream = await responseMessage.Content
+            .ReadAsStreamAsync(cancellationToken)
+            .ConfigureAwait(false);
+        using var streamReader = new StreamReader(responseStream, Encoding.UTF8);
+
+        var accumulatedText = new StringBuilder();
+
+        // SSE frames are separated by blank lines. Within a frame we care
+        // about the `data:` lines; Anthropic also emits `event:` lines but
+        // the JSON payload carries its own `type` so we don't need them.
+        string? currentLine;
+        while ((currentLine = await streamReader.ReadLineAsync(cancellationToken).ConfigureAwait(false)) is not null)
+        {
+            if (currentLine.Length == 0) continue;
+            if (!currentLine.StartsWith("data:", StringComparison.Ordinal)) continue;
+
+            var jsonPayload = currentLine.AsSpan(5).TrimStart().ToString();
+            if (jsonPayload == "[DONE]") break;
+            if (jsonPayload.Length == 0) continue;
+
+            var chunk = ParseTextDelta(jsonPayload);
+            if (chunk.Length > 0)
+            {
+                accumulatedText.Append(chunk);
+                onTextChunk(chunk);
+            }
+        }
+
+        stopwatch.Stop();
+        return new ChatStreamResult(accumulatedText.ToString(), stopwatch.Elapsed);
+    }
+
+    /// <summary>
+    /// Extracts the <c>delta.text</c> string from an Anthropic streaming
+    /// payload, or returns empty if this event type doesn't carry text.
+    /// Anthropic emits many event types (<c>message_start</c>,
+    /// <c>content_block_start</c>, <c>ping</c>, <c>message_delta</c>, etc.)
+    /// — we only act on <c>content_block_delta</c> with a
+    /// <c>text_delta</c> payload, which mirrors the macOS client.
+    /// </summary>
+    private static string ParseTextDelta(string jsonPayload)
+    {
+        try
+        {
+            using var parsedDocument = JsonDocument.Parse(jsonPayload);
+            var rootObject = parsedDocument.RootElement;
+            if (!rootObject.TryGetProperty("type", out var typeProperty)) return string.Empty;
+            if (typeProperty.GetString() != "content_block_delta") return string.Empty;
+            if (!rootObject.TryGetProperty("delta", out var deltaProperty)) return string.Empty;
+            if (!deltaProperty.TryGetProperty("type", out var deltaTypeProperty)) return string.Empty;
+            if (deltaTypeProperty.GetString() != "text_delta") return string.Empty;
+            if (!deltaProperty.TryGetProperty("text", out var textProperty)) return string.Empty;
+            return textProperty.GetString() ?? string.Empty;
+        }
+        catch (JsonException)
+        {
+            return string.Empty;
+        }
+    }
+
+    private string BuildRequestPayload(
+        string systemPrompt,
+        IReadOnlyList<ConversationTurn> conversationHistory,
+        string userPrompt,
+        IReadOnlyList<InlineImage> images)
+    {
+        // Anthropic accepts either a plain string or an array of content
+        // parts. We use the array form for the latest user turn so we can
+        // include images; historical turns have no images and can stay
+        // as plain strings to keep the payload compact.
+        var messageArray = new List<object>(conversationHistory.Count * 2 + 1);
+        foreach (var historicalTurn in conversationHistory)
+        {
+            messageArray.Add(new { role = "user", content = historicalTurn.UserMessage });
+            messageArray.Add(new { role = "assistant", content = historicalTurn.AssistantMessage });
+        }
+
+        var latestUserContentParts = new List<object>(images.Count + 1);
+        foreach (var image in images)
+        {
+            latestUserContentParts.Add(new
+            {
+                type = "image",
+                source = new
+                {
+                    type = "base64",
+                    media_type = image.MimeType,
+                    data = Convert.ToBase64String(image.Data),
+                },
+            });
+        }
+        latestUserContentParts.Add(new { type = "text", text = userPrompt });
+        messageArray.Add(new { role = "user", content = latestUserContentParts });
+
+        var requestObject = new
+        {
+            model = Model,
+            max_tokens = MaxOutputTokens,
+            stream = true,
+            system = systemPrompt,
+            messages = messageArray,
+        };
+
+        return JsonSerializer.Serialize(requestObject);
+    }
+
+    public void Dispose()
+    {
+        if (_ownsHttpClient) _httpClient.Dispose();
+    }
+}

--- a/windows/Clicky/Services/ClickyAnalytics.cs
+++ b/windows/Clicky/Services/ClickyAnalytics.cs
@@ -1,0 +1,150 @@
+using System.Diagnostics;
+using System.Net.Http;
+using System.Reflection;
+using System.Text;
+using System.Text.Json;
+
+namespace Clicky.Services;
+
+/// <summary>
+/// Fire-and-forget PostHog client. Mirrors the event surface of the macOS
+/// <c>ClickyAnalytics.swift</c> so the two clients show up side-by-side in
+/// the same PostHog project.
+///
+/// Calls POST directly to <c>/capture/</c> — one small HTTP request per
+/// event, no batching — which is plenty for the event volume a single
+/// desktop app produces. The whole class is a no-op unless
+/// <see cref="Configure"/> has been called with a real write key; swap the
+/// placeholder in <see cref="WorkerConfig.PostHogWriteKey"/> to turn on.
+///
+/// Thread-safety: every method is safe to call from any thread. Failures
+/// never propagate — analytics must never break the app.
+/// </summary>
+public static class ClickyAnalytics
+{
+    private const string PlaceholderWriteKey = "phc_YOUR_POSTHOG_WRITE_KEY_HERE";
+
+    private static readonly JsonSerializerOptions JsonOptions = new()
+    {
+        DefaultIgnoreCondition = System.Text.Json.Serialization.JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private static HttpClient? _httpClient;
+    private static string? _distinctId;
+    private static string? _appVersion;
+    private static bool _isEnabled;
+
+    /// <summary>
+    /// Wires the PostHog client with the persisted distinct-id. Idempotent —
+    /// safe to call more than once. Fires <c>app_opened</c> as soon as the
+    /// first call succeeds.
+    /// </summary>
+    public static void Configure(string distinctId)
+    {
+        if (_httpClient is not null) return;
+
+        if (string.IsNullOrWhiteSpace(WorkerConfig.PostHogWriteKey)
+            || string.Equals(WorkerConfig.PostHogWriteKey, PlaceholderWriteKey, StringComparison.Ordinal))
+        {
+            _isEnabled = false;
+            return;
+        }
+
+        _httpClient = new HttpClient
+        {
+            Timeout = TimeSpan.FromSeconds(10),
+        };
+        _distinctId = distinctId;
+        _appVersion = Assembly.GetExecutingAssembly().GetName().Version?.ToString() ?? "unknown";
+        _isEnabled = true;
+
+        TrackAppOpened();
+    }
+
+    // ---- Event helpers (one per macOS ClickyAnalytics case) ----
+
+    public static void TrackAppOpened() => Track("app_opened");
+    public static void TrackOnboardingStarted() => Track("onboarding_started");
+    public static void TrackOnboardingReplayed() => Track("onboarding_replayed");
+    public static void TrackOnboardingCompleted() => Track("onboarding_completed");
+
+    public static void TrackPermissionGranted(string permissionName) =>
+        Track("permission_granted", ("permission", permissionName));
+
+    public static void TrackAllPermissionsGranted() => Track("all_permissions_granted");
+
+    public static void TrackPermissionDenied(string permissionName) =>
+        Track("permission_denied", ("permission", permissionName));
+
+    public static void TrackPushToTalkStarted() => Track("push_to_talk_started");
+    public static void TrackPushToTalkReleased() => Track("push_to_talk_released");
+
+    public static void TrackUserMessageSent(string transcript) =>
+        Track("user_message_sent",
+            ("transcript", transcript),
+            ("character_count", transcript.Length));
+
+    public static void TrackAiResponseReceived(string responseText, string modelId) =>
+        Track("ai_response_received",
+            ("response_text", responseText),
+            ("character_count", responseText.Length),
+            ("model", modelId));
+
+    public static void TrackElementPointed(string? elementLabel, int? screenNumber) =>
+        Track("element_pointed",
+            ("element_label", elementLabel ?? string.Empty),
+            ("screen_number", screenNumber ?? 1));
+
+    public static void TrackResponseError(string errorMessage) =>
+        Track("response_error", ("error", errorMessage));
+
+    public static void TrackTtsError(string errorMessage) =>
+        Track("tts_error", ("error", errorMessage));
+
+    // ---- Core capture ----
+
+    private static void Track(string eventName, params (string Key, object? Value)[] extraProperties)
+    {
+        if (!_isEnabled || _httpClient is null || _distinctId is null) return;
+
+        var properties = new Dictionary<string, object?>
+        {
+            ["$os"] = "Windows",
+            ["$os_version"] = Environment.OSVersion.Version.ToString(),
+            ["app_version"] = _appVersion ?? "unknown",
+            ["platform"] = "windows",
+        };
+        foreach (var (key, value) in extraProperties)
+        {
+            properties[key] = value;
+        }
+
+        var payload = new
+        {
+            api_key = WorkerConfig.PostHogWriteKey,
+            @event = eventName,
+            distinct_id = _distinctId,
+            properties,
+            timestamp = DateTimeOffset.UtcNow.ToString("o"),
+        };
+
+        // Fire-and-forget. Log failures to debug output only — analytics
+        // must not surface errors to the user or break the flow.
+        _ = Task.Run(async () =>
+        {
+            try
+            {
+                var json = JsonSerializer.Serialize(payload, JsonOptions);
+                using var content = new StringContent(json, Encoding.UTF8, "application/json");
+                using var response = await _httpClient.PostAsync(WorkerConfig.PostHogCaptureUrl, content)
+                    .ConfigureAwait(false);
+                // Don't throw on non-success; PostHog returns 200 with an
+                // error body when rate-limited or misconfigured.
+            }
+            catch (Exception ex)
+            {
+                Debug.WriteLine($"[ClickyAnalytics] capture failed: {ex.Message}");
+            }
+        });
+    }
+}

--- a/windows/Clicky/Services/DictationSession.cs
+++ b/windows/Clicky/Services/DictationSession.cs
@@ -1,0 +1,142 @@
+namespace Clicky.Services;
+
+/// <summary>
+/// Bridges <see cref="MicrophoneCaptureService"/> to
+/// <see cref="AssemblyAIStreamingClient"/> and exposes a simple
+/// start/finalize/stop API for the orchestrator. Equivalent role to the
+/// macOS <c>BuddyDictationManager</c> — minus the Apple-speech fallback
+/// since Windows only ships with AssemblyAI in M2.
+/// </summary>
+public sealed class DictationSession : IAsyncDisposable
+{
+    /// <summary>Fallback window — if AssemblyAI hasn't emitted a final
+    /// transcript within this time after <see cref="RequestFinalTranscriptAsync"/>,
+    /// the session resolves with whatever partial it last saw. Matches the
+    /// 2.8 s fallback in the macOS provider.</summary>
+    private static readonly TimeSpan FinalTranscriptFallback = TimeSpan.FromSeconds(2.8);
+
+    private readonly MicrophoneCaptureService _microphoneCaptureService;
+    private readonly AssemblyAIStreamingClient _assemblyAIStreamingClient;
+
+    private string _latestPartialTranscript = string.Empty;
+    private TaskCompletionSource<string>? _finalTranscriptCompletionSource;
+    private CancellationTokenSource? _sessionLifetimeCts;
+
+    public event EventHandler<string>? PartialTranscriptUpdated;
+    public event EventHandler<Exception>? SessionFaulted;
+
+    public bool IsActive { get; private set; }
+
+    public DictationSession()
+    {
+        _microphoneCaptureService = new MicrophoneCaptureService();
+        _assemblyAIStreamingClient = new AssemblyAIStreamingClient();
+    }
+
+    public async Task StartAsync(CancellationToken cancellationToken)
+    {
+        if (IsActive) return;
+
+        _sessionLifetimeCts = CancellationTokenSource.CreateLinkedTokenSource(cancellationToken);
+        _latestPartialTranscript = string.Empty;
+        _finalTranscriptCompletionSource = null;
+
+        _assemblyAIStreamingClient.TranscriptUpdated += OnAssemblyAITranscriptUpdated;
+        _assemblyAIStreamingClient.FinalTranscriptReady += OnAssemblyAIFinalTranscriptReady;
+        _assemblyAIStreamingClient.SessionFaulted += OnUpstreamSessionFaulted;
+
+        _microphoneCaptureService.AudioFrameCaptured += OnMicrophoneAudioFrameCaptured;
+        _microphoneCaptureService.CaptureFaulted += OnUpstreamSessionFaulted;
+
+        // Open the websocket first — if this throws, the mic never starts.
+        await _assemblyAIStreamingClient.StartAsync(_sessionLifetimeCts.Token).ConfigureAwait(false);
+        _microphoneCaptureService.Start();
+
+        IsActive = true;
+    }
+
+    /// <summary>
+    /// Called on push-to-talk release. Stops the mic (so no more audio is
+    /// sent), asks AssemblyAI to finalize the current turn, and awaits the
+    /// final transcript — with a fallback to the last partial if the
+    /// websocket doesn't echo a final within the grace window.
+    /// </summary>
+    public async Task<string> RequestFinalTranscriptAsync(CancellationToken cancellationToken)
+    {
+        if (!IsActive) return string.Empty;
+
+        _microphoneCaptureService.Stop();
+
+        _finalTranscriptCompletionSource = new TaskCompletionSource<string>(
+            TaskCreationOptions.RunContinuationsAsynchronously);
+
+        try
+        {
+            await _assemblyAIStreamingClient.RequestFinalTranscriptAsync(cancellationToken).ConfigureAwait(false);
+        }
+        catch (Exception requestException)
+        {
+            SessionFaulted?.Invoke(this, requestException);
+            return _latestPartialTranscript;
+        }
+
+        // Wait for FinalTranscriptReady or the fallback timer.
+        using var fallbackCts = new CancellationTokenSource(FinalTranscriptFallback);
+        using var registration = fallbackCts.Token.Register(() =>
+            _finalTranscriptCompletionSource?.TrySetResult(_latestPartialTranscript));
+
+        return await _finalTranscriptCompletionSource.Task.ConfigureAwait(false);
+    }
+
+    public async Task StopAsync(CancellationToken cancellationToken)
+    {
+        if (!IsActive) return;
+        IsActive = false;
+
+        _microphoneCaptureService.Stop();
+        await _assemblyAIStreamingClient.StopAsync(cancellationToken).ConfigureAwait(false);
+
+        _assemblyAIStreamingClient.TranscriptUpdated -= OnAssemblyAITranscriptUpdated;
+        _assemblyAIStreamingClient.FinalTranscriptReady -= OnAssemblyAIFinalTranscriptReady;
+        _assemblyAIStreamingClient.SessionFaulted -= OnUpstreamSessionFaulted;
+        _microphoneCaptureService.AudioFrameCaptured -= OnMicrophoneAudioFrameCaptured;
+        _microphoneCaptureService.CaptureFaulted -= OnUpstreamSessionFaulted;
+
+        _sessionLifetimeCts?.Cancel();
+        _sessionLifetimeCts?.Dispose();
+        _sessionLifetimeCts = null;
+    }
+
+    private void OnMicrophoneAudioFrameCaptured(object? sender, ReadOnlyMemory<byte> frameBytes)
+    {
+        _assemblyAIStreamingClient.AppendAudio(frameBytes);
+    }
+
+    private void OnAssemblyAITranscriptUpdated(object? sender, TranscriptEventArgs args)
+    {
+        if (args.Transcript.Length > 0)
+        {
+            _latestPartialTranscript = args.Transcript;
+        }
+        PartialTranscriptUpdated?.Invoke(this, _latestPartialTranscript);
+    }
+
+    private void OnAssemblyAIFinalTranscriptReady(object? sender, TranscriptEventArgs args)
+    {
+        var finalText = args.Transcript.Length > 0 ? args.Transcript : _latestPartialTranscript;
+        _finalTranscriptCompletionSource?.TrySetResult(finalText);
+    }
+
+    private void OnUpstreamSessionFaulted(object? sender, Exception exception)
+    {
+        SessionFaulted?.Invoke(this, exception);
+        _finalTranscriptCompletionSource?.TrySetResult(_latestPartialTranscript);
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        await StopAsync(CancellationToken.None).ConfigureAwait(false);
+        _microphoneCaptureService.Dispose();
+        await _assemblyAIStreamingClient.DisposeAsync().ConfigureAwait(false);
+    }
+}

--- a/windows/Clicky/Services/ElevenLabsTtsClient.cs
+++ b/windows/Clicky/Services/ElevenLabsTtsClient.cs
@@ -1,0 +1,151 @@
+using System.IO;
+using System.Net.Http;
+using System.Text;
+using System.Text.Json;
+using NAudio.Wave;
+
+namespace Clicky.Services;
+
+/// <summary>
+/// Port of <c>ElevenLabsTTSClient.swift</c>. Posts the caption text to the
+/// Worker's <c>/tts</c> route, receives an MP3 stream, and plays it through
+/// the default output device via NAudio. Only one utterance plays at a
+/// time — a new call cancels the previous playback.
+/// </summary>
+public sealed class ElevenLabsTtsClient : IDisposable
+{
+    private const string ElevenLabsModel = "eleven_flash_v2_5";
+    private const double VoiceStability = 0.5;
+    private const double VoiceSimilarityBoost = 0.75;
+
+    private readonly HttpClient _httpClient;
+    private readonly bool _ownsHttpClient;
+
+    private readonly object _playbackLock = new();
+    private WaveOutEvent? _activeWaveOut;
+    private Mp3FileReader? _activeMp3Reader;
+    private MemoryStream? _activeMp3Stream;
+
+    public event EventHandler? PlaybackFinished;
+
+    public bool IsPlaying
+    {
+        get
+        {
+            lock (_playbackLock)
+            {
+                return _activeWaveOut?.PlaybackState == PlaybackState.Playing;
+            }
+        }
+    }
+
+    public ElevenLabsTtsClient(HttpClient? httpClient = null)
+    {
+        if (httpClient is null)
+        {
+            _httpClient = new HttpClient { Timeout = TimeSpan.FromSeconds(30) };
+            _ownsHttpClient = true;
+        }
+        else
+        {
+            _httpClient = httpClient;
+            _ownsHttpClient = false;
+        }
+    }
+
+    public async Task SpeakAsync(string caption, CancellationToken cancellationToken)
+    {
+        if (string.IsNullOrWhiteSpace(caption)) return;
+
+        var requestPayload = JsonSerializer.Serialize(new
+        {
+            text = caption,
+            model_id = ElevenLabsModel,
+            voice_settings = new
+            {
+                stability = VoiceStability,
+                similarity_boost = VoiceSimilarityBoost,
+            },
+        });
+
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Post, WorkerConfig.TtsUrl)
+        {
+            Content = new StringContent(requestPayload, Encoding.UTF8, "application/json"),
+        };
+
+        using var responseMessage = await _httpClient
+            .SendAsync(requestMessage, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!responseMessage.IsSuccessStatusCode)
+        {
+            var errorBody = await responseMessage.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            throw new HttpRequestException(
+                $"ElevenLabs proxy returned {(int)responseMessage.StatusCode}: {errorBody}");
+        }
+
+        var mp3Bytes = await responseMessage.Content.ReadAsByteArrayAsync(cancellationToken).ConfigureAwait(false);
+        StartPlayback(mp3Bytes);
+    }
+
+    public void StopPlayback()
+    {
+        lock (_playbackLock)
+        {
+            TeardownCurrentPlaybackLocked();
+        }
+    }
+
+    private void StartPlayback(byte[] mp3Bytes)
+    {
+        lock (_playbackLock)
+        {
+            TeardownCurrentPlaybackLocked();
+
+            // Ownership of these disposables transfers to the field until
+            // PlaybackStopped fires — the stream must outlive the reader.
+            var mp3Stream = new MemoryStream(mp3Bytes, writable: false);
+            var mp3Reader = new Mp3FileReader(mp3Stream);
+            var waveOut = new WaveOutEvent();
+            waveOut.Init(mp3Reader);
+
+            waveOut.PlaybackStopped += OnWaveOutPlaybackStopped;
+
+            _activeMp3Stream = mp3Stream;
+            _activeMp3Reader = mp3Reader;
+            _activeWaveOut = waveOut;
+
+            waveOut.Play();
+        }
+    }
+
+    private void OnWaveOutPlaybackStopped(object? sender, StoppedEventArgs stoppedEventArgs)
+    {
+        lock (_playbackLock)
+        {
+            TeardownCurrentPlaybackLocked();
+        }
+        PlaybackFinished?.Invoke(this, EventArgs.Empty);
+    }
+
+    private void TeardownCurrentPlaybackLocked()
+    {
+        if (_activeWaveOut is not null)
+        {
+            _activeWaveOut.PlaybackStopped -= OnWaveOutPlaybackStopped;
+            try { _activeWaveOut.Stop(); } catch { /* already stopped */ }
+            _activeWaveOut.Dispose();
+            _activeWaveOut = null;
+        }
+        _activeMp3Reader?.Dispose();
+        _activeMp3Reader = null;
+        _activeMp3Stream?.Dispose();
+        _activeMp3Stream = null;
+    }
+
+    public void Dispose()
+    {
+        StopPlayback();
+        if (_ownsHttpClient) _httpClient.Dispose();
+    }
+}

--- a/windows/Clicky/Services/GeminiClient.cs
+++ b/windows/Clicky/Services/GeminiClient.cs
@@ -1,0 +1,191 @@
+using System.Diagnostics;
+using System.IO;
+using System.Net.Http;
+using System.Net.Http.Headers;
+using System.Text;
+using System.Text.Json;
+
+namespace Clicky.Services;
+
+/// <summary>
+/// Streaming Google Gemini client. Talks to the Cloudflare Worker's
+/// <c>/chat-gemini</c> route. The Worker extracts the <c>model</c> field
+/// from the body (Gemini requires it in the URL path) and forwards the
+/// rest. Port of <c>GeminiAPI.swift</c>.
+/// </summary>
+public sealed class GeminiClient : IChatClient, IDisposable
+{
+    public const string DefaultModel = "gemini-2.5-flash";
+    private const int MaxOutputTokens = 1024;
+
+    private readonly HttpClient _httpClient;
+    private readonly bool _ownsHttpClient;
+
+    public string Model { get; set; }
+
+    public GeminiClient(string model = DefaultModel, HttpClient? httpClient = null)
+    {
+        Model = model;
+        if (httpClient is null)
+        {
+            _httpClient = new HttpClient { Timeout = Timeout.InfiniteTimeSpan };
+            _ownsHttpClient = true;
+        }
+        else
+        {
+            _httpClient = httpClient;
+            _ownsHttpClient = false;
+        }
+    }
+
+    public async Task<ChatStreamResult> StreamChatAsync(
+        string systemPrompt,
+        IReadOnlyList<ConversationTurn> conversationHistory,
+        string userPrompt,
+        IReadOnlyList<InlineImage> images,
+        Action<string> onTextChunk,
+        CancellationToken cancellationToken)
+    {
+        var stopwatch = Stopwatch.StartNew();
+
+        var requestPayload = BuildRequestPayload(systemPrompt, conversationHistory, userPrompt, images);
+        using var requestMessage = new HttpRequestMessage(HttpMethod.Post, WorkerConfig.ChatGeminiUrl)
+        {
+            Content = new StringContent(requestPayload, Encoding.UTF8, "application/json"),
+        };
+        requestMessage.Headers.Accept.Add(new MediaTypeWithQualityHeaderValue("text/event-stream"));
+
+        using var responseMessage = await _httpClient
+            .SendAsync(requestMessage, HttpCompletionOption.ResponseHeadersRead, cancellationToken)
+            .ConfigureAwait(false);
+
+        if (!responseMessage.IsSuccessStatusCode)
+        {
+            var errorBody = await responseMessage.Content.ReadAsStringAsync(cancellationToken).ConfigureAwait(false);
+            throw new HttpRequestException(
+                $"Gemini proxy returned {(int)responseMessage.StatusCode}: {errorBody}");
+        }
+
+        await using var responseStream = await responseMessage.Content
+            .ReadAsStreamAsync(cancellationToken)
+            .ConfigureAwait(false);
+        using var streamReader = new StreamReader(responseStream, Encoding.UTF8);
+
+        var accumulatedText = new StringBuilder();
+
+        string? currentLine;
+        while ((currentLine = await streamReader.ReadLineAsync(cancellationToken).ConfigureAwait(false)) is not null)
+        {
+            if (currentLine.Length == 0) continue;
+            if (!currentLine.StartsWith("data:", StringComparison.Ordinal)) continue;
+
+            var jsonPayload = currentLine.AsSpan(5).TrimStart().ToString();
+            if (jsonPayload.Length == 0) continue;
+
+            var chunk = ExtractTextFromGeminiChunk(jsonPayload);
+            if (chunk.Length > 0)
+            {
+                accumulatedText.Append(chunk);
+                onTextChunk(chunk);
+            }
+        }
+
+        stopwatch.Stop();
+        return new ChatStreamResult(accumulatedText.ToString(), stopwatch.Elapsed);
+    }
+
+    /// <summary>
+    /// Reads <c>candidates[0].content.parts[*].text</c> from a Gemini SSE
+    /// chunk and concatenates all text parts. Gemini may split a single
+    /// emission across multiple parts.
+    /// </summary>
+    private static string ExtractTextFromGeminiChunk(string jsonPayload)
+    {
+        try
+        {
+            using var parsedDocument = JsonDocument.Parse(jsonPayload);
+            var rootObject = parsedDocument.RootElement;
+            if (!rootObject.TryGetProperty("candidates", out var candidatesProperty)) return string.Empty;
+            if (candidatesProperty.ValueKind != JsonValueKind.Array || candidatesProperty.GetArrayLength() == 0) return string.Empty;
+            var firstCandidate = candidatesProperty[0];
+            if (!firstCandidate.TryGetProperty("content", out var contentProperty)) return string.Empty;
+            if (!contentProperty.TryGetProperty("parts", out var partsProperty)) return string.Empty;
+            if (partsProperty.ValueKind != JsonValueKind.Array) return string.Empty;
+
+            var combinedTextBuilder = new StringBuilder();
+            foreach (var singlePart in partsProperty.EnumerateArray())
+            {
+                if (singlePart.TryGetProperty("text", out var textProperty) && textProperty.ValueKind == JsonValueKind.String)
+                {
+                    combinedTextBuilder.Append(textProperty.GetString());
+                }
+            }
+            return combinedTextBuilder.ToString();
+        }
+        catch (JsonException)
+        {
+            return string.Empty;
+        }
+    }
+
+    private string BuildRequestPayload(
+        string systemPrompt,
+        IReadOnlyList<ConversationTurn> conversationHistory,
+        string userPrompt,
+        IReadOnlyList<InlineImage> images)
+    {
+        // Gemini's roles are "user" and "model" (not "assistant"). System
+        // instructions ride in a separate top-level field. Inline images
+        // use `inline_data` with snake_case field names.
+        var contentsArray = new List<object>(conversationHistory.Count * 2 + 1);
+        foreach (var historicalTurn in conversationHistory)
+        {
+            contentsArray.Add(new
+            {
+                role = "user",
+                parts = new object[] { new { text = historicalTurn.UserMessage } },
+            });
+            contentsArray.Add(new
+            {
+                role = "model",
+                parts = new object[] { new { text = historicalTurn.AssistantMessage } },
+            });
+        }
+
+        var latestUserParts = new List<object>(images.Count + 1);
+        foreach (var image in images)
+        {
+            latestUserParts.Add(new
+            {
+                inline_data = new
+                {
+                    mime_type = image.MimeType,
+                    data = Convert.ToBase64String(image.Data),
+                },
+            });
+        }
+        latestUserParts.Add(new { text = userPrompt });
+        contentsArray.Add(new { role = "user", parts = latestUserParts });
+
+        var requestObject = new
+        {
+            model = Model,
+            systemInstruction = new
+            {
+                parts = new object[] { new { text = systemPrompt } },
+            },
+            contents = contentsArray,
+            generationConfig = new
+            {
+                maxOutputTokens = MaxOutputTokens,
+            },
+        };
+
+        return JsonSerializer.Serialize(requestObject);
+    }
+
+    public void Dispose()
+    {
+        if (_ownsHttpClient) _httpClient.Dispose();
+    }
+}

--- a/windows/Clicky/Services/GeminiClient.cs
+++ b/windows/Clicky/Services/GeminiClient.cs
@@ -152,7 +152,9 @@ public sealed class GeminiClient : IChatClient, IDisposable
             });
         }
 
-        var latestUserParts = new List<object>(images.Count + 1);
+        // Each inline_data image is followed by a text part carrying its
+        // label, matching the macOS GeminiAPI.analyzeImageStreaming payload.
+        var latestUserParts = new List<object>(images.Count * 2 + 1);
         foreach (var image in images)
         {
             latestUserParts.Add(new
@@ -163,6 +165,10 @@ public sealed class GeminiClient : IChatClient, IDisposable
                     data = Convert.ToBase64String(image.Data),
                 },
             });
+            if (!string.IsNullOrEmpty(image.Label))
+            {
+                latestUserParts.Add(new { text = image.Label });
+            }
         }
         latestUserParts.Add(new { text = userPrompt });
         contentsArray.Add(new { role = "user", parts = latestUserParts });

--- a/windows/Clicky/Services/GlobalHotkeyService.cs
+++ b/windows/Clicky/Services/GlobalHotkeyService.cs
@@ -1,0 +1,145 @@
+using System.Diagnostics;
+using System.Runtime.InteropServices;
+using System.Windows.Input;
+using Clicky.Interop;
+
+namespace Clicky.Services;
+
+/// <summary>
+/// Detects the push-to-talk shortcut (Ctrl+Alt by default) system-wide via a
+/// low-level keyboard hook. This is the Windows analog of the macOS CGEvent
+/// tap used in GlobalPushToTalkShortcutMonitor.swift.
+///
+/// The hook is listen-only — we do NOT swallow the keys, so Ctrl+Alt combos
+/// still reach other apps normally. Users can hold Ctrl+Alt to talk to Clicky
+/// without breaking their current app's keyboard handling.
+///
+/// Events are raised on the thread that installed the hook (the UI thread).
+/// Subscribers should keep handlers short to avoid stalling global keyboard
+/// delivery — dispatch heavy work off-thread immediately.
+/// </summary>
+public sealed class GlobalHotkeyService : IDisposable
+{
+    private IntPtr _hookHandle = IntPtr.Zero;
+
+    // Held as a field so the GC doesn't collect the delegate while the hook
+    // is installed — that would cause a nasty access violation in user32.dll.
+    private NativeMethods.LowLevelKeyboardProc? _hookCallback;
+
+    private bool _isCtrlHeld;
+    private bool _isAltHeld;
+    private bool _isShortcutActive;
+
+    /// <summary>
+    /// Raised when the push-to-talk combination transitions to held.
+    /// Subscribers should begin recording immediately.
+    /// </summary>
+    public event EventHandler? ShortcutPressed;
+
+    /// <summary>
+    /// Raised when either modifier in the push-to-talk combination is released.
+    /// Subscribers should finalize the recording and submit the transcript.
+    /// </summary>
+    public event EventHandler? ShortcutReleased;
+
+    public void Start()
+    {
+        if (_hookHandle != IntPtr.Zero)
+        {
+            return;
+        }
+
+        _hookCallback = HookCallback;
+        using var process = Process.GetCurrentProcess();
+        using var module = process.MainModule
+            ?? throw new InvalidOperationException("Cannot read main module for hook installation.");
+        var moduleHandle = NativeMethods.GetModuleHandle(module.ModuleName);
+
+        _hookHandle = NativeMethods.SetWindowsHookEx(
+            NativeMethods.WH_KEYBOARD_LL,
+            _hookCallback,
+            moduleHandle,
+            0);
+
+        if (_hookHandle == IntPtr.Zero)
+        {
+            throw new InvalidOperationException(
+                $"Failed to install low-level keyboard hook (GetLastError={Marshal.GetLastWin32Error()}).");
+        }
+    }
+
+    public void Stop()
+    {
+        if (_hookHandle == IntPtr.Zero)
+        {
+            return;
+        }
+
+        NativeMethods.UnhookWindowsHookEx(_hookHandle);
+        _hookHandle = IntPtr.Zero;
+        _hookCallback = null;
+        _isCtrlHeld = false;
+        _isAltHeld = false;
+        _isShortcutActive = false;
+    }
+
+    public void Dispose() => Stop();
+
+    private IntPtr HookCallback(int nCode, IntPtr wParam, IntPtr lParam)
+    {
+        if (nCode < 0)
+        {
+            return NativeMethods.CallNextHookEx(_hookHandle, nCode, wParam, lParam);
+        }
+
+        var hookStruct = Marshal.PtrToStructure<NativeMethods.KBDLLHOOKSTRUCT>(lParam);
+        var virtualKey = (Key)KeyInterop.KeyFromVirtualKey((int)hookStruct.vkCode);
+        var messageCode = wParam.ToInt32();
+
+        var isKeyDown = messageCode == NativeMethods.WM_KEYDOWN || messageCode == NativeMethods.WM_SYSKEYDOWN;
+        var isKeyUp = messageCode == NativeMethods.WM_KEYUP || messageCode == NativeMethods.WM_SYSKEYUP;
+
+        // Track only Ctrl and Alt — left and right variants both map to the
+        // same push-to-talk action (matches macOS left/right option behavior).
+        var isCtrlKey = virtualKey is Key.LeftCtrl or Key.RightCtrl;
+        var isAltKey = virtualKey is Key.LeftAlt or Key.RightAlt;
+
+        if (isCtrlKey)
+        {
+            if (isKeyDown) _isCtrlHeld = true;
+            else if (isKeyUp) _isCtrlHeld = false;
+        }
+        else if (isAltKey)
+        {
+            if (isKeyDown) _isAltHeld = true;
+            else if (isKeyUp) _isAltHeld = false;
+        }
+        else
+        {
+            // Any non-modifier keystroke cancels the shortcut. Without this,
+            // "Ctrl+Alt+T" (or any typing combo) would fire push-to-talk.
+            if (_isShortcutActive)
+            {
+                _isShortcutActive = false;
+                ShortcutReleased?.Invoke(this, EventArgs.Empty);
+            }
+
+            return NativeMethods.CallNextHookEx(_hookHandle, nCode, wParam, lParam);
+        }
+
+        var shouldBeActive = _isCtrlHeld && _isAltHeld;
+
+        if (shouldBeActive && !_isShortcutActive)
+        {
+            _isShortcutActive = true;
+            ShortcutPressed?.Invoke(this, EventArgs.Empty);
+        }
+        else if (!shouldBeActive && _isShortcutActive)
+        {
+            _isShortcutActive = false;
+            ShortcutReleased?.Invoke(this, EventArgs.Empty);
+        }
+
+        return NativeMethods.CallNextHookEx(_hookHandle, nCode, wParam, lParam);
+    }
+}

--- a/windows/Clicky/Services/IChatClient.cs
+++ b/windows/Clicky/Services/IChatClient.cs
@@ -35,8 +35,15 @@ public interface IChatClient
 /// <summary>A completed (user, assistant) pair in the rolling history.</summary>
 public sealed record ConversationTurn(string UserMessage, string AssistantMessage);
 
-/// <summary>Inline image for vision calls — raw bytes plus IANA media type.</summary>
-public sealed record InlineImage(byte[] Data, string MimeType);
+/// <summary>
+/// Inline image for vision calls — raw bytes plus IANA media type, and an
+/// optional <paramref name="Label"/>. When <c>Label</c> is non-null the chat
+/// clients emit it as a text part immediately before the image so the model
+/// knows which screen it's looking at (e.g. "screen 1 of 2 — cursor is on
+/// this screen (primary focus) (image dimensions: 1280x800 pixels)"). This
+/// matches the macOS <c>analyzeImageStreaming</c> contract.
+/// </summary>
+public sealed record InlineImage(byte[] Data, string MimeType, string? Label = null);
 
 /// <summary>Result of a streaming chat call — full accumulated text + wall time.</summary>
 public sealed record ChatStreamResult(string FullText, TimeSpan Duration);

--- a/windows/Clicky/Services/IChatClient.cs
+++ b/windows/Clicky/Services/IChatClient.cs
@@ -1,0 +1,42 @@
+namespace Clicky.Services;
+
+/// <summary>
+/// Provider-agnostic streaming chat interface. Both <see cref="ClaudeClient"/>
+/// and <see cref="GeminiClient"/> implement it so the orchestrator can swap
+/// providers based on the user's model selection without caring which is
+/// running. Mirrors the shared shape that <c>ClaudeAPI.swift</c> and
+/// <c>GeminiAPI.swift</c> expose on macOS.
+/// </summary>
+public interface IChatClient
+{
+    /// <summary>
+    /// Model identifier sent to the provider. Setter is used when the user
+    /// changes the selection in the tray panel mid-session.
+    /// </summary>
+    string Model { get; set; }
+
+    /// <summary>
+    /// Streams a response for <paramref name="userPrompt"/> given the
+    /// accumulated <paramref name="conversationHistory"/> and the optional
+    /// <paramref name="images"/> (inline base64 parts on the wire).
+    /// <paramref name="onTextChunk"/> fires on the calling thread for every
+    /// incremental text delta; the returned task resolves with the full
+    /// accumulated text once the stream closes.
+    /// </summary>
+    Task<ChatStreamResult> StreamChatAsync(
+        string systemPrompt,
+        IReadOnlyList<ConversationTurn> conversationHistory,
+        string userPrompt,
+        IReadOnlyList<InlineImage> images,
+        Action<string> onTextChunk,
+        CancellationToken cancellationToken);
+}
+
+/// <summary>A completed (user, assistant) pair in the rolling history.</summary>
+public sealed record ConversationTurn(string UserMessage, string AssistantMessage);
+
+/// <summary>Inline image for vision calls — raw bytes plus IANA media type.</summary>
+public sealed record InlineImage(byte[] Data, string MimeType);
+
+/// <summary>Result of a streaming chat call — full accumulated text + wall time.</summary>
+public sealed record ChatStreamResult(string FullText, TimeSpan Duration);

--- a/windows/Clicky/Services/MicrophoneCaptureService.cs
+++ b/windows/Clicky/Services/MicrophoneCaptureService.cs
@@ -1,0 +1,100 @@
+using NAudio.Wave;
+
+namespace Clicky.Services;
+
+/// <summary>
+/// Captures the default input device as 16-kHz, 16-bit, mono PCM — the
+/// exact format AssemblyAI's realtime endpoint expects. This is the
+/// Windows equivalent of <c>AVAudioEngine.inputNode.installTap</c> in the
+/// macOS <c>BuddyDictationManager</c>.
+///
+/// Uses <see cref="WaveInEvent"/> (winmm wrapper) because it can ask the
+/// Windows audio engine for a specific format directly — shared-mode
+/// conversion to 16 kHz mono happens in the mixer so we don't need to
+/// pull in MediaFoundation for resampling.
+/// </summary>
+public sealed class MicrophoneCaptureService : IDisposable
+{
+    private const int TargetSampleRateHz = 16_000;
+    private const int TargetBitsPerSample = 16;
+    private const int TargetChannelCount = 1;
+
+    // 100 ms of 16-kHz 16-bit mono = 3,200 bytes per buffer. AssemblyAI
+    // accepts 50–1000 ms frames; 100 ms gives snappy partials without
+    // drowning the websocket in tiny frames.
+    private const int BufferMilliseconds = 100;
+
+    private WaveInEvent? _waveInDevice;
+
+    public event EventHandler<ReadOnlyMemory<byte>>? AudioFrameCaptured;
+    public event EventHandler<Exception>? CaptureFaulted;
+
+    public bool IsRunning { get; private set; }
+
+    public void Start()
+    {
+        if (IsRunning) return;
+
+        _waveInDevice = new WaveInEvent
+        {
+            WaveFormat = new WaveFormat(TargetSampleRateHz, TargetBitsPerSample, TargetChannelCount),
+            BufferMilliseconds = BufferMilliseconds,
+            // Three queued buffers keeps the capture pipeline saturated
+            // without introducing perceptible latency.
+            NumberOfBuffers = 3,
+        };
+
+        _waveInDevice.DataAvailable += OnMicrophoneDataAvailable;
+        _waveInDevice.RecordingStopped += OnMicrophoneRecordingStopped;
+
+        _waveInDevice.StartRecording();
+        IsRunning = true;
+    }
+
+    public void Stop()
+    {
+        if (!IsRunning) return;
+        IsRunning = false;
+
+        try
+        {
+            _waveInDevice?.StopRecording();
+        }
+        catch
+        {
+            // StopRecording throws if the device was already released —
+            // swallow; the consumer has no action to take.
+        }
+    }
+
+    private void OnMicrophoneDataAvailable(object? sender, WaveInEventArgs waveInEventArgs)
+    {
+        if (waveInEventArgs.BytesRecorded <= 0) return;
+        // Copy into a fresh buffer — NAudio reuses the internal one across
+        // events, so consumers (channels, async sends) must own their slice.
+        var frameCopy = new byte[waveInEventArgs.BytesRecorded];
+        Buffer.BlockCopy(waveInEventArgs.Buffer, 0, frameCopy, 0, waveInEventArgs.BytesRecorded);
+        AudioFrameCaptured?.Invoke(this, frameCopy);
+    }
+
+    private void OnMicrophoneRecordingStopped(object? sender, StoppedEventArgs stoppedEventArgs)
+    {
+        if (stoppedEventArgs.Exception is not null)
+        {
+            CaptureFaulted?.Invoke(this, stoppedEventArgs.Exception);
+        }
+
+        if (_waveInDevice is not null)
+        {
+            _waveInDevice.DataAvailable -= OnMicrophoneDataAvailable;
+            _waveInDevice.RecordingStopped -= OnMicrophoneRecordingStopped;
+            _waveInDevice.Dispose();
+            _waveInDevice = null;
+        }
+    }
+
+    public void Dispose()
+    {
+        Stop();
+    }
+}

--- a/windows/Clicky/Services/MicrophonePermissionHelper.cs
+++ b/windows/Clicky/Services/MicrophonePermissionHelper.cs
@@ -1,0 +1,66 @@
+using System.Diagnostics;
+using NAudio.CoreAudioApi;
+
+namespace Clicky.Services;
+
+/// <summary>
+/// Windows-only equivalent of the TCC microphone prompt in the macOS
+/// <c>BuddyDictationManager.requestInitialPushToTalkPermissionsIfNeeded</c>.
+///
+/// There is no first-party Win32 API to prompt for microphone access on
+/// unpackaged desktop apps — the privacy toggle lives in
+/// <c>ms-settings:privacy-microphone</c>. The best we can do is:
+///   1. probe for an active capture endpoint at startup so a disabled mic
+///      is surfaced before the user tries to talk, and
+///   2. offer a one-click shortcut to the relevant Settings page when a
+///      capture attempt fails.
+/// </summary>
+public static class MicrophonePermissionHelper
+{
+    /// <summary>
+    /// Returns <c>true</c> iff Windows has at least one <c>Active</c> capture
+    /// endpoint — i.e. a microphone is present and the privacy/device toggle
+    /// isn't blocking it. Privacy-blocked microphones move to the
+    /// <c>Disabled</c> state and are excluded here.
+    /// </summary>
+    public static bool HasActiveCaptureDevice()
+    {
+        try
+        {
+            using var deviceEnumerator = new MMDeviceEnumerator();
+            var activeCaptureEndpoints = deviceEnumerator.EnumerateAudioEndPoints(
+                DataFlow.Capture,
+                DeviceState.Active);
+            return activeCaptureEndpoints.Count > 0;
+        }
+        catch
+        {
+            // MMDeviceEnumerator throwing usually means the audio service
+            // is down or we're running in a very unusual environment — treat
+            // as "no mic" so the UI nudges the user to check settings.
+            return false;
+        }
+    }
+
+    /// <summary>
+    /// Opens the Windows 10/11 "Microphone" privacy page in Settings. Uses
+    /// the <c>ms-settings:</c> protocol so the user lands one click away
+    /// from the per-app toggle.
+    /// </summary>
+    public static void OpenWindowsMicrophonePrivacySettings()
+    {
+        try
+        {
+            Process.Start(new ProcessStartInfo
+            {
+                FileName = "ms-settings:privacy-microphone",
+                UseShellExecute = true,
+            });
+        }
+        catch
+        {
+            // Settings URI handler missing — nothing useful to show the
+            // user, they can open Settings manually.
+        }
+    }
+}

--- a/windows/Clicky/Services/OverlayWindowManager.cs
+++ b/windows/Clicky/Services/OverlayWindowManager.cs
@@ -1,0 +1,185 @@
+using System.ComponentModel;
+using System.Windows.Threading;
+using Clicky.Interop;
+using Clicky.Views;
+
+namespace Clicky.Services;
+
+/// <summary>
+/// Owns the per-monitor <see cref="OverlayWindow"/> instances and drives the
+/// 60 fps cursor tracker that moves the blue triangle. Mirrors the macOS
+/// <c>OverlayWindowManager</c> in <c>OverlayWindow.swift</c>.
+///
+/// Lifecycle:
+///   1. <see cref="Start"/>   — enumerates monitors, spawns one overlay per
+///      display, and starts the dispatcher timer.
+///   2. Tracker tick — reads <c>GetCursorPos</c>, finds the monitor
+///      containing the cursor, asks every overlay to re-render its
+///      triangle (visible on the cursor's monitor, hidden elsewhere).
+///   3. <see cref="Dispose"/> — stops the timer and closes every overlay.
+///
+/// Visibility follows <see cref="AppState.CurrentVoiceState"/> so the
+/// triangle appears only during <c>Idle</c> / <c>Responding</c>, matching
+/// the macOS contract (during <c>Listening</c> the waveform replaces it,
+/// during <c>Processing</c> the spinner does — both are M5/M6 work; for
+/// now the triangle simply hides and the system cursor stays).
+/// </summary>
+public sealed class OverlayWindowManager : IDisposable
+{
+    // 60 fps — matches the macOS Timer(withTimeInterval: 0.016). Feels
+    // smooth and keeps CPU well below 1% of a modern core.
+    private static readonly TimeSpan CursorTrackerInterval = TimeSpan.FromMilliseconds(16);
+
+    private readonly AppState _appState;
+    private readonly Dispatcher _uiDispatcher;
+    private readonly List<MountedOverlay> _mountedOverlays = new();
+    private DispatcherTimer? _cursorTrackerTimer;
+    private bool _isDisposed;
+
+    public OverlayWindowManager(AppState appState, Dispatcher uiDispatcher)
+    {
+        _appState = appState;
+        _uiDispatcher = uiDispatcher;
+    }
+
+    /// <summary>
+    /// Boots every overlay and starts the tracking timer. Must be called
+    /// on the UI thread during app startup.
+    /// </summary>
+    public void Start()
+    {
+        foreach (var enumeratedMonitor in EnumerateMonitors())
+        {
+            var overlay = new OverlayWindow(
+                monitorBoundsLeftDevicePixels: enumeratedMonitor.BoundsLeft,
+                monitorBoundsTopDevicePixels: enumeratedMonitor.BoundsTop,
+                monitorWidthDevicePixels: enumeratedMonitor.PhysicalWidthPixels,
+                monitorHeightDevicePixels: enumeratedMonitor.PhysicalHeightPixels);
+            overlay.ShowOnMonitor();
+            _mountedOverlays.Add(new MountedOverlay(enumeratedMonitor, overlay));
+        }
+
+        _cursorTrackerTimer = new DispatcherTimer(DispatcherPriority.Render, _uiDispatcher)
+        {
+            Interval = CursorTrackerInterval,
+        };
+        _cursorTrackerTimer.Tick += OnCursorTrackerTick;
+        _cursorTrackerTimer.Start();
+
+        _appState.PropertyChanged += OnAppStatePropertyChanged;
+    }
+
+    private void OnCursorTrackerTick(object? sender, EventArgs eventArgs)
+    {
+        if (_mountedOverlays.Count == 0) return;
+        if (!NativeMethods.GetCursorPos(out var cursorPositionDevicePixels)) return;
+
+        var triangleShouldBeVisible = TriangleVisibleForVoiceState(_appState.CurrentVoiceState);
+
+        foreach (var mountedOverlay in _mountedOverlays)
+        {
+            var cursorIsOnThisMonitor = mountedOverlay.Monitor.ContainsDevicePoint(
+                cursorPositionDevicePixels.X,
+                cursorPositionDevicePixels.Y);
+
+            mountedOverlay.Window.UpdateCursorState(
+                cursorGlobalDeviceX: cursorPositionDevicePixels.X,
+                cursorGlobalDeviceY: cursorPositionDevicePixels.Y,
+                cursorIsOnThisMonitor: cursorIsOnThisMonitor,
+                triangleShouldBeVisible: triangleShouldBeVisible);
+        }
+    }
+
+    /// <summary>
+    /// Triangle is visible while the user is passively present (Idle) or
+    /// hearing the response back (Responding). During Listening /
+    /// Processing the macOS overlay swaps in a waveform / spinner — those
+    /// are M5/M6 work; for now we just hide the triangle so the user
+    /// sees the system cursor only.
+    /// </summary>
+    private static bool TriangleVisibleForVoiceState(AppState.VoiceState voiceState)
+    {
+        return voiceState == AppState.VoiceState.Idle
+            || voiceState == AppState.VoiceState.Responding;
+    }
+
+    private void OnAppStatePropertyChanged(object? sender, PropertyChangedEventArgs args)
+    {
+        // Redraw on the next tick; no extra work required here — we only
+        // subscribe so future state-based extras (e.g. waveform for
+        // Listening in M5) have a hook to attach to.
+    }
+
+    // ---- Monitor enumeration ----
+    // Duplicated from ScreenCaptureService rather than shared so each
+    // feature owns a narrow, local view of the monitor topology. If a
+    // third caller shows up we can extract a MonitorEnumerator.
+
+    private static List<EnumeratedOverlayMonitor> EnumerateMonitors()
+    {
+        var enumeratedList = new List<EnumeratedOverlayMonitor>();
+
+        bool MonitorEnumCallback(IntPtr hMonitor, IntPtr hdcMonitor, ref NativeMethods.RECT lprcMonitor, IntPtr dwData)
+        {
+            var monitorInfo = new NativeMethods.MONITORINFOEX
+            {
+                cbSize = System.Runtime.InteropServices.Marshal.SizeOf<NativeMethods.MONITORINFOEX>(),
+            };
+            if (!NativeMethods.GetMonitorInfo(hMonitor, ref monitorInfo))
+            {
+                return true;
+            }
+
+            enumeratedList.Add(new EnumeratedOverlayMonitor(
+                Handle: hMonitor,
+                BoundsLeft: monitorInfo.rcMonitor.Left,
+                BoundsTop: monitorInfo.rcMonitor.Top,
+                PhysicalWidthPixels: monitorInfo.rcMonitor.Width,
+                PhysicalHeightPixels: monitorInfo.rcMonitor.Height));
+            return true;
+        }
+
+        NativeMethods.EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero, MonitorEnumCallback, IntPtr.Zero);
+        return enumeratedList;
+    }
+
+    public void Dispose()
+    {
+        if (_isDisposed) return;
+        _isDisposed = true;
+
+        _appState.PropertyChanged -= OnAppStatePropertyChanged;
+
+        if (_cursorTrackerTimer is not null)
+        {
+            _cursorTrackerTimer.Stop();
+            _cursorTrackerTimer.Tick -= OnCursorTrackerTick;
+            _cursorTrackerTimer = null;
+        }
+
+        foreach (var mountedOverlay in _mountedOverlays)
+        {
+            try { mountedOverlay.Window.Close(); }
+            catch { /* window already torn down during app shutdown — ignore */ }
+        }
+        _mountedOverlays.Clear();
+    }
+
+    private sealed record EnumeratedOverlayMonitor(
+        IntPtr Handle,
+        int BoundsLeft,
+        int BoundsTop,
+        int PhysicalWidthPixels,
+        int PhysicalHeightPixels)
+    {
+        public bool ContainsDevicePoint(int globalDeviceX, int globalDeviceY)
+        {
+            return globalDeviceX >= BoundsLeft
+                && globalDeviceX < BoundsLeft + PhysicalWidthPixels
+                && globalDeviceY >= BoundsTop
+                && globalDeviceY < BoundsTop + PhysicalHeightPixels;
+        }
+    }
+
+    private sealed record MountedOverlay(EnumeratedOverlayMonitor Monitor, OverlayWindow Window);
+}

--- a/windows/Clicky/Services/OverlayWindowManager.cs
+++ b/windows/Clicky/Services/OverlayWindowManager.cs
@@ -75,6 +75,7 @@ public sealed class OverlayWindowManager : IDisposable
         if (!NativeMethods.GetCursorPos(out var cursorPositionDevicePixels)) return;
 
         var triangleShouldBeVisible = TriangleVisibleForVoiceState(_appState.CurrentVoiceState);
+        var anyOverlayIsFlying = _mountedOverlays.Any(mounted => mounted.Window.IsFlightInProgress);
 
         foreach (var mountedOverlay in _mountedOverlays)
         {
@@ -82,12 +83,53 @@ public sealed class OverlayWindowManager : IDisposable
                 cursorPositionDevicePixels.X,
                 cursorPositionDevicePixels.Y);
 
+            // While any overlay is running a pointing flight, suppress the
+            // cursor-following triangle everywhere else — only one buddy at a
+            // time, matching the macOS single-active-overlay contract.
+            var triangleVisibleOnThisOverlay = triangleShouldBeVisible
+                && (!anyOverlayIsFlying || mountedOverlay.Window.IsFlightInProgress);
+
             mountedOverlay.Window.UpdateCursorState(
                 cursorGlobalDeviceX: cursorPositionDevicePixels.X,
                 cursorGlobalDeviceY: cursorPositionDevicePixels.Y,
                 cursorIsOnThisMonitor: cursorIsOnThisMonitor,
-                triangleShouldBeVisible: triangleShouldBeVisible);
+                triangleShouldBeVisible: triangleVisibleOnThisOverlay);
         }
+    }
+
+    /// <summary>
+    /// Kicks off the element-pointing flight on whichever overlay owns the
+    /// given monitor bounds. The caller passes display-local device pixels
+    /// (from <see cref="MonitorCapture.DisplayWidthPixels"/> space), so the
+    /// overlay can scale to DIPs with its own per-monitor DPI.
+    ///
+    /// No-ops if the target monitor is no longer mounted (e.g. unplugged
+    /// between capture and reply) or if a flight is already in progress —
+    /// the AI would have to emit a second [POINT:…] mid-flight for that to
+    /// happen, which in practice doesn't occur during a single TTS turn.
+    /// </summary>
+    public void FlyToElement(
+        int targetMonitorBoundsLeftDevicePixels,
+        int targetMonitorBoundsTopDevicePixels,
+        double targetDisplayLocalDeviceX,
+        double targetDisplayLocalDeviceY,
+        string bubblePhrase)
+    {
+        _uiDispatcher.BeginInvoke(() =>
+        {
+            if (_isDisposed) return;
+            if (_mountedOverlays.Any(mounted => mounted.Window.IsFlightInProgress)) return;
+
+            var targetOverlay = _mountedOverlays.FirstOrDefault(mounted =>
+                mounted.Monitor.BoundsLeft == targetMonitorBoundsLeftDevicePixels
+                && mounted.Monitor.BoundsTop == targetMonitorBoundsTopDevicePixels);
+            if (targetOverlay is null) return;
+
+            targetOverlay.Window.BeginElementPointingFlight(
+                targetDisplayLocalDeviceX: targetDisplayLocalDeviceX,
+                targetDisplayLocalDeviceY: targetDisplayLocalDeviceY,
+                bubblePhrase: bubblePhrase);
+        });
     }
 
     /// <summary>

--- a/windows/Clicky/Services/PointingTagParser.cs
+++ b/windows/Clicky/Services/PointingTagParser.cs
@@ -1,0 +1,77 @@
+using System.Text.RegularExpressions;
+
+namespace Clicky.Services;
+
+/// <summary>
+/// Parses the trailing <c>[POINT:x,y:label:screenN]</c> / <c>[POINT:none]</c>
+/// tag the AI appends to voice responses. Port of
+/// <c>CompanionManager.parsePointingCoordinates</c>.
+///
+/// The orchestrator calls this after the stream completes to split the
+/// reply into "spoken text" (TTS input) and the optional pointing target
+/// (coordinate + screen + human-readable label).
+/// </summary>
+public static class PointingTagParser
+{
+    // Same regex the Swift app uses — groups:
+    //   1 = x (integer pixels), 2 = y, 3 = label (optional), 4 = screen index (optional, 1-based)
+    private static readonly Regex TrailingPointTagRegex = new(
+        @"\[POINT:(?:none|(\d+)\s*,\s*(\d+)(?::([^\]:\s][^\]:]*?))?(?::screen(\d+))?)\]\s*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+
+    public static PointingParseResult Parse(string responseText)
+    {
+        if (string.IsNullOrEmpty(responseText))
+        {
+            return new PointingParseResult(string.Empty, null, null, null);
+        }
+
+        var match = TrailingPointTagRegex.Match(responseText);
+        if (!match.Success)
+        {
+            return new PointingParseResult(responseText, null, null, null);
+        }
+
+        // The "spoken text" is everything before the tag, with trailing
+        // whitespace trimmed — TTS should read the reply, not the tag.
+        var spokenText = responseText.Substring(0, match.Index).TrimEnd();
+
+        var hasCoordinate = match.Groups[1].Success && match.Groups[2].Success;
+        if (!hasCoordinate)
+        {
+            // [POINT:none] — spoken text only, no flight.
+            return new PointingParseResult(spokenText, null, "none", null);
+        }
+
+        var pointX = int.Parse(match.Groups[1].Value, System.Globalization.CultureInfo.InvariantCulture);
+        var pointY = int.Parse(match.Groups[2].Value, System.Globalization.CultureInfo.InvariantCulture);
+
+        string? elementLabel = null;
+        if (match.Groups[3].Success)
+        {
+            elementLabel = match.Groups[3].Value.Trim();
+            if (elementLabel.Length == 0) elementLabel = null;
+        }
+
+        int? screenNumber = null;
+        if (match.Groups[4].Success
+            && int.TryParse(match.Groups[4].Value, System.Globalization.NumberStyles.Integer, System.Globalization.CultureInfo.InvariantCulture, out var parsedScreenNumber))
+        {
+            screenNumber = parsedScreenNumber;
+        }
+
+        return new PointingParseResult(spokenText, (pointX, pointY), elementLabel, screenNumber);
+    }
+}
+
+/// <summary>
+/// Result of parsing a <c>[POINT:…]</c> tag. <see cref="Coordinate"/> is
+/// null when the AI emitted <c>[POINT:none]</c> (or no tag at all);
+/// <see cref="ScreenNumber"/> is 1-based and references the cursor-first
+/// capture list the AI saw, or null to default to the cursor screen.
+/// </summary>
+public sealed record PointingParseResult(
+    string SpokenText,
+    (int X, int Y)? Coordinate,
+    string? ElementLabel,
+    int? ScreenNumber);

--- a/windows/Clicky/Services/ScreenCaptureService.cs
+++ b/windows/Clicky/Services/ScreenCaptureService.cs
@@ -1,0 +1,300 @@
+using System.Globalization;
+using System.IO;
+using System.Windows;
+using System.Windows.Interop;
+using System.Windows.Media;
+using System.Windows.Media.Imaging;
+using Clicky.Interop;
+
+namespace Clicky.Services;
+
+/// <summary>
+/// Grabs a JPEG of every attached display and returns them ordered with
+/// the cursor's display first. Port of the macOS
+/// <c>CompanionScreenCaptureUtility.captureAllScreensAsJPEG()</c>.
+///
+/// Uses GDI BitBlt against the desktop DC — simple, per-monitor-DPI-aware
+/// (thanks to PerMonitorV2 in app.manifest), and doesn't require the
+/// WinRT <c>Windows.Graphics.Capture</c> picker flow. Acceptable for
+/// static snapshots; if we ever need continuous capture we can swap in
+/// <c>GraphicsCaptureItem</c> later.
+/// </summary>
+public sealed class ScreenCaptureService
+{
+    /// <summary>JPEG encoder quality, matches the macOS client (0.8 → 80%).</summary>
+    private const int JpegQualityPercent = 80;
+
+    /// <summary>Longest-side pixel budget. Anything larger is downscaled so
+    /// the API request stays well under Anthropic/Gemini inline image
+    /// size limits and keeps uploads fast. Matches macOS (1280 points).</summary>
+    private const int MaxLongestSidePixels = 1280;
+
+    /// <summary>
+    /// Captures every monitor synchronously. Returns a list ordered with
+    /// the cursor's monitor first (flagged "primary focus" in the label)
+    /// and the rest in enumeration order.
+    /// </summary>
+    public IReadOnlyList<MonitorCapture> CaptureAllMonitors()
+    {
+        var enumeratedMonitors = EnumerateMonitors();
+        if (enumeratedMonitors.Count == 0)
+        {
+            return Array.Empty<MonitorCapture>();
+        }
+
+        var cursorMonitorHandle = FindCursorMonitorHandle();
+        var orderedMonitors = OrderCursorFirst(enumeratedMonitors, cursorMonitorHandle);
+
+        var capturedList = new List<MonitorCapture>(orderedMonitors.Count);
+        for (var orderedIndex = 0; orderedIndex < orderedMonitors.Count; orderedIndex++)
+        {
+            var monitor = orderedMonitors[orderedIndex];
+            var humanReadableLabel = BuildMonitorLabel(
+                orderedIndex: orderedIndex,
+                totalCount: orderedMonitors.Count,
+                isCursorMonitor: monitor.HandleEquals(cursorMonitorHandle),
+                isPrimaryMonitor: (monitor.Flags & NativeMethods.MONITORINFOF_PRIMARY) != 0);
+
+            var capture = CaptureSingleMonitor(monitor, humanReadableLabel);
+            capturedList.Add(capture);
+        }
+        return capturedList;
+    }
+
+    private MonitorCapture CaptureSingleMonitor(EnumeratedMonitor monitor, string humanReadableLabel)
+    {
+        // 1. Capture raw pixels via GDI BitBlt.
+        var sourceBitmap = BitBltMonitorToBitmapSource(monitor);
+
+        // 2. Downscale so the largest side fits MaxLongestSidePixels.
+        var downscaledBitmap = DownscaleIfLarger(sourceBitmap, MaxLongestSidePixels);
+
+        // 3. Encode as JPEG at the configured quality.
+        var jpegBytes = EncodeAsJpeg(downscaledBitmap, JpegQualityPercent);
+
+        return new MonitorCapture(
+            JpegData: jpegBytes,
+            MimeType: "image/jpeg",
+            Label: humanReadableLabel,
+            IsCursorMonitor: monitor.HandleEquals(FindCursorMonitorHandle()),
+            DisplayWidthPixels: monitor.PhysicalWidthPixels,
+            DisplayHeightPixels: monitor.PhysicalHeightPixels,
+            ScreenshotWidthPixels: downscaledBitmap.PixelWidth,
+            ScreenshotHeightPixels: downscaledBitmap.PixelHeight,
+            DisplayBoundsDevicePixels: new Int32Rect(
+                monitor.BoundsLeft, monitor.BoundsTop,
+                monitor.PhysicalWidthPixels, monitor.PhysicalHeightPixels));
+    }
+
+    /// <summary>
+    /// Walks every monitor via EnumDisplayMonitors. The callback gives us
+    /// an HMONITOR per display; we turn each into a MONITORINFOEX for the
+    /// bounds + device name. Returned in system enumeration order.
+    /// </summary>
+    private static List<EnumeratedMonitor> EnumerateMonitors()
+    {
+        var enumeratedList = new List<EnumeratedMonitor>();
+
+        bool MonitorEnumCallback(IntPtr hMonitor, IntPtr hdcMonitor, ref NativeMethods.RECT lprcMonitor, IntPtr dwData)
+        {
+            var monitorInfo = new NativeMethods.MONITORINFOEX
+            {
+                cbSize = System.Runtime.InteropServices.Marshal.SizeOf<NativeMethods.MONITORINFOEX>(),
+            };
+            if (!NativeMethods.GetMonitorInfo(hMonitor, ref monitorInfo))
+            {
+                // Skip monitors we couldn't query — shouldn't happen in practice.
+                return true;
+            }
+
+            enumeratedList.Add(new EnumeratedMonitor(
+                Handle: hMonitor,
+                BoundsLeft: monitorInfo.rcMonitor.Left,
+                BoundsTop: monitorInfo.rcMonitor.Top,
+                PhysicalWidthPixels: monitorInfo.rcMonitor.Width,
+                PhysicalHeightPixels: monitorInfo.rcMonitor.Height,
+                Flags: monitorInfo.dwFlags,
+                DeviceName: monitorInfo.szDevice ?? string.Empty));
+            return true;
+        }
+
+        NativeMethods.EnumDisplayMonitors(IntPtr.Zero, IntPtr.Zero, MonitorEnumCallback, IntPtr.Zero);
+        return enumeratedList;
+    }
+
+    private static IntPtr FindCursorMonitorHandle()
+    {
+        if (!NativeMethods.GetCursorPos(out var cursorPosition))
+        {
+            return IntPtr.Zero;
+        }
+        return NativeMethods.MonitorFromPoint(cursorPosition, NativeMethods.MONITOR_DEFAULTTONEAREST);
+    }
+
+    /// <summary>Moves the cursor monitor to index 0; preserves the rest in
+    /// original order. Mirrors the macOS ordering so the AI prompt places
+    /// the "primary focus" screen first.</summary>
+    private static List<EnumeratedMonitor> OrderCursorFirst(
+        IReadOnlyList<EnumeratedMonitor> sourceMonitors,
+        IntPtr cursorMonitorHandle)
+    {
+        var orderedList = new List<EnumeratedMonitor>(sourceMonitors.Count);
+        EnumeratedMonitor? cursorMonitor = null;
+        foreach (var monitor in sourceMonitors)
+        {
+            if (monitor.HandleEquals(cursorMonitorHandle)) { cursorMonitor = monitor; }
+            else { orderedList.Add(monitor); }
+        }
+        if (cursorMonitor is not null)
+        {
+            orderedList.Insert(0, cursorMonitor);
+        }
+        return orderedList;
+    }
+
+    /// <summary>
+    /// Copies a monitor's pixels into a WPF-consumable BitmapSource via
+    /// GDI BitBlt. We operate on the desktop DC so the coordinates are
+    /// virtual-screen coordinates (matches what GetMonitorInfo returns
+    /// under PerMonitorV2 DPI awareness).
+    /// </summary>
+    private static BitmapSource BitBltMonitorToBitmapSource(EnumeratedMonitor monitor)
+    {
+        var desktopDC = NativeMethods.GetDC(IntPtr.Zero);
+        if (desktopDC == IntPtr.Zero)
+        {
+            throw new InvalidOperationException("GetDC(desktop) returned NULL.");
+        }
+
+        IntPtr memoryDC = IntPtr.Zero;
+        IntPtr compatibleBitmap = IntPtr.Zero;
+        IntPtr previousBitmap = IntPtr.Zero;
+
+        try
+        {
+            memoryDC = NativeMethods.CreateCompatibleDC(desktopDC);
+            if (memoryDC == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("CreateCompatibleDC failed.");
+            }
+
+            compatibleBitmap = NativeMethods.CreateCompatibleBitmap(
+                desktopDC,
+                monitor.PhysicalWidthPixels,
+                monitor.PhysicalHeightPixels);
+            if (compatibleBitmap == IntPtr.Zero)
+            {
+                throw new InvalidOperationException("CreateCompatibleBitmap failed.");
+            }
+
+            previousBitmap = NativeMethods.SelectObject(memoryDC, compatibleBitmap);
+
+            var bitBltSucceeded = NativeMethods.BitBlt(
+                hDCDest: memoryDC,
+                xDest: 0, yDest: 0,
+                width: monitor.PhysicalWidthPixels,
+                height: monitor.PhysicalHeightPixels,
+                hDCSource: desktopDC,
+                xSource: monitor.BoundsLeft,
+                ySource: monitor.BoundsTop,
+                rop: NativeMethods.SRCCOPY | NativeMethods.CAPTUREBLT);
+
+            if (!bitBltSucceeded)
+            {
+                var lastError = System.Runtime.InteropServices.Marshal.GetLastWin32Error();
+                throw new InvalidOperationException($"BitBlt failed (Win32 error {lastError}).");
+            }
+
+            // Snapshot into a WPF BitmapSource. CreateBitmapSourceFromHBitmap
+            // copies the pixels into managed memory — safe to free the
+            // HBITMAP immediately after.
+            var bitmapSource = Imaging.CreateBitmapSourceFromHBitmap(
+                compatibleBitmap,
+                IntPtr.Zero,
+                Int32Rect.Empty,
+                BitmapSizeOptions.FromEmptyOptions());
+            bitmapSource.Freeze();
+            return bitmapSource;
+        }
+        finally
+        {
+            if (previousBitmap != IntPtr.Zero && memoryDC != IntPtr.Zero)
+            {
+                NativeMethods.SelectObject(memoryDC, previousBitmap);
+            }
+            if (compatibleBitmap != IntPtr.Zero) NativeMethods.DeleteObject(compatibleBitmap);
+            if (memoryDC != IntPtr.Zero) NativeMethods.DeleteDC(memoryDC);
+            NativeMethods.ReleaseDC(IntPtr.Zero, desktopDC);
+        }
+    }
+
+    private static BitmapSource DownscaleIfLarger(BitmapSource sourceBitmap, int maxLongestSide)
+    {
+        var longestSide = Math.Max(sourceBitmap.PixelWidth, sourceBitmap.PixelHeight);
+        if (longestSide <= maxLongestSide) return sourceBitmap;
+
+        var scaleFactor = (double)maxLongestSide / longestSide;
+        var scaledTransform = new ScaleTransform(scaleFactor, scaleFactor);
+        var transformedBitmap = new TransformedBitmap(sourceBitmap, scaledTransform);
+        transformedBitmap.Freeze();
+        return transformedBitmap;
+    }
+
+    private static byte[] EncodeAsJpeg(BitmapSource bitmap, int qualityPercent)
+    {
+        var encoder = new JpegBitmapEncoder { QualityLevel = qualityPercent };
+        encoder.Frames.Add(BitmapFrame.Create(bitmap));
+        using var memoryStream = new MemoryStream();
+        encoder.Save(memoryStream);
+        return memoryStream.ToArray();
+    }
+
+    /// <summary>
+    /// Builds the per-monitor label the AI sees in the prompt. Matches the
+    /// macOS format so prompt-engineering tweaks there translate directly.
+    /// </summary>
+    private static string BuildMonitorLabel(int orderedIndex, int totalCount, bool isCursorMonitor, bool isPrimaryMonitor)
+    {
+        var labelBuilder = new System.Text.StringBuilder();
+        labelBuilder.Append("screen ").Append((orderedIndex + 1).ToString(CultureInfo.InvariantCulture));
+        labelBuilder.Append(" of ").Append(totalCount.ToString(CultureInfo.InvariantCulture));
+
+        if (isCursorMonitor)
+        {
+            labelBuilder.Append(" — cursor is on this screen (primary focus)");
+        }
+        else if (isPrimaryMonitor)
+        {
+            labelBuilder.Append(" — primary display");
+        }
+        return labelBuilder.ToString();
+    }
+
+    private sealed record EnumeratedMonitor(
+        IntPtr Handle,
+        int BoundsLeft,
+        int BoundsTop,
+        int PhysicalWidthPixels,
+        int PhysicalHeightPixels,
+        uint Flags,
+        string DeviceName)
+    {
+        public bool HandleEquals(IntPtr otherHandle) => Handle == otherHandle && Handle != IntPtr.Zero;
+    }
+}
+
+/// <summary>
+/// A single captured monitor ready to ship to an AI provider. Mirrors the
+/// macOS <c>CompanionScreenCapture</c> struct — field names adjusted for
+/// C# conventions.
+/// </summary>
+public sealed record MonitorCapture(
+    byte[] JpegData,
+    string MimeType,
+    string Label,
+    bool IsCursorMonitor,
+    int DisplayWidthPixels,
+    int DisplayHeightPixels,
+    int ScreenshotWidthPixels,
+    int ScreenshotHeightPixels,
+    Int32Rect DisplayBoundsDevicePixels);

--- a/windows/Clicky/Services/SettingsService.cs
+++ b/windows/Clicky/Services/SettingsService.cs
@@ -1,0 +1,117 @@
+using System.IO;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace Clicky.Services;
+
+/// <summary>
+/// Persists user preferences to %APPDATA%\Clicky\settings.json.
+/// Equivalent of the macOS app's UserDefaults usage in CompanionManager.swift.
+/// Reads are synchronous and cheap; writes debounce so rapid toggles don't
+/// thrash the disk.
+/// </summary>
+public sealed class SettingsService
+{
+    private static readonly string SettingsDirectory = Path.Combine(
+        Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData),
+        "Clicky");
+
+    private static readonly string SettingsFilePath = Path.Combine(SettingsDirectory, "settings.json");
+
+    private static readonly JsonSerializerOptions SerializerOptions = new()
+    {
+        WriteIndented = true,
+        DefaultIgnoreCondition = JsonIgnoreCondition.WhenWritingNull,
+    };
+
+    private PersistedSettings _currentSettings;
+    private readonly object _writeLock = new();
+
+    public SettingsService()
+    {
+        _currentSettings = LoadFromDiskOrDefault();
+    }
+
+    public string SelectedModelId
+    {
+        get => _currentSettings.SelectedModelId ?? DefaultModelId;
+        set
+        {
+            _currentSettings.SelectedModelId = value;
+            PersistToDisk();
+        }
+    }
+
+    public bool IsClickyCursorEnabled
+    {
+        get => _currentSettings.IsClickyCursorEnabled ?? true;
+        set
+        {
+            _currentSettings.IsClickyCursorEnabled = value;
+            PersistToDisk();
+        }
+    }
+
+    public bool HasCompletedOnboarding
+    {
+        get => _currentSettings.HasCompletedOnboarding ?? false;
+        set
+        {
+            _currentSettings.HasCompletedOnboarding = value;
+            PersistToDisk();
+        }
+    }
+
+    /// <summary>
+    /// Default to Gemini Flash since it's the cheapest option and the user
+    /// explicitly called out credit cost as a concern. Matches the macOS
+    /// default (Sonnet) only if that proves to be a better experience.
+    /// </summary>
+    public const string DefaultModelId = "claude-sonnet-4-6";
+
+    private PersistedSettings LoadFromDiskOrDefault()
+    {
+        try
+        {
+            if (!File.Exists(SettingsFilePath))
+            {
+                return new PersistedSettings();
+            }
+
+            var fileContents = File.ReadAllText(SettingsFilePath);
+            var deserialized = JsonSerializer.Deserialize<PersistedSettings>(fileContents, SerializerOptions);
+            return deserialized ?? new PersistedSettings();
+        }
+        catch (Exception ex)
+        {
+            // Corrupt or unreadable settings file — fall back to defaults so
+            // the app still starts. We don't surface this to the user.
+            System.Diagnostics.Debug.WriteLine($"[SettingsService] Failed to load settings: {ex.Message}");
+            return new PersistedSettings();
+        }
+    }
+
+    private void PersistToDisk()
+    {
+        lock (_writeLock)
+        {
+            try
+            {
+                Directory.CreateDirectory(SettingsDirectory);
+                var serialized = JsonSerializer.Serialize(_currentSettings, SerializerOptions);
+                File.WriteAllText(SettingsFilePath, serialized);
+            }
+            catch (Exception ex)
+            {
+                System.Diagnostics.Debug.WriteLine($"[SettingsService] Failed to save settings: {ex.Message}");
+            }
+        }
+    }
+
+    private sealed class PersistedSettings
+    {
+        public string? SelectedModelId { get; set; }
+        public bool? IsClickyCursorEnabled { get; set; }
+        public bool? HasCompletedOnboarding { get; set; }
+    }
+}

--- a/windows/Clicky/Services/SettingsService.cs
+++ b/windows/Clicky/Services/SettingsService.cs
@@ -63,6 +63,25 @@ public sealed class SettingsService
     }
 
     /// <summary>
+    /// Stable, anonymous per-install identifier used as PostHog's
+    /// <c>distinct_id</c>. Generated lazily on first access so events can be
+    /// correlated across launches without ever linking to an identity.
+    /// </summary>
+    public string AnalyticsDistinctId
+    {
+        get
+        {
+            if (!string.IsNullOrEmpty(_currentSettings.AnalyticsDistinctId))
+            {
+                return _currentSettings.AnalyticsDistinctId;
+            }
+            _currentSettings.AnalyticsDistinctId = Guid.NewGuid().ToString("N");
+            PersistToDisk();
+            return _currentSettings.AnalyticsDistinctId;
+        }
+    }
+
+    /// <summary>
     /// Default to Gemini Flash since it's the cheapest option and the user
     /// explicitly called out credit cost as a concern. Matches the macOS
     /// default (Sonnet) only if that proves to be a better experience.
@@ -113,5 +132,6 @@ public sealed class SettingsService
         public string? SelectedModelId { get; set; }
         public bool? IsClickyCursorEnabled { get; set; }
         public bool? HasCompletedOnboarding { get; set; }
+        public string? AnalyticsDistinctId { get; set; }
     }
 }

--- a/windows/Clicky/Services/VoicePipelineOrchestrator.cs
+++ b/windows/Clicky/Services/VoicePipelineOrchestrator.cs
@@ -104,6 +104,8 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
 
     public async Task HandlePushToTalkPressedAsync()
     {
+        ClickyAnalytics.TrackPushToTalkStarted();
+
         // Talking over the previous reply → cancel in-flight AI request and
         // stop TTS so the user isn't competing with the assistant's voice.
         _currentRequestCts?.Cancel();
@@ -120,16 +122,27 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
             newSession.SessionFaulted += OnDictationFaulted;
             await newSession.StartAsync(CancellationToken.None).ConfigureAwait(false);
             _activeDictationSession = newSession;
+
+            // Successful capture start is the clearest signal that the mic
+            // privacy toggle is granted — clear any stale "blocked" state.
+            SetMicrophonePermissionIssueOnUi(false);
         }
         catch (Exception startException)
         {
             SetVoiceStateOnUi(AppState.VoiceState.Idle);
-            ReportFailureOnUi($"Couldn't start dictation: {startException.Message}");
+            SetMicrophonePermissionIssueOnUi(true);
+            ReportFailureOnUi(
+                "Couldn't start microphone. Check Windows privacy settings. "
+                + $"({startException.Message})");
+            ClickyAnalytics.TrackPermissionDenied("microphone");
+            ClickyAnalytics.TrackResponseError(startException.Message);
         }
     }
 
     public async Task HandlePushToTalkReleasedAsync()
     {
+        ClickyAnalytics.TrackPushToTalkReleased();
+
         var releasedSession = _activeDictationSession;
         if (releasedSession is null)
         {
@@ -162,6 +175,7 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
         }
 
         SetLiveTranscriptOnUi(finalTranscript);
+        ClickyAnalytics.TrackUserMessageSent(finalTranscript);
         await DispatchToAiAndSpeakAsync(finalTranscript).ConfigureAwait(false);
     }
 
@@ -207,6 +221,8 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
 
             AppendTurnToHistory(userPrompt, spokenText);
 
+            ClickyAnalytics.TrackAiResponseReceived(spokenText, _appState.SelectedModelId);
+
             TriggerPointingFlightIfRequested(pointingParseResult, capturedMonitors);
 
             if (spokenText.Length == 0)
@@ -216,7 +232,16 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
             }
 
             SetVoiceStateOnUi(AppState.VoiceState.Responding);
-            await _elevenLabsTtsClient.SpeakAsync(spokenText, cancellationToken).ConfigureAwait(false);
+            try
+            {
+                await _elevenLabsTtsClient.SpeakAsync(spokenText, cancellationToken).ConfigureAwait(false);
+            }
+            catch (OperationCanceledException) { throw; }
+            catch (Exception ttsException)
+            {
+                ClickyAnalytics.TrackTtsError(ttsException.Message);
+                throw;
+            }
         }
         catch (OperationCanceledException)
         {
@@ -226,6 +251,7 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
         {
             SetVoiceStateOnUi(AppState.VoiceState.Idle);
             ReportFailureOnUi($"AI request failed: {aiException.Message}");
+            ClickyAnalytics.TrackResponseError(aiException.Message);
         }
     }
 
@@ -303,6 +329,8 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
             targetDisplayLocalDeviceX: displayLocalDeviceX,
             targetDisplayLocalDeviceY: displayLocalDeviceY,
             bubblePhrase: bubblePhrase);
+
+        ClickyAnalytics.TrackElementPointed(parseResult.ElementLabel, targetCaptureIndex + 1);
     }
 
     private IChatClient ResolveClientForCurrentModel()
@@ -393,6 +421,11 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
     private void ReportFailureOnUi(string failureMessage)
     {
         _uiDispatcher.BeginInvoke(() => _appState.LastStatusMessage = failureMessage);
+    }
+
+    private void SetMicrophonePermissionIssueOnUi(bool hasIssue)
+    {
+        _uiDispatcher.BeginInvoke(() => _appState.IsMicrophonePermissionIssue = hasIssue);
     }
 
     // ---- Model defaults ----

--- a/windows/Clicky/Services/VoicePipelineOrchestrator.cs
+++ b/windows/Clicky/Services/VoicePipelineOrchestrator.cs
@@ -1,0 +1,277 @@
+using System.Windows.Threading;
+
+namespace Clicky.Services;
+
+/// <summary>
+/// End-to-end voice pipeline. Drives the push-to-talk flow:
+///   press   → mic + AssemblyAI start, <c>AppState.VoiceState.Listening</c>
+///   release → finalize transcript, dispatch to Claude/Gemini streaming
+///             (<c>VoiceState.Processing</c>), stream response to the
+///             panel, hand the final caption to ElevenLabs for playback
+///             (<c>VoiceState.Responding</c>), return to
+///             <c>VoiceState.Idle</c> when audio stops.
+///
+/// The macOS equivalent is the transcript→AI→TTS pipeline embedded in
+/// <c>CompanionManager.swift</c>. We pulled it into its own class on
+/// Windows so <c>App.xaml.cs</c> and <c>AppState</c> stay small.
+/// </summary>
+public sealed class VoicePipelineOrchestrator : IAsyncDisposable
+{
+    // Kept short because TTS reads the reply out loud — a long monologue
+    // makes the app feel sluggish. Mirrors the macOS Buddy personality.
+    private const string VoiceSystemPrompt =
+        "You are Clicky, a concise and friendly voice assistant. Reply in one or two short sentences " +
+        "suitable for being read aloud. Avoid lists and markdown. If the user asks you to point at " +
+        "something, say what you would point at in plain words — the visual pointing feature is not " +
+        "available in this milestone.";
+
+    private const int ConversationHistoryMaxTurns = 10;
+
+    private readonly AppState _appState;
+    private readonly Dispatcher _uiDispatcher;
+    private readonly ClaudeClient _claudeClient;
+    private readonly GeminiClient _geminiClient;
+    private readonly ElevenLabsTtsClient _elevenLabsTtsClient;
+
+    private DictationSession? _activeDictationSession;
+    private readonly List<ConversationTurn> _conversationHistory = new();
+
+    private CancellationTokenSource? _currentRequestCts;
+
+    public VoicePipelineOrchestrator(AppState appState, Dispatcher uiDispatcher)
+    {
+        _appState = appState;
+        _uiDispatcher = uiDispatcher;
+
+        _claudeClient = new ClaudeClient(model: InferInitialClaudeModel(appState.SelectedModelId));
+        _geminiClient = new GeminiClient(model: InferInitialGeminiModel(appState.SelectedModelId));
+        _elevenLabsTtsClient = new ElevenLabsTtsClient();
+        _elevenLabsTtsClient.PlaybackFinished += OnTtsPlaybackFinished;
+
+        _appState.PropertyChanged += OnAppStatePropertyChanged;
+    }
+
+    public async Task HandlePushToTalkPressedAsync()
+    {
+        // Talking over the previous reply → cancel in-flight AI request and
+        // stop TTS so the user isn't competing with the assistant's voice.
+        _currentRequestCts?.Cancel();
+        _elevenLabsTtsClient.StopPlayback();
+
+        SetVoiceStateOnUi(AppState.VoiceState.Listening);
+        SetLiveTranscriptOnUi(string.Empty);
+        SetStreamedResponseOnUi(string.Empty);
+
+        try
+        {
+            var newSession = new DictationSession();
+            newSession.PartialTranscriptUpdated += OnPartialTranscriptUpdated;
+            newSession.SessionFaulted += OnDictationFaulted;
+            await newSession.StartAsync(CancellationToken.None).ConfigureAwait(false);
+            _activeDictationSession = newSession;
+        }
+        catch (Exception startException)
+        {
+            SetVoiceStateOnUi(AppState.VoiceState.Idle);
+            ReportFailureOnUi($"Couldn't start dictation: {startException.Message}");
+        }
+    }
+
+    public async Task HandlePushToTalkReleasedAsync()
+    {
+        var releasedSession = _activeDictationSession;
+        if (releasedSession is null)
+        {
+            SetVoiceStateOnUi(AppState.VoiceState.Idle);
+            return;
+        }
+
+        SetVoiceStateOnUi(AppState.VoiceState.Processing);
+
+        string finalTranscript;
+        try
+        {
+            finalTranscript = await releasedSession.RequestFinalTranscriptAsync(CancellationToken.None)
+                .ConfigureAwait(false);
+        }
+        catch (Exception finalizeException)
+        {
+            SetVoiceStateOnUi(AppState.VoiceState.Idle);
+            ReportFailureOnUi($"Transcription ended unexpectedly: {finalizeException.Message}");
+            await TeardownDictationSessionAsync(releasedSession).ConfigureAwait(false);
+            return;
+        }
+
+        await TeardownDictationSessionAsync(releasedSession).ConfigureAwait(false);
+
+        if (string.IsNullOrWhiteSpace(finalTranscript))
+        {
+            SetVoiceStateOnUi(AppState.VoiceState.Idle);
+            return;
+        }
+
+        SetLiveTranscriptOnUi(finalTranscript);
+        await DispatchToAiAndSpeakAsync(finalTranscript).ConfigureAwait(false);
+    }
+
+    private async Task DispatchToAiAndSpeakAsync(string userPrompt)
+    {
+        _currentRequestCts?.Dispose();
+        _currentRequestCts = new CancellationTokenSource();
+        var cancellationToken = _currentRequestCts.Token;
+
+        var selectedClient = ResolveClientForCurrentModel();
+
+        try
+        {
+            var streamResult = await selectedClient.StreamChatAsync(
+                systemPrompt: VoiceSystemPrompt,
+                conversationHistory: _conversationHistory,
+                userPrompt: userPrompt,
+                images: Array.Empty<InlineImage>(),
+                onTextChunk: AppendToStreamedResponseOnUi,
+                cancellationToken: cancellationToken).ConfigureAwait(false);
+
+            if (cancellationToken.IsCancellationRequested) return;
+
+            AppendTurnToHistory(userPrompt, streamResult.FullText);
+
+            if (streamResult.FullText.Length == 0)
+            {
+                SetVoiceStateOnUi(AppState.VoiceState.Idle);
+                return;
+            }
+
+            SetVoiceStateOnUi(AppState.VoiceState.Responding);
+            await _elevenLabsTtsClient.SpeakAsync(streamResult.FullText, cancellationToken).ConfigureAwait(false);
+        }
+        catch (OperationCanceledException)
+        {
+            // User cut us off — leave the state reset to the next handler.
+        }
+        catch (Exception aiException)
+        {
+            SetVoiceStateOnUi(AppState.VoiceState.Idle);
+            ReportFailureOnUi($"AI request failed: {aiException.Message}");
+        }
+    }
+
+    private IChatClient ResolveClientForCurrentModel()
+    {
+        var currentModelId = _appState.SelectedModelId;
+        if (AppState.IsGeminiModelId(currentModelId))
+        {
+            _geminiClient.Model = currentModelId;
+            return _geminiClient;
+        }
+        _claudeClient.Model = currentModelId;
+        return _claudeClient;
+    }
+
+    private void AppendTurnToHistory(string userPrompt, string assistantReply)
+    {
+        _conversationHistory.Add(new ConversationTurn(userPrompt, assistantReply));
+        while (_conversationHistory.Count > ConversationHistoryMaxTurns)
+        {
+            _conversationHistory.RemoveAt(0);
+        }
+    }
+
+    private async Task TeardownDictationSessionAsync(DictationSession session)
+    {
+        session.PartialTranscriptUpdated -= OnPartialTranscriptUpdated;
+        session.SessionFaulted -= OnDictationFaulted;
+        try
+        {
+            await session.StopAsync(CancellationToken.None).ConfigureAwait(false);
+        }
+        catch { /* tearing down — best effort */ }
+        await session.DisposeAsync().ConfigureAwait(false);
+        if (ReferenceEquals(_activeDictationSession, session))
+        {
+            _activeDictationSession = null;
+        }
+    }
+
+    private void OnPartialTranscriptUpdated(object? sender, string partialTranscript)
+    {
+        SetLiveTranscriptOnUi(partialTranscript);
+    }
+
+    private void OnDictationFaulted(object? sender, Exception exception)
+    {
+        ReportFailureOnUi($"Dictation error: {exception.Message}");
+        SetVoiceStateOnUi(AppState.VoiceState.Idle);
+    }
+
+    private void OnTtsPlaybackFinished(object? sender, EventArgs eventArgs)
+    {
+        SetVoiceStateOnUi(AppState.VoiceState.Idle);
+    }
+
+    private void OnAppStatePropertyChanged(object? sender, System.ComponentModel.PropertyChangedEventArgs args)
+    {
+        // Keep the chat clients' models in sync with the user's selection
+        // so a mid-conversation switch takes effect on the next turn.
+        if (args.PropertyName == nameof(AppState.SelectedModelId))
+        {
+            ResolveClientForCurrentModel();
+        }
+    }
+
+    // ---- UI marshaling helpers ----
+
+    private void SetVoiceStateOnUi(AppState.VoiceState newState)
+    {
+        _uiDispatcher.BeginInvoke(() => _appState.CurrentVoiceState = newState);
+    }
+
+    private void SetLiveTranscriptOnUi(string transcript)
+    {
+        _uiDispatcher.BeginInvoke(() => _appState.LiveTranscript = transcript);
+    }
+
+    private void SetStreamedResponseOnUi(string newText)
+    {
+        _uiDispatcher.BeginInvoke(() => _appState.StreamedResponseText = newText);
+    }
+
+    private void AppendToStreamedResponseOnUi(string textChunk)
+    {
+        _uiDispatcher.BeginInvoke(() => _appState.StreamedResponseText += textChunk);
+    }
+
+    private void ReportFailureOnUi(string failureMessage)
+    {
+        _uiDispatcher.BeginInvoke(() => _appState.LastStatusMessage = failureMessage);
+    }
+
+    // ---- Model defaults ----
+
+    private static string InferInitialClaudeModel(string selectedModelId)
+    {
+        return AppState.IsGeminiModelId(selectedModelId) ? ClaudeClient.DefaultModel : selectedModelId;
+    }
+
+    private static string InferInitialGeminiModel(string selectedModelId)
+    {
+        return AppState.IsGeminiModelId(selectedModelId) ? selectedModelId : GeminiClient.DefaultModel;
+    }
+
+    public async ValueTask DisposeAsync()
+    {
+        _appState.PropertyChanged -= OnAppStatePropertyChanged;
+        _currentRequestCts?.Cancel();
+        _currentRequestCts?.Dispose();
+
+        if (_activeDictationSession is not null)
+        {
+            await TeardownDictationSessionAsync(_activeDictationSession).ConfigureAwait(false);
+        }
+
+        _elevenLabsTtsClient.PlaybackFinished -= OnTtsPlaybackFinished;
+        _elevenLabsTtsClient.Dispose();
+        _claudeClient.Dispose();
+        _geminiClient.Dispose();
+    }
+}

--- a/windows/Clicky/Services/VoicePipelineOrchestrator.cs
+++ b/windows/Clicky/Services/VoicePipelineOrchestrator.cs
@@ -1,3 +1,5 @@
+using System.Globalization;
+using System.Text.RegularExpressions;
 using System.Windows.Threading;
 
 namespace Clicky.Services;
@@ -17,13 +19,51 @@ namespace Clicky.Services;
 /// </summary>
 public sealed class VoicePipelineOrchestrator : IAsyncDisposable
 {
-    // Kept short because TTS reads the reply out loud — a long monologue
-    // makes the app feel sluggish. Mirrors the macOS Buddy personality.
+    // Verbatim port of CompanionManager.companionVoiceResponseSystemPrompt.
+    // Kept in sync with the macOS version so prompt-engineering tweaks there
+    // translate directly. The trailing [POINT:...] tag is stripped before
+    // TTS / display; the M4 overlay will start consuming it.
     private const string VoiceSystemPrompt =
-        "You are Clicky, a concise and friendly voice assistant. Reply in one or two short sentences " +
-        "suitable for being read aloud. Avoid lists and markdown. If the user asks you to point at " +
-        "something, say what you would point at in plain words — the visual pointing feature is not " +
-        "available in this milestone.";
+        "you're clicky, a friendly always-on companion that lives in the user's menu bar. the user just spoke to you via push-to-talk and you can see their screen(s). your reply will be spoken aloud via text-to-speech, so write the way you'd actually talk. this is an ongoing conversation — you remember everything they've said before.\n" +
+        "\n" +
+        "rules:\n" +
+        "- default to one or two sentences. be direct and dense. BUT if the user asks you to explain more, go deeper, or elaborate, then go all out — give a thorough, detailed explanation with no length limit.\n" +
+        "- all lowercase, casual, warm. no emojis.\n" +
+        "- write for the ear, not the eye. short sentences. no lists, bullet points, markdown, or formatting — just natural speech.\n" +
+        "- don't use abbreviations or symbols that sound weird read aloud. write \"for example\" not \"e.g.\", spell out small numbers.\n" +
+        "- if the user's question relates to what's on their screen, reference specific things you see.\n" +
+        "- if the screenshot doesn't seem relevant to their question, just answer the question directly.\n" +
+        "- you can help with anything — coding, writing, general knowledge, brainstorming.\n" +
+        "- never say \"simply\" or \"just\".\n" +
+        "- don't read out code verbatim. describe what the code does or what needs to change conversationally.\n" +
+        "- focus on giving a thorough, useful explanation. don't end with simple yes/no questions like \"want me to explain more?\" or \"should i show you?\" — those are dead ends that force the user to just say yes.\n" +
+        "- instead, when it fits naturally, end by planting a seed — mention something bigger or more ambitious they could try, a related concept that goes deeper, or a next-level technique that builds on what you just explained. make it something worth coming back for, not a question they'd just nod to. it's okay to not end with anything extra if the answer is complete on its own.\n" +
+        "- if you receive multiple screen images, the one labeled \"primary focus\" is where the cursor is — prioritize that one but reference others if relevant.\n" +
+        "\n" +
+        "element pointing:\n" +
+        "you have a small blue triangle cursor that can fly to and point at things on screen. use it whenever pointing would genuinely help the user — if they're asking how to do something, looking for a menu, trying to find a button, or need help navigating an app, point at the relevant element. err on the side of pointing rather than not pointing, because it makes your help way more useful and concrete.\n" +
+        "\n" +
+        "don't point at things when it would be pointless — like if the user asks a general knowledge question, or the conversation has nothing to do with what's on screen, or you'd just be pointing at something obvious they're already looking at. but if there's a specific UI element, menu, button, or area on screen that's relevant to what you're helping with, point at it.\n" +
+        "\n" +
+        "when you point, append a coordinate tag at the very end of your response, AFTER your spoken text. the screenshot images are labeled with their pixel dimensions. use those dimensions as the coordinate space. the origin (0,0) is the top-left corner of the image. x increases rightward, y increases downward.\n" +
+        "\n" +
+        "format: [POINT:x,y:label] where x,y are integer pixel coordinates in the screenshot's coordinate space, and label is a short 1-3 word description of the element (like \"search bar\" or \"save button\"). if the element is on the cursor's screen you can omit the screen number. if the element is on a DIFFERENT screen, append :screenN where N is the screen number from the image label (e.g. :screen2). this is important — without the screen number, the cursor will point at the wrong place.\n" +
+        "\n" +
+        "if pointing wouldn't help, append [POINT:none].\n" +
+        "\n" +
+        "examples:\n" +
+        "- user asks how to color grade in final cut: \"you'll want to open the color inspector — it's right up in the top right area of the toolbar. click that and you'll get all the color wheels and curves. [POINT:1100,42:color inspector]\"\n" +
+        "- user asks what html is: \"html stands for hypertext markup language, it's basically the skeleton of every web page. curious how it connects to the css you're looking at? [POINT:none]\"\n" +
+        "- user asks how to commit in xcode: \"see that source control menu up top? click that and hit commit, or you can use command option c as a shortcut. [POINT:285,11:source control]\"\n" +
+        "- element is on screen 2 (not where cursor is): \"that's over on your other monitor — see the terminal window? [POINT:400,300:terminal:screen2]\"";
+
+    // Matches a trailing [POINT:none] / [POINT:x,y:label] / [POINT:x,y:label:screenN]
+    // tag so we can strip it before speaking / displaying. Same shape as the
+    // Swift regex in CompanionManager.parsePointingCoordinates — the M4/M5
+    // overlay will re-parse the captured groups to aim the pointer.
+    private static readonly Regex PointingTagTrailingRegex = new(
+        @"\[POINT:(?:none|(\d+)\s*,\s*(\d+)(?::([^\]:\s][^\]:]*?))?(?::screen(\d+))?)\]\s*$",
+        RegexOptions.Compiled | RegexOptions.CultureInvariant);
 
     private const int ConversationHistoryMaxTurns = 10;
 
@@ -32,6 +72,7 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
     private readonly ClaudeClient _claudeClient;
     private readonly GeminiClient _geminiClient;
     private readonly ElevenLabsTtsClient _elevenLabsTtsClient;
+    private readonly ScreenCaptureService _screenCaptureService;
 
     private DictationSession? _activeDictationSession;
     private readonly List<ConversationTurn> _conversationHistory = new();
@@ -47,6 +88,7 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
         _geminiClient = new GeminiClient(model: InferInitialGeminiModel(appState.SelectedModelId));
         _elevenLabsTtsClient = new ElevenLabsTtsClient();
         _elevenLabsTtsClient.PlaybackFinished += OnTtsPlaybackFinished;
+        _screenCaptureService = new ScreenCaptureService();
 
         _appState.PropertyChanged += OnAppStatePropertyChanged;
     }
@@ -124,26 +166,40 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
 
         try
         {
+            // Grab every monitor JPEG before contacting the model. BitBlt is
+            // synchronous and runs on a thread pool thread so the UI doesn't
+            // freeze while the capture happens.
+            var inlineImages = await Task.Run(BuildInlineImagesForCurrentScreens, cancellationToken).ConfigureAwait(false);
+
+            if (cancellationToken.IsCancellationRequested) return;
+
             var streamResult = await selectedClient.StreamChatAsync(
                 systemPrompt: VoiceSystemPrompt,
                 conversationHistory: _conversationHistory,
                 userPrompt: userPrompt,
-                images: Array.Empty<InlineImage>(),
+                images: inlineImages,
                 onTextChunk: AppendToStreamedResponseOnUi,
                 cancellationToken: cancellationToken).ConfigureAwait(false);
 
             if (cancellationToken.IsCancellationRequested) return;
 
-            AppendTurnToHistory(userPrompt, streamResult.FullText);
+            // Strip the trailing [POINT:...] tag — M3 ignores the coordinates,
+            // M4/M5 will parse them to fly the overlay cursor. TTS speaks the
+            // stripped text, and the panel shows the stripped text so the
+            // user doesn't see the raw tag at the end.
+            var strippedReplyText = PointingTagTrailingRegex.Replace(streamResult.FullText, string.Empty).TrimEnd();
+            SetStreamedResponseOnUi(strippedReplyText);
 
-            if (streamResult.FullText.Length == 0)
+            AppendTurnToHistory(userPrompt, strippedReplyText);
+
+            if (strippedReplyText.Length == 0)
             {
                 SetVoiceStateOnUi(AppState.VoiceState.Idle);
                 return;
             }
 
             SetVoiceStateOnUi(AppState.VoiceState.Responding);
-            await _elevenLabsTtsClient.SpeakAsync(streamResult.FullText, cancellationToken).ConfigureAwait(false);
+            await _elevenLabsTtsClient.SpeakAsync(strippedReplyText, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -154,6 +210,34 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
             SetVoiceStateOnUi(AppState.VoiceState.Idle);
             ReportFailureOnUi($"AI request failed: {aiException.Message}");
         }
+    }
+
+    /// <summary>
+    /// Captures every monitor and wraps each JPEG into an <see cref="InlineImage"/>
+    /// whose label matches the macOS format — "screen N of M — cursor is on
+    /// this screen (primary focus) (image dimensions: WxH pixels)" — so the
+    /// model's coordinate space maps to the pixels it actually sees.
+    /// </summary>
+    private IReadOnlyList<InlineImage> BuildInlineImagesForCurrentScreens()
+    {
+        var capturedMonitors = _screenCaptureService.CaptureAllMonitors();
+        if (capturedMonitors.Count == 0) return Array.Empty<InlineImage>();
+
+        var inlineImages = new List<InlineImage>(capturedMonitors.Count);
+        foreach (var monitorCapture in capturedMonitors)
+        {
+            var dimensionSuffix = string.Format(
+                CultureInfo.InvariantCulture,
+                " (image dimensions: {0}x{1} pixels)",
+                monitorCapture.ScreenshotWidthPixels,
+                monitorCapture.ScreenshotHeightPixels);
+
+            inlineImages.Add(new InlineImage(
+                Data: monitorCapture.JpegData,
+                MimeType: monitorCapture.MimeType,
+                Label: monitorCapture.Label + dimensionSuffix));
+        }
+        return inlineImages;
     }
 
     private IChatClient ResolveClientForCurrentModel()

--- a/windows/Clicky/Services/VoicePipelineOrchestrator.cs
+++ b/windows/Clicky/Services/VoicePipelineOrchestrator.cs
@@ -1,5 +1,4 @@
 using System.Globalization;
-using System.Text.RegularExpressions;
 using System.Windows.Threading;
 
 namespace Clicky.Services;
@@ -57,13 +56,18 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
         "- user asks how to commit in xcode: \"see that source control menu up top? click that and hit commit, or you can use command option c as a shortcut. [POINT:285,11:source control]\"\n" +
         "- element is on screen 2 (not where cursor is): \"that's over on your other monitor — see the terminal window? [POINT:400,300:terminal:screen2]\"";
 
-    // Matches a trailing [POINT:none] / [POINT:x,y:label] / [POINT:x,y:label:screenN]
-    // tag so we can strip it before speaking / displaying. Same shape as the
-    // Swift regex in CompanionManager.parsePointingCoordinates — the M4/M5
-    // overlay will re-parse the captured groups to aim the pointer.
-    private static readonly Regex PointingTagTrailingRegex = new(
-        @"\[POINT:(?:none|(\d+)\s*,\s*(\d+)(?::([^\]:\s][^\]:]*?))?(?::screen(\d+))?)\]\s*$",
-        RegexOptions.Compiled | RegexOptions.CultureInvariant);
+    // Short "here!" phrases picked at random for the speech bubble the
+    // triangle shows once it reaches the element. Mirrors the macOS list
+    // in OverlayWindow.navigationBubblePhrases.
+    private static readonly string[] PointerBubblePhrases =
+    {
+        "right here!",
+        "this one!",
+        "over here!",
+        "click this!",
+        "here it is!",
+        "found it!",
+    };
 
     private const int ConversationHistoryMaxTurns = 10;
 
@@ -73,16 +77,21 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
     private readonly GeminiClient _geminiClient;
     private readonly ElevenLabsTtsClient _elevenLabsTtsClient;
     private readonly ScreenCaptureService _screenCaptureService;
+    private readonly OverlayWindowManager? _overlayWindowManager;
 
     private DictationSession? _activeDictationSession;
     private readonly List<ConversationTurn> _conversationHistory = new();
 
     private CancellationTokenSource? _currentRequestCts;
 
-    public VoicePipelineOrchestrator(AppState appState, Dispatcher uiDispatcher)
+    public VoicePipelineOrchestrator(
+        AppState appState,
+        Dispatcher uiDispatcher,
+        OverlayWindowManager? overlayWindowManager = null)
     {
         _appState = appState;
         _uiDispatcher = uiDispatcher;
+        _overlayWindowManager = overlayWindowManager;
 
         _claudeClient = new ClaudeClient(model: InferInitialClaudeModel(appState.SelectedModelId));
         _geminiClient = new GeminiClient(model: InferInitialGeminiModel(appState.SelectedModelId));
@@ -168,8 +177,13 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
         {
             // Grab every monitor JPEG before contacting the model. BitBlt is
             // synchronous and runs on a thread pool thread so the UI doesn't
-            // freeze while the capture happens.
-            var inlineImages = await Task.Run(BuildInlineImagesForCurrentScreens, cancellationToken).ConfigureAwait(false);
+            // freeze while the capture happens. We also keep the raw capture
+            // list so [POINT:…] coordinates can be mapped back to the matching
+            // monitor's bounds once the reply is parsed.
+            var capturedMonitors = await Task.Run(
+                () => _screenCaptureService.CaptureAllMonitors(),
+                cancellationToken).ConfigureAwait(false);
+            var inlineImages = BuildInlineImagesFromCaptures(capturedMonitors);
 
             if (cancellationToken.IsCancellationRequested) return;
 
@@ -183,23 +197,26 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
 
             if (cancellationToken.IsCancellationRequested) return;
 
-            // Strip the trailing [POINT:...] tag — M3 ignores the coordinates,
-            // M4/M5 will parse them to fly the overlay cursor. TTS speaks the
-            // stripped text, and the panel shows the stripped text so the
-            // user doesn't see the raw tag at the end.
-            var strippedReplyText = PointingTagTrailingRegex.Replace(streamResult.FullText, string.Empty).TrimEnd();
-            SetStreamedResponseOnUi(strippedReplyText);
+            // Split the reply into spoken text + optional pointing target.
+            // TTS speaks the spoken text; the flight fires before playback
+            // starts so the triangle is already en route when the user
+            // hears Clicky start talking.
+            var pointingParseResult = PointingTagParser.Parse(streamResult.FullText);
+            var spokenText = pointingParseResult.SpokenText;
+            SetStreamedResponseOnUi(spokenText);
 
-            AppendTurnToHistory(userPrompt, strippedReplyText);
+            AppendTurnToHistory(userPrompt, spokenText);
 
-            if (strippedReplyText.Length == 0)
+            TriggerPointingFlightIfRequested(pointingParseResult, capturedMonitors);
+
+            if (spokenText.Length == 0)
             {
                 SetVoiceStateOnUi(AppState.VoiceState.Idle);
                 return;
             }
 
             SetVoiceStateOnUi(AppState.VoiceState.Responding);
-            await _elevenLabsTtsClient.SpeakAsync(strippedReplyText, cancellationToken).ConfigureAwait(false);
+            await _elevenLabsTtsClient.SpeakAsync(spokenText, cancellationToken).ConfigureAwait(false);
         }
         catch (OperationCanceledException)
         {
@@ -213,14 +230,13 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
     }
 
     /// <summary>
-    /// Captures every monitor and wraps each JPEG into an <see cref="InlineImage"/>
-    /// whose label matches the macOS format — "screen N of M — cursor is on
-    /// this screen (primary focus) (image dimensions: WxH pixels)" — so the
+    /// Wraps each monitor capture into an <see cref="InlineImage"/> whose
+    /// label matches the macOS format — "screen N of M — cursor is on this
+    /// screen (primary focus) (image dimensions: WxH pixels)" — so the
     /// model's coordinate space maps to the pixels it actually sees.
     /// </summary>
-    private IReadOnlyList<InlineImage> BuildInlineImagesForCurrentScreens()
+    private static IReadOnlyList<InlineImage> BuildInlineImagesFromCaptures(IReadOnlyList<MonitorCapture> capturedMonitors)
     {
-        var capturedMonitors = _screenCaptureService.CaptureAllMonitors();
         if (capturedMonitors.Count == 0) return Array.Empty<InlineImage>();
 
         var inlineImages = new List<InlineImage>(capturedMonitors.Count);
@@ -238,6 +254,55 @@ public sealed class VoicePipelineOrchestrator : IAsyncDisposable
                 Label: monitorCapture.Label + dimensionSuffix));
         }
         return inlineImages;
+    }
+
+    /// <summary>
+    /// Maps a parsed <c>[POINT:x,y:label:screenN]</c> tag back to a concrete
+    /// overlay flight: picks the target monitor (by screen index, defaulting
+    /// to the cursor's monitor i.e. index 0), rescales screenshot pixels to
+    /// the monitor's native device pixels, clamps into bounds, and tells the
+    /// <see cref="OverlayWindowManager"/> to fly the triangle there.
+    /// </summary>
+    private void TriggerPointingFlightIfRequested(
+        PointingParseResult parseResult,
+        IReadOnlyList<MonitorCapture> capturedMonitors)
+    {
+        if (_overlayWindowManager is null) return;
+        if (parseResult.Coordinate is not (int pointX, int pointY)) return;
+        if (capturedMonitors.Count == 0) return;
+
+        // screenNumber is 1-based and indexes into the cursor-first capture
+        // list. Out-of-range values fall back to the cursor's screen so a
+        // sloppy AI reply still lands somewhere sensible.
+        var targetCaptureIndex = 0;
+        if (parseResult.ScreenNumber is int screenNumber)
+        {
+            var candidateIndex = screenNumber - 1;
+            if (candidateIndex >= 0 && candidateIndex < capturedMonitors.Count)
+            {
+                targetCaptureIndex = candidateIndex;
+            }
+        }
+
+        var targetCapture = capturedMonitors[targetCaptureIndex];
+        if (targetCapture.ScreenshotWidthPixels <= 0 || targetCapture.ScreenshotHeightPixels <= 0) return;
+
+        // Screenshot coords → display-local device pixels. The JPEG may be
+        // downscaled (MaxLongestSidePixels in ScreenCaptureService), so we
+        // rescale to the monitor's native resolution before handing off.
+        var screenshotScaleX = (double)targetCapture.DisplayWidthPixels / targetCapture.ScreenshotWidthPixels;
+        var screenshotScaleY = (double)targetCapture.DisplayHeightPixels / targetCapture.ScreenshotHeightPixels;
+        var displayLocalDeviceX = Math.Clamp(pointX * screenshotScaleX, 0, targetCapture.DisplayWidthPixels - 1);
+        var displayLocalDeviceY = Math.Clamp(pointY * screenshotScaleY, 0, targetCapture.DisplayHeightPixels - 1);
+
+        var bubblePhrase = PointerBubblePhrases[Random.Shared.Next(PointerBubblePhrases.Length)];
+
+        _overlayWindowManager.FlyToElement(
+            targetMonitorBoundsLeftDevicePixels: targetCapture.DisplayBoundsDevicePixels.X,
+            targetMonitorBoundsTopDevicePixels: targetCapture.DisplayBoundsDevicePixels.Y,
+            targetDisplayLocalDeviceX: displayLocalDeviceX,
+            targetDisplayLocalDeviceY: displayLocalDeviceY,
+            bubblePhrase: bubblePhrase);
     }
 
     private IChatClient ResolveClientForCurrentModel()

--- a/windows/Clicky/Services/WorkerConfig.cs
+++ b/windows/Clicky/Services/WorkerConfig.cs
@@ -1,0 +1,26 @@
+namespace Clicky.Services;
+
+/// <summary>
+/// Cloudflare Worker proxy endpoints. Mirrors the single <c>workerBaseURL</c>
+/// constant in the macOS <c>CompanionManager.swift</c>. All provider secrets
+/// (Anthropic, Gemini, AssemblyAI, ElevenLabs) live on the Worker — the
+/// desktop app ships with zero embedded keys and reaches the upstream APIs
+/// only through these routes.
+///
+/// Swap <see cref="BaseUrl"/> for your own Worker deployment. Everything
+/// else is derived from it.
+/// </summary>
+public static class WorkerConfig
+{
+    /// <summary>
+    /// Base URL of the Cloudflare Worker deployment. Matches the placeholder
+    /// used in the macOS source — replace with your own Worker subdomain
+    /// before shipping.
+    /// </summary>
+    public const string BaseUrl = "https://your-worker-name.your-subdomain.workers.dev";
+
+    public static string ChatClaudeUrl => $"{BaseUrl}/chat";
+    public static string ChatGeminiUrl => $"{BaseUrl}/chat-gemini";
+    public static string TranscribeTokenUrl => $"{BaseUrl}/transcribe-token";
+    public static string TtsUrl => $"{BaseUrl}/tts";
+}

--- a/windows/Clicky/Services/WorkerConfig.cs
+++ b/windows/Clicky/Services/WorkerConfig.cs
@@ -23,4 +23,17 @@ public static class WorkerConfig
     public static string ChatGeminiUrl => $"{BaseUrl}/chat-gemini";
     public static string TranscribeTokenUrl => $"{BaseUrl}/transcribe-token";
     public static string TtsUrl => $"{BaseUrl}/tts";
+
+    /// <summary>
+    /// PostHog project write-only key. PostHog keys are designed to ship in
+    /// client apps — they can only post events, not read data — so it's safe
+    /// to bundle one here. Swap the placeholder for your own project key to
+    /// enable analytics; leave it unset and <see cref="ClickyAnalytics"/>
+    /// silently drops every event.
+    /// </summary>
+    public const string PostHogWriteKey = "phc_YOUR_POSTHOG_WRITE_KEY_HERE";
+
+    /// <summary>PostHog capture endpoint (US region). Matches the macOS
+    /// <c>ClickyAnalytics.swift</c> host.</summary>
+    public const string PostHogCaptureUrl = "https://us.i.posthog.com/capture/";
 }

--- a/windows/Clicky/ViewModels/TrayPanelViewModel.cs
+++ b/windows/Clicky/ViewModels/TrayPanelViewModel.cs
@@ -1,0 +1,94 @@
+using CommunityToolkit.Mvvm.ComponentModel;
+using CommunityToolkit.Mvvm.Input;
+using System.Collections.ObjectModel;
+
+namespace Clicky.ViewModels;
+
+/// <summary>
+/// View-model for the borderless tray popover. Binds the model picker rows
+/// (Claude: Sonnet/Opus, Gemini: Flash/Pro) to <see cref="AppState.SelectedModelId"/>
+/// and exposes a Quit command for the app.
+/// </summary>
+public sealed partial class TrayPanelViewModel : ObservableObject
+{
+    private readonly AppState _appState;
+
+    public TrayPanelViewModel(AppState appState)
+    {
+        _appState = appState;
+        _appState.PropertyChanged += (_, args) =>
+        {
+            if (args.PropertyName == nameof(AppState.SelectedModelId))
+            {
+                // Refresh the IsSelected flag on every model option so the
+                // segmented-control highlight follows the active choice.
+                foreach (var option in ClaudeOptions) option.RefreshSelection(_appState.SelectedModelId);
+                foreach (var option in GeminiOptions) option.RefreshSelection(_appState.SelectedModelId);
+            }
+        };
+
+        ClaudeOptions = new ObservableCollection<ModelOption>
+        {
+            CreateOption("Sonnet", "claude-sonnet-4-6"),
+            CreateOption("Opus",   "claude-opus-4-6"),
+        };
+
+        GeminiOptions = new ObservableCollection<ModelOption>
+        {
+            CreateOption("Flash", "gemini-2.5-flash"),
+            CreateOption("Pro",   "gemini-2.5-pro"),
+        };
+    }
+
+    public ObservableCollection<ModelOption> ClaudeOptions { get; }
+    public ObservableCollection<ModelOption> GeminiOptions { get; }
+
+    [RelayCommand]
+    private void SelectModel(string modelId)
+    {
+        if (!string.IsNullOrEmpty(modelId))
+        {
+            _appState.SelectedModelId = modelId;
+        }
+    }
+
+    [RelayCommand]
+    private void Quit()
+    {
+        System.Windows.Application.Current.Shutdown();
+    }
+
+    private ModelOption CreateOption(string displayLabel, string modelId)
+    {
+        var option = new ModelOption(displayLabel, modelId, SelectModelCommand);
+        option.RefreshSelection(_appState.SelectedModelId);
+        return option;
+    }
+}
+
+/// <summary>
+/// A single button within a model-picker segmented control. Exposes a
+/// pre-bound <see cref="SelectCommand"/> so the XAML ItemsControl can wire
+/// each button without needing ancestor-lookup gymnastics.
+/// </summary>
+public sealed partial class ModelOption : ObservableObject
+{
+    public ModelOption(string displayLabel, string modelId, IRelayCommand<string?> selectCommand)
+    {
+        DisplayLabel = displayLabel;
+        ModelId = modelId;
+        SelectCommand = selectCommand;
+    }
+
+    public string DisplayLabel { get; }
+    public string ModelId { get; }
+    public IRelayCommand<string?> SelectCommand { get; }
+
+    [ObservableProperty]
+    private bool _isSelected;
+
+    public void RefreshSelection(string currentModelId)
+    {
+        IsSelected = string.Equals(currentModelId, ModelId, StringComparison.OrdinalIgnoreCase);
+    }
+}

--- a/windows/Clicky/ViewModels/TrayPanelViewModel.cs
+++ b/windows/Clicky/ViewModels/TrayPanelViewModel.cs
@@ -1,13 +1,14 @@
 using CommunityToolkit.Mvvm.ComponentModel;
 using CommunityToolkit.Mvvm.Input;
 using System.Collections.ObjectModel;
+using Clicky.Services;
 
 namespace Clicky.ViewModels;
 
 /// <summary>
 /// View-model for the borderless tray popover. Binds the model picker rows
 /// (Claude: Sonnet/Opus, Gemini: Flash/Pro) to <see cref="AppState.SelectedModelId"/>
-/// and exposes a Quit command for the app.
+/// and exposes Quit, onboarding, and privacy-settings commands for the app.
 /// </summary>
 public sealed partial class TrayPanelViewModel : ObservableObject
 {
@@ -25,6 +26,11 @@ public sealed partial class TrayPanelViewModel : ObservableObject
                 foreach (var option in ClaudeOptions) option.RefreshSelection(_appState.SelectedModelId);
                 foreach (var option in GeminiOptions) option.RefreshSelection(_appState.SelectedModelId);
             }
+            else if (args.PropertyName == nameof(AppState.HasCompletedOnboarding))
+            {
+                OnPropertyChanged(nameof(IsOnboardingVisible));
+                OnPropertyChanged(nameof(IsMainContentVisible));
+            }
         };
 
         ClaudeOptions = new ObservableCollection<ModelOption>
@@ -38,6 +44,37 @@ public sealed partial class TrayPanelViewModel : ObservableObject
             CreateOption("Flash", "gemini-2.5-flash"),
             CreateOption("Pro",   "gemini-2.5-pro"),
         };
+    }
+
+    /// <summary>
+    /// Shows the welcome/onboarding block (Get started button + intro copy)
+    /// until the user completes it once. After that it stays hidden and the
+    /// regular panel body takes over.
+    /// </summary>
+    public bool IsOnboardingVisible => !_appState.HasCompletedOnboarding;
+
+    /// <summary>The main panel body (transcript, model picker, footer) —
+    /// shown once onboarding is done.</summary>
+    public bool IsMainContentVisible => _appState.HasCompletedOnboarding;
+
+    [RelayCommand]
+    private void CompleteOnboarding()
+    {
+        _appState.HasCompletedOnboarding = true;
+        ClickyAnalytics.TrackOnboardingCompleted();
+    }
+
+    [RelayCommand]
+    private void ReplayOnboarding()
+    {
+        _appState.HasCompletedOnboarding = false;
+        ClickyAnalytics.TrackOnboardingReplayed();
+    }
+
+    [RelayCommand]
+    private void OpenMicrophonePrivacySettings()
+    {
+        MicrophonePermissionHelper.OpenWindowsMicrophonePrivacySettings();
     }
 
     public ObservableCollection<ModelOption> ClaudeOptions { get; }

--- a/windows/Clicky/ViewModels/TrayPanelViewModel.cs
+++ b/windows/Clicky/ViewModels/TrayPanelViewModel.cs
@@ -43,6 +43,15 @@ public sealed partial class TrayPanelViewModel : ObservableObject
     public ObservableCollection<ModelOption> ClaudeOptions { get; }
     public ObservableCollection<ModelOption> GeminiOptions { get; }
 
+    /// <summary>
+    /// Exposed so the panel can bind directly to
+    /// <see cref="AppState.LiveTranscript"/>,
+    /// <see cref="AppState.StreamedResponseText"/>, and
+    /// <see cref="AppState.LastStatusMessage"/> without the view-model
+    /// having to re-publish them.
+    /// </summary>
+    public AppState AppState => _appState;
+
     [RelayCommand]
     private void SelectModel(string modelId)
     {

--- a/windows/Clicky/Views/BooleanToVisibilityConverter.cs
+++ b/windows/Clicky/Views/BooleanToVisibilityConverter.cs
@@ -1,0 +1,30 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Clicky.Views;
+
+/// <summary>
+/// Maps a bound boolean to <see cref="Visibility"/>. True → Visible,
+/// False → Collapsed by default; pass <c>"Invert"</c> as the converter
+/// parameter to flip the mapping (used by the tray panel to show the
+/// welcome block while the main panel is collapsed, and vice-versa).
+/// </summary>
+[ValueConversion(typeof(bool), typeof(Visibility))]
+public sealed class BooleanToVisibilityConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        var boolValue = value is bool b && b;
+        if (string.Equals(parameter as string, "Invert", StringComparison.OrdinalIgnoreCase))
+        {
+            boolValue = !boolValue;
+        }
+        return boolValue ? Visibility.Visible : Visibility.Collapsed;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/windows/Clicky/Views/OverlayWindow.xaml
+++ b/windows/Clicky/Views/OverlayWindow.xaml
@@ -1,0 +1,61 @@
+<Window x:Class="Clicky.Views.OverlayWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        WindowStyle="None"
+        AllowsTransparency="True"
+        Background="Transparent"
+        ShowInTaskbar="False"
+        Topmost="True"
+        ResizeMode="NoResize"
+        Focusable="False"
+        IsHitTestVisible="False"
+        SnapsToDevicePixels="False"
+        UseLayoutRounding="False"
+        ShowActivated="False"
+        Title="Clicky Overlay"
+        Width="1"
+        Height="1">
+
+    <Window.Resources>
+        <ResourceDictionary>
+            <ResourceDictionary.MergedDictionaries>
+                <ResourceDictionary Source="pack://application:,,,/Resources/DesignSystem.xaml"/>
+            </ResourceDictionary.MergedDictionaries>
+        </ResourceDictionary>
+    </Window.Resources>
+
+    <!--
+        The canvas fills the whole overlay; the triangle positions itself via
+        Canvas.Left / Canvas.Top in DIPs relative to the overlay's top-left.
+        Keep IsHitTestVisible="False" on every visual so nothing intercepts
+        clicks from the desktop beneath. The Window already sets that for us
+        but we repeat it on the triangle for clarity.
+
+        Triangle geometry (equilateral, 16 DIPs):
+          - base    from (0,   13.86) to (16,  13.86)
+          - apex    at   (8,    0)
+          - centroid is the average of the three points = (8, ~4.62).
+        We rotate + translate about the centroid so the pointer's
+        "visual anchor" lines up with the computed cursor-offset position.
+    -->
+    <Canvas x:Name="OverlayCanvas" Background="Transparent" IsHitTestVisible="False">
+        <Polygon x:Name="BlueTriangle"
+                 Points="8,0 16,13.856 0,13.856"
+                 Fill="{StaticResource OverlayCursorBlue}"
+                 IsHitTestVisible="False"
+                 Visibility="Collapsed"
+                 RenderTransformOrigin="0.5,0.3333">
+            <Polygon.Effect>
+                <DropShadowEffect Color="#3380FF"
+                                  BlurRadius="12"
+                                  ShadowDepth="0"
+                                  Opacity="0.85"/>
+            </Polygon.Effect>
+            <Polygon.RenderTransform>
+                <TransformGroup>
+                    <RotateTransform x:Name="BlueTriangleRotation" Angle="-35"/>
+                </TransformGroup>
+            </Polygon.RenderTransform>
+        </Polygon>
+    </Canvas>
+</Window>

--- a/windows/Clicky/Views/OverlayWindow.xaml
+++ b/windows/Clicky/Views/OverlayWindow.xaml
@@ -25,20 +25,20 @@
     </Window.Resources>
 
     <!--
-        The canvas fills the whole overlay; the triangle positions itself via
-        Canvas.Left / Canvas.Top in DIPs relative to the overlay's top-left.
-        Keep IsHitTestVisible="False" on every visual so nothing intercepts
-        clicks from the desktop beneath. The Window already sets that for us
-        but we repeat it on the triangle for clarity.
+        The canvas fills the whole overlay; the triangle and the pointer
+        bubble position themselves via Canvas.Left / Canvas.Top in DIPs
+        relative to the overlay's top-left.
 
         Triangle geometry (equilateral, 16 DIPs):
           - base    from (0,   13.86) to (16,  13.86)
           - apex    at   (8,    0)
           - centroid is the average of the three points = (8, ~4.62).
-        We rotate + translate about the centroid so the pointer's
+        The rotation + uniform scale are applied around the centroid so the
         "visual anchor" lines up with the computed cursor-offset position.
     -->
     <Canvas x:Name="OverlayCanvas" Background="Transparent" IsHitTestVisible="False">
+
+        <!-- Blue triangle cursor -->
         <Polygon x:Name="BlueTriangle"
                  Points="8,0 16,13.856 0,13.856"
                  Fill="{StaticResource OverlayCursorBlue}"
@@ -53,9 +53,40 @@
             </Polygon.Effect>
             <Polygon.RenderTransform>
                 <TransformGroup>
+                    <ScaleTransform x:Name="BlueTriangleScale" ScaleX="1" ScaleY="1"/>
                     <RotateTransform x:Name="BlueTriangleRotation" Angle="-35"/>
                 </TransformGroup>
             </Polygon.RenderTransform>
         </Polygon>
+
+        <!--
+            Pointer speech bubble. Positioned relative to the triangle via
+            Canvas.Left / Canvas.Top updates at runtime. Matches the macOS
+            navigationBubble: rounded 6pt pill, white 11pt text, blue fill,
+            blue drop-shadow glow, scale-bounce entrance (0.5 → 1.0).
+        -->
+        <Border x:Name="PointerBubble"
+                Background="{StaticResource OverlayCursorBlue}"
+                CornerRadius="6"
+                Padding="8,4"
+                IsHitTestVisible="False"
+                Visibility="Collapsed"
+                RenderTransformOrigin="0.5,0.5">
+            <Border.Effect>
+                <DropShadowEffect Color="#3380FF"
+                                  BlurRadius="10"
+                                  ShadowDepth="0"
+                                  Opacity="0.55"/>
+            </Border.Effect>
+            <Border.RenderTransform>
+                <ScaleTransform x:Name="PointerBubbleScale" ScaleX="0.5" ScaleY="0.5"/>
+            </Border.RenderTransform>
+            <TextBlock x:Name="PointerBubbleText"
+                       FontFamily="{StaticResource PrimaryFontFamily}"
+                       FontSize="11"
+                       FontWeight="Medium"
+                       Foreground="White"
+                       Text=""/>
+        </Border>
     </Canvas>
 </Window>

--- a/windows/Clicky/Views/OverlayWindow.xaml.cs
+++ b/windows/Clicky/Views/OverlayWindow.xaml.cs
@@ -1,0 +1,147 @@
+using System.Windows;
+using System.Windows.Controls;
+using System.Windows.Interop;
+using Clicky.Interop;
+
+namespace Clicky.Views;
+
+/// <summary>
+/// Transparent, click-through, always-on-top overlay covering a single
+/// monitor. Renders the blue triangle cursor that follows the system mouse.
+///
+/// One instance is created per connected display; the
+/// <see cref="Services.OverlayWindowManager"/> owns their lifecycle and
+/// drives cursor updates at 60 fps.
+///
+/// Mirrors the macOS <c>OverlayWindow</c> in <c>OverlayWindow.swift</c>.
+/// </summary>
+public partial class OverlayWindow : Window
+{
+    // Cursor-to-triangle offset matches the macOS overlay (35 px right,
+    // 25 px down) so the triangle sits beside the system cursor rather
+    // than on top of it. Interpreted in DIPs.
+    private const double CursorOffsetDipX = 35;
+    private const double CursorOffsetDipY = 25;
+
+    // The three polygon vertices live in a 16-DIP bounding box; the
+    // RotateTransform origin is (0.5, 0.3333) which puts the pivot at the
+    // centroid. When we move the triangle we place that centroid at the
+    // target position, so these constants shift the Canvas.Left/Top.
+    private const double TriangleBoundingBoxDipWidth = 16.0;
+    private const double TriangleBoundingBoxDipHeight = 13.856;
+    private const double TriangleCentroidOffsetDipX = TriangleBoundingBoxDipWidth / 2.0;
+    private const double TriangleCentroidOffsetDipY = TriangleBoundingBoxDipHeight / 3.0;
+
+    private readonly int _monitorBoundsLeftDevicePixels;
+    private readonly int _monitorBoundsTopDevicePixels;
+    private readonly int _monitorWidthDevicePixels;
+    private readonly int _monitorHeightDevicePixels;
+
+    private bool _hasBeenPositioned;
+
+    public OverlayWindow(
+        int monitorBoundsLeftDevicePixels,
+        int monitorBoundsTopDevicePixels,
+        int monitorWidthDevicePixels,
+        int monitorHeightDevicePixels)
+    {
+        _monitorBoundsLeftDevicePixels = monitorBoundsLeftDevicePixels;
+        _monitorBoundsTopDevicePixels = monitorBoundsTopDevicePixels;
+        _monitorWidthDevicePixels = monitorWidthDevicePixels;
+        _monitorHeightDevicePixels = monitorHeightDevicePixels;
+
+        InitializeComponent();
+        SourceInitialized += ApplyClickThroughExtendedStyles;
+    }
+
+    /// <summary>
+    /// Called once during startup by <see cref="Services.OverlayWindowManager"/>.
+    /// Applies click-through window styles and positions the overlay over
+    /// the monitor in device-pixel coordinates.
+    /// </summary>
+    public void ShowOnMonitor()
+    {
+        // Ensure the HWND exists — required before SetWindowPos and before
+        // the style bits get applied by <see cref="ApplyClickThroughExtendedStyles"/>.
+        var windowHandle = new WindowInteropHelper(this).EnsureHandle();
+
+        NativeMethods.SetWindowPos(
+            windowHandle,
+            NativeMethods.HWND_TOPMOST,
+            _monitorBoundsLeftDevicePixels,
+            _monitorBoundsTopDevicePixels,
+            _monitorWidthDevicePixels,
+            _monitorHeightDevicePixels,
+            NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_SHOWWINDOW);
+
+        Visibility = Visibility.Visible;
+        _hasBeenPositioned = true;
+    }
+
+    /// <summary>
+    /// Updates the overlay's triangle for a single cursor tracker tick.
+    /// When <paramref name="cursorIsOnThisMonitor"/> is false, we hide the
+    /// triangle so only one overlay shows it at a time.
+    /// </summary>
+    public void UpdateCursorState(
+        int cursorGlobalDeviceX,
+        int cursorGlobalDeviceY,
+        bool cursorIsOnThisMonitor,
+        bool triangleShouldBeVisible)
+    {
+        if (!_hasBeenPositioned) return;
+
+        if (!cursorIsOnThisMonitor || !triangleShouldBeVisible)
+        {
+            if (BlueTriangle.Visibility != Visibility.Collapsed)
+            {
+                BlueTriangle.Visibility = Visibility.Collapsed;
+            }
+            return;
+        }
+
+        // Convert the global cursor position (device pixels) into this
+        // monitor's local space, then into DIPs using the window's DPI so
+        // the triangle lands at the right spot on a scaled display.
+        var dpiScale = NativeMethods.GetDpiScale(this);
+        if (dpiScale <= 0) dpiScale = 1.0;
+
+        var cursorLocalDeviceX = cursorGlobalDeviceX - _monitorBoundsLeftDevicePixels;
+        var cursorLocalDeviceY = cursorGlobalDeviceY - _monitorBoundsTopDevicePixels;
+
+        var cursorLocalDipX = cursorLocalDeviceX / dpiScale;
+        var cursorLocalDipY = cursorLocalDeviceY / dpiScale;
+
+        // The triangle's RenderTransformOrigin is (0.5, 1/3), so we offset
+        // the Canvas.Left/Top by the centroid offsets to put the triangle's
+        // centroid exactly at (cursor + offset).
+        var triangleAnchorDipX = cursorLocalDipX + CursorOffsetDipX;
+        var triangleAnchorDipY = cursorLocalDipY + CursorOffsetDipY;
+
+        Canvas.SetLeft(BlueTriangle, triangleAnchorDipX - TriangleCentroidOffsetDipX);
+        Canvas.SetTop(BlueTriangle, triangleAnchorDipY - TriangleCentroidOffsetDipY);
+
+        if (BlueTriangle.Visibility != Visibility.Visible)
+        {
+            BlueTriangle.Visibility = Visibility.Visible;
+        }
+    }
+
+    private static void ApplyClickThroughExtendedStyles(object? sender, EventArgs eventArgs)
+    {
+        if (sender is not OverlayWindow overlayWindow) return;
+
+        var windowHandle = new WindowInteropHelper(overlayWindow).Handle;
+        var currentExtendedStyle = NativeMethods.GetExtendedStyle(windowHandle);
+        // WS_EX_TRANSPARENT  — forwards mouse events to the window beneath
+        // WS_EX_LAYERED      — required for WS_EX_TRANSPARENT on a non-child
+        // WS_EX_NOACTIVATE   — clicking the overlay never steals focus
+        // WS_EX_TOOLWINDOW   — never appears in Alt+Tab / taskbar
+        var desiredExtendedStyle = currentExtendedStyle
+            | NativeMethods.WS_EX_TRANSPARENT
+            | NativeMethods.WS_EX_LAYERED
+            | NativeMethods.WS_EX_NOACTIVATE
+            | NativeMethods.WS_EX_TOOLWINDOW;
+        NativeMethods.SetExtendedStyle(windowHandle, desiredExtendedStyle);
+    }
+}

--- a/windows/Clicky/Views/OverlayWindow.xaml.cs
+++ b/windows/Clicky/Views/OverlayWindow.xaml.cs
@@ -1,17 +1,20 @@
 using System.Windows;
 using System.Windows.Controls;
 using System.Windows.Interop;
+using System.Windows.Threading;
 using Clicky.Interop;
 
 namespace Clicky.Views;
 
 /// <summary>
 /// Transparent, click-through, always-on-top overlay covering a single
-/// monitor. Renders the blue triangle cursor that follows the system mouse.
+/// monitor. Renders the blue triangle cursor that follows the system mouse
+/// and, during element pointing (M5), animates along a bezier arc to a
+/// target location and shows a speech bubble.
 ///
 /// One instance is created per connected display; the
-/// <see cref="Services.OverlayWindowManager"/> owns their lifecycle and
-/// drives cursor updates at 60 fps.
+/// <see cref="Services.OverlayWindowManager"/> owns their lifecycle, the
+/// cursor-tracking timer, and the per-element flight requests.
 ///
 /// Mirrors the macOS <c>OverlayWindow</c> in <c>OverlayWindow.swift</c>.
 /// </summary>
@@ -23,14 +26,44 @@ public partial class OverlayWindow : Window
     private const double CursorOffsetDipX = 35;
     private const double CursorOffsetDipY = 25;
 
-    // The three polygon vertices live in a 16-DIP bounding box; the
-    // RotateTransform origin is (0.5, 0.3333) which puts the pivot at the
-    // centroid. When we move the triangle we place that centroid at the
-    // target position, so these constants shift the Canvas.Left/Top.
+    // Element-target offset: the triangle lands *next to* the element,
+    // not on top of it — 8 DIPs right and 12 DIPs below, matching
+    // macOS OverlayWindow.startNavigatingToElement.
+    private const double ElementOffsetDipX = 8;
+    private const double ElementOffsetDipY = 12;
+
+    // Speech bubble sits to the lower-right of the triangle tip (same
+    // relative position as macOS: x + 10, y + 18 in DIPs).
+    private const double BubbleOffsetDipX = 10;
+    private const double BubbleOffsetDipY = 18;
+
+    // Triangle bounding box (16 × 13.856 DIPs). RenderTransformOrigin is
+    // (0.5, 1/3) so the rotation/scale pivot is the centroid. When we move
+    // the triangle we place that centroid at the target position — these
+    // constants shift Canvas.Left/Top from centroid-coord back to bounding-
+    // box coord.
     private const double TriangleBoundingBoxDipWidth = 16.0;
     private const double TriangleBoundingBoxDipHeight = 13.856;
     private const double TriangleCentroidOffsetDipX = TriangleBoundingBoxDipWidth / 2.0;
     private const double TriangleCentroidOffsetDipY = TriangleBoundingBoxDipHeight / 3.0;
+
+    // Default "resting" rotation for the triangle (matches the macOS -35°).
+    private const double RestingRotationDegrees = -35.0;
+
+    private const int AnimationFramesPerSecond = 60;
+    private static readonly TimeSpan AnimationFrameInterval =
+        TimeSpan.FromSeconds(1.0 / AnimationFramesPerSecond);
+
+    // Bezier flight clamps — duration scales linearly with distance / 800 DIPs,
+    // clamped to [0.6s, 1.4s] so tiny hops still feel purposeful and cross-
+    // monitor flights don't drag on forever.
+    private const double FlightMinDurationSeconds = 0.6;
+    private const double FlightMaxDurationSeconds = 1.4;
+    private const double FlightDurationDistanceDivisor = 800.0;
+
+    // Bubble hold before flying back, matches macOS (3s pill + 0.5s fade).
+    private static readonly TimeSpan BubbleHoldDuration = TimeSpan.FromSeconds(3.0);
+    private static readonly TimeSpan BubbleFadeDuration = TimeSpan.FromMilliseconds(500);
 
     private readonly int _monitorBoundsLeftDevicePixels;
     private readonly int _monitorBoundsTopDevicePixels;
@@ -38,6 +71,17 @@ public partial class OverlayWindow : Window
     private readonly int _monitorHeightDevicePixels;
 
     private bool _hasBeenPositioned;
+
+    // Flight state. When _isFlightActive is true, the cursor-follow path
+    // in UpdateCursorState is skipped — the flight animation drives the
+    // triangle position directly.
+    private bool _isFlightActive;
+    private DispatcherTimer? _flightFrameTimer;
+
+    // Position in DIPs where the triangle currently sits (as last rendered).
+    // Flights start from this point so successive calls chain smoothly.
+    private double _triangleCurrentDipX;
+    private double _triangleCurrentDipY;
 
     public OverlayWindow(
         int monitorBoundsLeftDevicePixels,
@@ -61,8 +105,6 @@ public partial class OverlayWindow : Window
     /// </summary>
     public void ShowOnMonitor()
     {
-        // Ensure the HWND exists — required before SetWindowPos and before
-        // the style bits get applied by <see cref="ApplyClickThroughExtendedStyles"/>.
         var windowHandle = new WindowInteropHelper(this).EnsureHandle();
 
         NativeMethods.SetWindowPos(
@@ -78,10 +120,15 @@ public partial class OverlayWindow : Window
         _hasBeenPositioned = true;
     }
 
+    /// <summary>True while a flight/point/return sequence is running on
+    /// this overlay. The manager consults this to suppress cursor updates
+    /// here and on other overlays.</summary>
+    public bool IsFlightInProgress => _isFlightActive;
+
     /// <summary>
     /// Updates the overlay's triangle for a single cursor tracker tick.
-    /// When <paramref name="cursorIsOnThisMonitor"/> is false, we hide the
-    /// triangle so only one overlay shows it at a time.
+    /// Ignored while a flight is active — the flight animation owns the
+    /// triangle's position and rotation for its duration.
     /// </summary>
     public void UpdateCursorState(
         int cursorGlobalDeviceX,
@@ -90,6 +137,7 @@ public partial class OverlayWindow : Window
         bool triangleShouldBeVisible)
     {
         if (!_hasBeenPositioned) return;
+        if (_isFlightActive) return;
 
         if (!cursorIsOnThisMonitor || !triangleShouldBeVisible)
         {
@@ -100,31 +148,333 @@ public partial class OverlayWindow : Window
             return;
         }
 
-        // Convert the global cursor position (device pixels) into this
-        // monitor's local space, then into DIPs using the window's DPI so
-        // the triangle lands at the right spot on a scaled display.
-        var dpiScale = NativeMethods.GetDpiScale(this);
-        if (dpiScale <= 0) dpiScale = 1.0;
+        var (localDipX, localDipY) = ConvertGlobalDeviceToLocalDip(cursorGlobalDeviceX, cursorGlobalDeviceY);
+        var triangleDipX = localDipX + CursorOffsetDipX;
+        var triangleDipY = localDipY + CursorOffsetDipY;
+        PositionTriangle(triangleDipX, triangleDipY);
 
-        var cursorLocalDeviceX = cursorGlobalDeviceX - _monitorBoundsLeftDevicePixels;
-        var cursorLocalDeviceY = cursorGlobalDeviceY - _monitorBoundsTopDevicePixels;
-
-        var cursorLocalDipX = cursorLocalDeviceX / dpiScale;
-        var cursorLocalDipY = cursorLocalDeviceY / dpiScale;
-
-        // The triangle's RenderTransformOrigin is (0.5, 1/3), so we offset
-        // the Canvas.Left/Top by the centroid offsets to put the triangle's
-        // centroid exactly at (cursor + offset).
-        var triangleAnchorDipX = cursorLocalDipX + CursorOffsetDipX;
-        var triangleAnchorDipY = cursorLocalDipY + CursorOffsetDipY;
-
-        Canvas.SetLeft(BlueTriangle, triangleAnchorDipX - TriangleCentroidOffsetDipX);
-        Canvas.SetTop(BlueTriangle, triangleAnchorDipY - TriangleCentroidOffsetDipY);
+        // Keep the resting pose while cursor-following.
+        BlueTriangleRotation.Angle = RestingRotationDegrees;
+        BlueTriangleScale.ScaleX = 1.0;
+        BlueTriangleScale.ScaleY = 1.0;
 
         if (BlueTriangle.Visibility != Visibility.Visible)
         {
             BlueTriangle.Visibility = Visibility.Visible;
         }
+    }
+
+    /// <summary>
+    /// Starts the full element-pointing sequence on this overlay:
+    /// bezier flight out → speech bubble hold → bezier flight back to the
+    /// current cursor. All UI updates happen on the caller's Dispatcher
+    /// (expected to be the UI thread).
+    /// </summary>
+    /// <param name="targetDisplayLocalDeviceX">Target X in device pixels, local to this monitor's top-left.</param>
+    /// <param name="targetDisplayLocalDeviceY">Target Y in device pixels, local to this monitor's top-left.</param>
+    /// <param name="bubblePhrase">Text for the speech bubble. Streamed character-by-character with jittered delays.</param>
+    public void BeginElementPointingFlight(
+        double targetDisplayLocalDeviceX,
+        double targetDisplayLocalDeviceY,
+        string bubblePhrase)
+    {
+        if (!_hasBeenPositioned) return;
+
+        var dpiScale = NativeMethods.GetDpiScale(this);
+        if (dpiScale <= 0) dpiScale = 1.0;
+
+        var targetDipX = targetDisplayLocalDeviceX / dpiScale;
+        var targetDipY = targetDisplayLocalDeviceY / dpiScale;
+
+        // Offset so the triangle lands beside the element. Clamp inside the
+        // overlay bounds with a small margin so the triangle never clips off
+        // the edge of the monitor.
+        var monitorWidthDip = _monitorWidthDevicePixels / dpiScale;
+        var monitorHeightDip = _monitorHeightDevicePixels / dpiScale;
+        var destinationDipX = Math.Clamp(targetDipX + ElementOffsetDipX, 20, Math.Max(20, monitorWidthDip - 20));
+        var destinationDipY = Math.Clamp(targetDipY + ElementOffsetDipY, 20, Math.Max(20, monitorHeightDip - 20));
+
+        // Starting point = current triangle position (if we don't have one,
+        // fall back to the system cursor's local position so the first
+        // flight of the app still looks natural).
+        EnsureCurrentTrianglePositionInitialized();
+
+        _isFlightActive = true;
+        BlueTriangle.Visibility = Visibility.Visible;
+
+        FlyTriangleAlongBezier(
+            startDipX: _triangleCurrentDipX,
+            startDipY: _triangleCurrentDipY,
+            endDipX: destinationDipX,
+            endDipY: destinationDipY,
+            onFlightComplete: () => ShowPointerBubbleAndScheduleReturn(bubblePhrase));
+    }
+
+    private void ShowPointerBubbleAndScheduleReturn(string bubblePhrase)
+    {
+        // Triangle has arrived — reset rotation and scale, then bounce the
+        // bubble in with streaming text.
+        BlueTriangleRotation.Angle = RestingRotationDegrees;
+        BlueTriangleScale.ScaleX = 1.0;
+        BlueTriangleScale.ScaleY = 1.0;
+
+        PositionPointerBubble();
+        PointerBubbleText.Text = string.Empty;
+        PointerBubble.Opacity = 1.0;
+        PointerBubbleScale.ScaleX = 0.5;
+        PointerBubbleScale.ScaleY = 0.5;
+        PointerBubble.Visibility = Visibility.Visible;
+
+        // Spring-bounce the bubble to 1.0x — WPF has no spring easing, so a
+        // short ease-out gives a close-enough bounce for this size.
+        AnimateBubbleScaleTo(targetScale: 1.0, durationMs: 260);
+
+        StreamBubbleCharacters(bubblePhrase, characterIndex: 0, onStreamComplete: () =>
+        {
+            // Hold for 3s, fade out 0.5s, then fly back.
+            var holdTimer = new DispatcherTimer { Interval = BubbleHoldDuration };
+            holdTimer.Tick += (_, _) =>
+            {
+                holdTimer.Stop();
+                FadeOutBubbleThenFlyBack();
+            };
+            holdTimer.Start();
+        });
+    }
+
+    private void FadeOutBubbleThenFlyBack()
+    {
+        var fadeTimer = new DispatcherTimer { Interval = AnimationFrameInterval };
+        var fadeStartTime = DateTime.UtcNow;
+
+        fadeTimer.Tick += (_, _) =>
+        {
+            var elapsed = DateTime.UtcNow - fadeStartTime;
+            var progress = Math.Clamp(elapsed.TotalMilliseconds / BubbleFadeDuration.TotalMilliseconds, 0.0, 1.0);
+            PointerBubble.Opacity = 1.0 - progress;
+
+            if (progress >= 1.0)
+            {
+                fadeTimer.Stop();
+                PointerBubble.Visibility = Visibility.Collapsed;
+                PointerBubbleText.Text = string.Empty;
+                FlyTriangleBackToCursor();
+            }
+        };
+        fadeTimer.Start();
+    }
+
+    private void FlyTriangleBackToCursor()
+    {
+        // Return target = system cursor + follow-offset, in local DIPs.
+        if (!NativeMethods.GetCursorPos(out var cursorDevicePixels))
+        {
+            EndFlight();
+            return;
+        }
+
+        var (cursorLocalDipX, cursorLocalDipY) = ConvertGlobalDeviceToLocalDip(cursorDevicePixels.X, cursorDevicePixels.Y);
+        var returnDipX = cursorLocalDipX + CursorOffsetDipX;
+        var returnDipY = cursorLocalDipY + CursorOffsetDipY;
+
+        FlyTriangleAlongBezier(
+            startDipX: _triangleCurrentDipX,
+            startDipY: _triangleCurrentDipY,
+            endDipX: returnDipX,
+            endDipY: returnDipY,
+            onFlightComplete: EndFlight);
+    }
+
+    private void EndFlight()
+    {
+        _isFlightActive = false;
+        BlueTriangleRotation.Angle = RestingRotationDegrees;
+        BlueTriangleScale.ScaleX = 1.0;
+        BlueTriangleScale.ScaleY = 1.0;
+    }
+
+    /// <summary>
+    /// Bezier flight with smoothstep easing, tangent-based rotation and a
+    /// scale pulse peaking at the midpoint — straight port of the macOS
+    /// animateBezierFlightArc.
+    /// </summary>
+    private void FlyTriangleAlongBezier(
+        double startDipX,
+        double startDipY,
+        double endDipX,
+        double endDipY,
+        Action onFlightComplete)
+    {
+        _flightFrameTimer?.Stop();
+
+        var deltaX = endDipX - startDipX;
+        var deltaY = endDipY - startDipY;
+        var distance = Math.Sqrt(deltaX * deltaX + deltaY * deltaY);
+
+        var flightDurationSeconds = Math.Clamp(
+            distance / FlightDurationDistanceDivisor,
+            FlightMinDurationSeconds,
+            FlightMaxDurationSeconds);
+        var totalFrames = Math.Max(1, (int)(flightDurationSeconds * AnimationFramesPerSecond));
+
+        // Arc control point — lifted upward (negative Y in screen coords)
+        // so the triangle swoops. Height capped at 80 DIPs like macOS.
+        var midpointDipX = (startDipX + endDipX) / 2.0;
+        var midpointDipY = (startDipY + endDipY) / 2.0;
+        var arcHeight = Math.Min(distance * 0.2, 80.0);
+        var controlPointDipX = midpointDipX;
+        var controlPointDipY = midpointDipY - arcHeight;
+
+        var currentFrame = 0;
+        _flightFrameTimer = new DispatcherTimer(DispatcherPriority.Render, Dispatcher)
+        {
+            Interval = AnimationFrameInterval,
+        };
+        _flightFrameTimer.Tick += (_, _) =>
+        {
+            currentFrame++;
+
+            if (currentFrame > totalFrames)
+            {
+                _flightFrameTimer.Stop();
+                _flightFrameTimer = null;
+                PositionTriangle(endDipX, endDipY);
+                BlueTriangleScale.ScaleX = 1.0;
+                BlueTriangleScale.ScaleY = 1.0;
+                _triangleCurrentDipX = endDipX;
+                _triangleCurrentDipY = endDipY;
+                onFlightComplete();
+                return;
+            }
+
+            var linearProgress = (double)currentFrame / totalFrames;
+            // Smoothstep easeInOut: 3t² - 2t³
+            var t = linearProgress * linearProgress * (3.0 - 2.0 * linearProgress);
+            var oneMinusT = 1.0 - t;
+
+            // Quadratic bezier B(t)
+            var bezierDipX = oneMinusT * oneMinusT * startDipX
+                           + 2.0 * oneMinusT * t * controlPointDipX
+                           + t * t * endDipX;
+            var bezierDipY = oneMinusT * oneMinusT * startDipY
+                           + 2.0 * oneMinusT * t * controlPointDipY
+                           + t * t * endDipY;
+            PositionTriangle(bezierDipX, bezierDipY);
+
+            // Rotation along the curve tangent B'(t). The +90° offset aligns
+            // the triangle's tip (which points up at 0°) with the direction
+            // of travel returned by atan2.
+            var tangentX = 2.0 * oneMinusT * (controlPointDipX - startDipX)
+                         + 2.0 * t * (endDipX - controlPointDipX);
+            var tangentY = 2.0 * oneMinusT * (controlPointDipY - startDipY)
+                         + 2.0 * t * (endDipY - controlPointDipY);
+            BlueTriangleRotation.Angle = Math.Atan2(tangentY, tangentX) * (180.0 / Math.PI) + 90.0;
+
+            // Scale pulse — sin curve, peaks at 1.3× at mid-flight.
+            var scalePulse = 1.0 + Math.Sin(linearProgress * Math.PI) * 0.3;
+            BlueTriangleScale.ScaleX = scalePulse;
+            BlueTriangleScale.ScaleY = scalePulse;
+        };
+        _flightFrameTimer.Start();
+    }
+
+    private void StreamBubbleCharacters(string phrase, int characterIndex, Action onStreamComplete)
+    {
+        if (!_isFlightActive)
+        {
+            // Flight was cancelled / interrupted — stop streaming.
+            return;
+        }
+
+        if (characterIndex >= phrase.Length)
+        {
+            onStreamComplete();
+            return;
+        }
+
+        PointerBubbleText.Text += phrase[characterIndex];
+        PositionPointerBubble();
+
+        var characterDelayMs = 30 + Random.Shared.Next(31); // 30..60 ms
+        var characterTimer = new DispatcherTimer { Interval = TimeSpan.FromMilliseconds(characterDelayMs) };
+        characterTimer.Tick += (_, _) =>
+        {
+            characterTimer.Stop();
+            StreamBubbleCharacters(phrase, characterIndex + 1, onStreamComplete);
+        };
+        characterTimer.Start();
+    }
+
+    private void AnimateBubbleScaleTo(double targetScale, int durationMs)
+    {
+        var startingScale = PointerBubbleScale.ScaleX;
+        var startTime = DateTime.UtcNow;
+        var scaleTimer = new DispatcherTimer(DispatcherPriority.Render, Dispatcher)
+        {
+            Interval = AnimationFrameInterval,
+        };
+        scaleTimer.Tick += (_, _) =>
+        {
+            var elapsed = (DateTime.UtcNow - startTime).TotalMilliseconds;
+            var progress = Math.Clamp(elapsed / durationMs, 0.0, 1.0);
+            // Ease-out cubic for a gentle overshoot-free bounce.
+            var eased = 1.0 - Math.Pow(1.0 - progress, 3.0);
+            var currentScale = startingScale + (targetScale - startingScale) * eased;
+            PointerBubbleScale.ScaleX = currentScale;
+            PointerBubbleScale.ScaleY = currentScale;
+
+            if (progress >= 1.0)
+            {
+                scaleTimer.Stop();
+            }
+        };
+        scaleTimer.Start();
+    }
+
+    private void EnsureCurrentTrianglePositionInitialized()
+    {
+        if (_triangleCurrentDipX != 0 || _triangleCurrentDipY != 0) return;
+
+        // No prior position recorded — seed from the current system cursor.
+        if (!NativeMethods.GetCursorPos(out var cursorDevicePixels)) return;
+        var (cursorLocalDipX, cursorLocalDipY) = ConvertGlobalDeviceToLocalDip(cursorDevicePixels.X, cursorDevicePixels.Y);
+        _triangleCurrentDipX = cursorLocalDipX + CursorOffsetDipX;
+        _triangleCurrentDipY = cursorLocalDipY + CursorOffsetDipY;
+        PositionTriangle(_triangleCurrentDipX, _triangleCurrentDipY);
+    }
+
+    private void PositionTriangle(double centroidDipX, double centroidDipY)
+    {
+        Canvas.SetLeft(BlueTriangle, centroidDipX - TriangleCentroidOffsetDipX);
+        Canvas.SetTop(BlueTriangle, centroidDipY - TriangleCentroidOffsetDipY);
+        _triangleCurrentDipX = centroidDipX;
+        _triangleCurrentDipY = centroidDipY;
+        if (PointerBubble.Visibility == Visibility.Visible)
+        {
+            PositionPointerBubble();
+        }
+    }
+
+    private void PositionPointerBubble()
+    {
+        // Measure the bubble so we can center it around (triangle + offset).
+        PointerBubble.Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+        var bubbleDesired = PointerBubble.DesiredSize;
+
+        var anchorDipX = _triangleCurrentDipX + BubbleOffsetDipX;
+        var anchorDipY = _triangleCurrentDipY + BubbleOffsetDipY;
+        Canvas.SetLeft(PointerBubble, anchorDipX - bubbleDesired.Width / 2.0);
+        Canvas.SetTop(PointerBubble, anchorDipY - bubbleDesired.Height / 2.0);
+    }
+
+    private (double LocalDipX, double LocalDipY) ConvertGlobalDeviceToLocalDip(int globalDeviceX, int globalDeviceY)
+    {
+        var dpiScale = NativeMethods.GetDpiScale(this);
+        if (dpiScale <= 0) dpiScale = 1.0;
+
+        var localDeviceX = globalDeviceX - _monitorBoundsLeftDevicePixels;
+        var localDeviceY = globalDeviceY - _monitorBoundsTopDevicePixels;
+        return (localDeviceX / dpiScale, localDeviceY / dpiScale);
     }
 
     private static void ApplyClickThroughExtendedStyles(object? sender, EventArgs eventArgs)

--- a/windows/Clicky/Views/StringToVisibilityConverter.cs
+++ b/windows/Clicky/Views/StringToVisibilityConverter.cs
@@ -1,0 +1,24 @@
+using System.Globalization;
+using System.Windows;
+using System.Windows.Data;
+
+namespace Clicky.Views;
+
+/// <summary>
+/// Collapses a UI element when its bound string is null, empty, or
+/// whitespace; shows it otherwise. Used by the tray panel to hide the
+/// transcript and response rows until they have content.
+/// </summary>
+[ValueConversion(typeof(string), typeof(Visibility))]
+public sealed class StringToVisibilityConverter : IValueConverter
+{
+    public object Convert(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        return string.IsNullOrWhiteSpace(value as string) ? Visibility.Collapsed : Visibility.Visible;
+    }
+
+    public object ConvertBack(object? value, Type targetType, object? parameter, CultureInfo culture)
+    {
+        throw new NotSupportedException();
+    }
+}

--- a/windows/Clicky/Views/TrayPanelWindow.xaml
+++ b/windows/Clicky/Views/TrayPanelWindow.xaml
@@ -25,6 +25,119 @@
          not clipped to the window bounds. -->
     <Grid Margin="16">
 
+        <!-- Window-local resources. MUST be declared before any descendant
+             that references them via {StaticResource ...}: WPF resolves
+             static-resource markup extensions at parse time and does NOT
+             support forward references within the same XAML scope. The
+             DynamicResource brushes below resolve later via the merged
+             App.xaml dictionaries, which is why they don't need to live
+             here. -->
+        <Grid.Resources>
+
+            <!-- Converter: collapses an element when its bound string is empty. -->
+            <views:StringToVisibilityConverter x:Key="StringToVisibilityConverter"/>
+
+            <!-- Converter: maps bool -> Visibility (pass "Invert" as parameter to flip). -->
+            <views:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+
+            <!-- Primary CTA button used by onboarding "Get started". -->
+            <Style x:Key="PrimaryButtonStyle" TargetType="Button">
+                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="FontFamily" Value="{DynamicResource PrimaryFontFamily}"/>
+                <Setter Property="FontSize" Value="13"/>
+                <Setter Property="FontWeight" Value="SemiBold"/>
+                <Setter Property="Padding" Value="14,8"/>
+                <Setter Property="Background" Value="{DynamicResource OverlayCursorBlue}"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="SnapsToDevicePixels" Value="True"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="ButtonSurface"
+                                    Background="{TemplateBinding Background}"
+                                    CornerRadius="6"
+                                    Padding="{TemplateBinding Padding}">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="ButtonSurface" Property="Opacity" Value="0.9"/>
+                                </Trigger>
+                                <Trigger Property="IsPressed" Value="True">
+                                    <Setter TargetName="ButtonSurface" Property="Opacity" Value="0.8"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <!-- Segmented-control option button. Highlights via the Tag
+                 property bound to IsSelected. -->
+            <Style x:Key="ModelOptionButtonStyle" TargetType="Button">
+                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextTertiary}"/>
+                <Setter Property="FontFamily" Value="{DynamicResource PrimaryFontFamily}"/>
+                <Setter Property="FontSize" Value="11"/>
+                <Setter Property="FontWeight" Value="Medium"/>
+                <Setter Property="Padding" Value="10,5"/>
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="SnapsToDevicePixels" Value="True"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="OptionBackground"
+                                    Background="Transparent"
+                                    CornerRadius="5"
+                                    Padding="{TemplateBinding Padding}">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <!-- Selected state drives the highlight via the Tag bound to IsSelected -->
+                                <Trigger Property="Tag" Value="True">
+                                    <Setter TargetName="OptionBackground" Property="Background" Value="{DynamicResource TranslucentFillMid}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <!-- Quiet footer button (Quit link) -->
+            <Style x:Key="FooterTextButtonStyle" TargetType="Button">
+                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
+                <Setter Property="FontFamily" Value="{DynamicResource PrimaryFontFamily}"/>
+                <Setter Property="FontSize" Value="12"/>
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="Padding" Value="4,6"/>
+                <Setter Property="HorizontalContentAlignment" Value="Left"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border Background="Transparent" Padding="{TemplateBinding Padding}">
+                                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalAlignment="Center"/>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+        </Grid.Resources>
+
         <!-- Panel shell: dark rounded surface with a subtle border and a
              two-layer drop shadow to match the macOS panel's depth. -->
         <Border Background="{DynamicResource Background}"
@@ -283,115 +396,6 @@
 
             </StackPanel>
         </Border>
-
-        <!-- Window-local resources: button styles that depend on the design
-             system brushes. Declared last so the brushes resolve via the
-             merged App.xaml dictionaries. -->
-        <Grid.Resources>
-
-            <!-- Converter: collapses an element when its bound string is empty. -->
-            <views:StringToVisibilityConverter x:Key="StringToVisibilityConverter"/>
-
-            <!-- Converter: maps bool → Visibility (pass "Invert" as parameter to flip). -->
-            <views:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
-
-            <!-- Primary CTA button used by onboarding "Get started". -->
-            <Style x:Key="PrimaryButtonStyle" TargetType="Button">
-                <Setter Property="Cursor" Value="Hand"/>
-                <Setter Property="Foreground" Value="White"/>
-                <Setter Property="FontFamily" Value="{DynamicResource PrimaryFontFamily}"/>
-                <Setter Property="FontSize" Value="13"/>
-                <Setter Property="FontWeight" Value="SemiBold"/>
-                <Setter Property="Padding" Value="14,8"/>
-                <Setter Property="Background" Value="{DynamicResource OverlayCursorBlue}"/>
-                <Setter Property="BorderThickness" Value="0"/>
-                <Setter Property="SnapsToDevicePixels" Value="True"/>
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="Button">
-                            <Border x:Name="ButtonSurface"
-                                    Background="{TemplateBinding Background}"
-                                    CornerRadius="6"
-                                    Padding="{TemplateBinding Padding}">
-                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                            </Border>
-                            <ControlTemplate.Triggers>
-                                <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter TargetName="ButtonSurface" Property="Opacity" Value="0.9"/>
-                                </Trigger>
-                                <Trigger Property="IsPressed" Value="True">
-                                    <Setter TargetName="ButtonSurface" Property="Opacity" Value="0.8"/>
-                                </Trigger>
-                            </ControlTemplate.Triggers>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-
-            <!-- Segmented-control option button. Highlights via the Tag
-                 property bound to IsSelected. -->
-            <Style x:Key="ModelOptionButtonStyle" TargetType="Button">
-                <Setter Property="Cursor" Value="Hand"/>
-                <Setter Property="Foreground" Value="{DynamicResource TextTertiary}"/>
-                <Setter Property="FontFamily" Value="{DynamicResource PrimaryFontFamily}"/>
-                <Setter Property="FontSize" Value="11"/>
-                <Setter Property="FontWeight" Value="Medium"/>
-                <Setter Property="Padding" Value="10,5"/>
-                <Setter Property="Background" Value="Transparent"/>
-                <Setter Property="BorderThickness" Value="0"/>
-                <Setter Property="SnapsToDevicePixels" Value="True"/>
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="Button">
-                            <Border x:Name="OptionBackground"
-                                    Background="Transparent"
-                                    CornerRadius="5"
-                                    Padding="{TemplateBinding Padding}">
-                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
-                            </Border>
-                            <ControlTemplate.Triggers>
-                                <!-- Selected state drives the highlight via the Tag bound to IsSelected -->
-                                <Trigger Property="Tag" Value="True">
-                                    <Setter TargetName="OptionBackground" Property="Background" Value="{DynamicResource TranslucentFillMid}"/>
-                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
-                                </Trigger>
-                                <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
-                                </Trigger>
-                            </ControlTemplate.Triggers>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-
-            <!-- Quiet footer button (Quit link) -->
-            <Style x:Key="FooterTextButtonStyle" TargetType="Button">
-                <Setter Property="Cursor" Value="Hand"/>
-                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
-                <Setter Property="FontFamily" Value="{DynamicResource PrimaryFontFamily}"/>
-                <Setter Property="FontSize" Value="12"/>
-                <Setter Property="Background" Value="Transparent"/>
-                <Setter Property="BorderThickness" Value="0"/>
-                <Setter Property="Padding" Value="4,6"/>
-                <Setter Property="HorizontalContentAlignment" Value="Left"/>
-                <Setter Property="Template">
-                    <Setter.Value>
-                        <ControlTemplate TargetType="Button">
-                            <Border Background="Transparent" Padding="{TemplateBinding Padding}">
-                                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
-                                                  VerticalAlignment="Center"/>
-                            </Border>
-                            <ControlTemplate.Triggers>
-                                <Trigger Property="IsMouseOver" Value="True">
-                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
-                                </Trigger>
-                            </ControlTemplate.Triggers>
-                        </ControlTemplate>
-                    </Setter.Value>
-                </Setter>
-            </Style>
-
-        </Grid.Resources>
 
     </Grid>
 </Window>

--- a/windows/Clicky/Views/TrayPanelWindow.xaml
+++ b/windows/Clicky/Views/TrayPanelWindow.xaml
@@ -1,0 +1,237 @@
+<Window x:Class="Clicky.Views.TrayPanelWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        xmlns:vm="clr-namespace:Clicky.ViewModels"
+        mc:Ignorable="d"
+        xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
+        xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
+        Title="Clicky"
+        Width="320"
+        SizeToContent="Height"
+        WindowStyle="None"
+        ResizeMode="NoResize"
+        AllowsTransparency="True"
+        Background="Transparent"
+        ShowInTaskbar="False"
+        Topmost="True"
+        ShowActivated="False"
+        WindowStartupLocation="Manual"
+        UseLayoutRounding="True"
+        FontFamily="{DynamicResource PrimaryFontFamily}"
+        d:DataContext="{d:DesignInstance vm:TrayPanelViewModel}">
+
+    <!-- Outer transparent margin reserves space for the drop shadow so it's
+         not clipped to the window bounds. -->
+    <Grid Margin="16">
+
+        <!-- Panel shell: dark rounded surface with a subtle border and a
+             two-layer drop shadow to match the macOS panel's depth. -->
+        <Border Background="{DynamicResource Background}"
+                BorderBrush="{DynamicResource BorderSubtle}"
+                BorderThickness="1"
+                CornerRadius="{DynamicResource CornerRadiusExtraLargeR}"
+                Effect="{DynamicResource PanelShadowEffect}">
+            <StackPanel Margin="16,14,16,14">
+
+                <!-- Header: status dot + app name -->
+                <Grid Margin="0,0,0,10">
+                    <Grid.ColumnDefinitions>
+                        <ColumnDefinition Width="Auto"/>
+                        <ColumnDefinition Width="*"/>
+                    </Grid.ColumnDefinitions>
+
+                    <Ellipse Grid.Column="0"
+                             Width="8" Height="8"
+                             Fill="{DynamicResource Success}"
+                             VerticalAlignment="Center"
+                             Margin="0,0,8,0"/>
+
+                    <TextBlock Grid.Column="1"
+                               Text="Clicky"
+                               Style="{DynamicResource HeaderTextStyle}"
+                               VerticalAlignment="Center"/>
+                </Grid>
+
+                <!-- Divider -->
+                <Rectangle Height="1"
+                           Fill="{DynamicResource BorderSubtle}"
+                           Margin="0,2,0,12"/>
+
+                <!-- Primary instruction -->
+                <TextBlock Style="{DynamicResource BodyTextStyle}"
+                           TextWrapping="Wrap"
+                           Margin="0,0,0,6">
+                    <Run Text="Hold "/>
+                    <Run Text="Ctrl + Alt" FontWeight="SemiBold"/>
+                    <Run Text=" to talk. Release to send."/>
+                </TextBlock>
+
+                <TextBlock Style="{DynamicResource TertiaryTextStyle}"
+                           TextWrapping="Wrap"
+                           Margin="0,0,0,14">
+                    Clicky sees your screen and speaks back. Your mic stays off until you hold the shortcut.
+                </TextBlock>
+
+                <!-- Model picker rows -->
+                <StackPanel Margin="0,4,0,14">
+
+                    <!-- Claude row -->
+                    <Grid Margin="0,0,0,8">
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Column="0"
+                                   Text="Claude"
+                                   Style="{DynamicResource SecondaryTextStyle}"
+                                   VerticalAlignment="Center"/>
+
+                        <Border Grid.Column="1"
+                                Background="{DynamicResource TranslucentFillLow}"
+                                BorderBrush="{DynamicResource BorderSubtle}"
+                                BorderThickness="0.5"
+                                CornerRadius="{DynamicResource CornerRadiusSmallR}">
+                            <ItemsControl ItemsSource="{Binding ClaudeOptions}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Orientation="Horizontal"/>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Button Style="{DynamicResource ModelOptionButtonStyle}"
+                                                Command="{Binding SelectCommand}"
+                                                CommandParameter="{Binding ModelId}"
+                                                Content="{Binding DisplayLabel}"
+                                                Tag="{Binding IsSelected}"/>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </Border>
+                    </Grid>
+
+                    <!-- Gemini row -->
+                    <Grid>
+                        <Grid.ColumnDefinitions>
+                            <ColumnDefinition Width="*"/>
+                            <ColumnDefinition Width="Auto"/>
+                        </Grid.ColumnDefinitions>
+
+                        <TextBlock Grid.Column="0"
+                                   Text="Gemini"
+                                   Style="{DynamicResource SecondaryTextStyle}"
+                                   VerticalAlignment="Center"/>
+
+                        <Border Grid.Column="1"
+                                Background="{DynamicResource TranslucentFillLow}"
+                                BorderBrush="{DynamicResource BorderSubtle}"
+                                BorderThickness="0.5"
+                                CornerRadius="{DynamicResource CornerRadiusSmallR}">
+                            <ItemsControl ItemsSource="{Binding GeminiOptions}">
+                                <ItemsControl.ItemsPanel>
+                                    <ItemsPanelTemplate>
+                                        <StackPanel Orientation="Horizontal"/>
+                                    </ItemsPanelTemplate>
+                                </ItemsControl.ItemsPanel>
+                                <ItemsControl.ItemTemplate>
+                                    <DataTemplate>
+                                        <Button Style="{DynamicResource ModelOptionButtonStyle}"
+                                                Command="{Binding SelectCommand}"
+                                                CommandParameter="{Binding ModelId}"
+                                                Content="{Binding DisplayLabel}"
+                                                Tag="{Binding IsSelected}"/>
+                                    </DataTemplate>
+                                </ItemsControl.ItemTemplate>
+                            </ItemsControl>
+                        </Border>
+                    </Grid>
+
+                </StackPanel>
+
+                <!-- Footer divider -->
+                <Rectangle Height="1"
+                           Fill="{DynamicResource BorderSubtle}"
+                           Margin="0,0,0,10"/>
+
+                <!-- Quit -->
+                <Button Style="{DynamicResource FooterTextButtonStyle}"
+                        Command="{Binding QuitCommand}"
+                        HorizontalContentAlignment="Left"
+                        Content="Quit Clicky"/>
+
+            </StackPanel>
+        </Border>
+
+        <!-- Window-local resources: button styles that depend on the design
+             system brushes. Declared last so the brushes resolve via the
+             merged App.xaml dictionaries. -->
+        <Grid.Resources>
+
+            <!-- Segmented-control option button. Highlights via the Tag
+                 property bound to IsSelected. -->
+            <Style x:Key="ModelOptionButtonStyle" TargetType="Button">
+                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextTertiary}"/>
+                <Setter Property="FontFamily" Value="{DynamicResource PrimaryFontFamily}"/>
+                <Setter Property="FontSize" Value="11"/>
+                <Setter Property="FontWeight" Value="Medium"/>
+                <Setter Property="Padding" Value="10,5"/>
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="SnapsToDevicePixels" Value="True"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="OptionBackground"
+                                    Background="Transparent"
+                                    CornerRadius="5"
+                                    Padding="{TemplateBinding Padding}">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <!-- Selected state drives the highlight via the Tag bound to IsSelected -->
+                                <Trigger Property="Tag" Value="True">
+                                    <Setter TargetName="OptionBackground" Property="Background" Value="{DynamicResource TranslucentFillMid}"/>
+                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
+                                </Trigger>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+            <!-- Quiet footer button (Quit link) -->
+            <Style x:Key="FooterTextButtonStyle" TargetType="Button">
+                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="Foreground" Value="{DynamicResource TextSecondary}"/>
+                <Setter Property="FontFamily" Value="{DynamicResource PrimaryFontFamily}"/>
+                <Setter Property="FontSize" Value="12"/>
+                <Setter Property="Background" Value="Transparent"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="Padding" Value="4,6"/>
+                <Setter Property="HorizontalContentAlignment" Value="Left"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border Background="Transparent" Padding="{TemplateBinding Padding}">
+                                <ContentPresenter HorizontalAlignment="{TemplateBinding HorizontalContentAlignment}"
+                                                  VerticalAlignment="Center"/>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter Property="Foreground" Value="{DynamicResource TextPrimary}"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
+
+        </Grid.Resources>
+
+    </Grid>
+</Window>

--- a/windows/Clicky/Views/TrayPanelWindow.xaml
+++ b/windows/Clicky/Views/TrayPanelWindow.xaml
@@ -2,6 +2,7 @@
         xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
         xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
         xmlns:vm="clr-namespace:Clicky.ViewModels"
+        xmlns:views="clr-namespace:Clicky.Views"
         mc:Ignorable="d"
         xmlns:d="http://schemas.microsoft.com/expression/blend/2008"
         xmlns:mc="http://schemas.openxmlformats.org/markup-compatibility/2006"
@@ -71,6 +72,52 @@
                            Margin="0,0,0,14">
                     Clicky sees your screen and speaks back. Your mic stays off until you hold the shortcut.
                 </TextBlock>
+
+                <!-- Live transcript (user side). Shown while dictating and
+                     briefly after release. Collapsed when empty. -->
+                <Border Background="{DynamicResource TranslucentFillLow}"
+                        BorderBrush="{DynamicResource BorderSubtle}"
+                        BorderThickness="0.5"
+                        CornerRadius="{DynamicResource CornerRadiusSmallR}"
+                        Padding="10,8"
+                        Margin="0,0,0,8"
+                        Visibility="{Binding AppState.LiveTranscript, Converter={StaticResource StringToVisibilityConverter}}">
+                    <StackPanel>
+                        <TextBlock Text="You"
+                                   Style="{DynamicResource TertiaryTextStyle}"
+                                   Margin="0,0,0,2"/>
+                        <TextBlock Text="{Binding AppState.LiveTranscript}"
+                                   Style="{DynamicResource BodyTextStyle}"
+                                   TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Streaming assistant response. Fills in as SSE chunks
+                     arrive from the active provider. -->
+                <Border Background="{DynamicResource TranslucentFillLow}"
+                        BorderBrush="{DynamicResource BorderSubtle}"
+                        BorderThickness="0.5"
+                        CornerRadius="{DynamicResource CornerRadiusSmallR}"
+                        Padding="10,8"
+                        Margin="0,0,0,14"
+                        Visibility="{Binding AppState.StreamedResponseText, Converter={StaticResource StringToVisibilityConverter}}">
+                    <StackPanel>
+                        <TextBlock Text="Clicky"
+                                   Style="{DynamicResource TertiaryTextStyle}"
+                                   Margin="0,0,0,2"/>
+                        <TextBlock Text="{Binding AppState.StreamedResponseText}"
+                                   Style="{DynamicResource BodyTextStyle}"
+                                   TextWrapping="Wrap"/>
+                    </StackPanel>
+                </Border>
+
+                <!-- Status/error line. Only appears when the pipeline
+                     reports something the user should know about. -->
+                <TextBlock Text="{Binding AppState.LastStatusMessage}"
+                           Style="{DynamicResource TertiaryTextStyle}"
+                           TextWrapping="Wrap"
+                           Margin="0,0,0,10"
+                           Visibility="{Binding AppState.LastStatusMessage, Converter={StaticResource StringToVisibilityConverter}}"/>
 
                 <!-- Model picker rows -->
                 <StackPanel Margin="0,4,0,14">
@@ -167,6 +214,9 @@
              system brushes. Declared last so the brushes resolve via the
              merged App.xaml dictionaries. -->
         <Grid.Resources>
+
+            <!-- Converter: collapses an element when its bound string is empty. -->
+            <views:StringToVisibilityConverter x:Key="StringToVisibilityConverter"/>
 
             <!-- Segmented-control option button. Highlights via the Tag
                  property bound to IsSelected. -->

--- a/windows/Clicky/Views/TrayPanelWindow.xaml
+++ b/windows/Clicky/Views/TrayPanelWindow.xaml
@@ -58,20 +58,84 @@
                            Fill="{DynamicResource BorderSubtle}"
                            Margin="0,2,0,12"/>
 
-                <!-- Primary instruction -->
-                <TextBlock Style="{DynamicResource BodyTextStyle}"
-                           TextWrapping="Wrap"
-                           Margin="0,0,0,6">
-                    <Run Text="Hold "/>
-                    <Run Text="Ctrl + Alt" FontWeight="SemiBold"/>
-                    <Run Text=" to talk. Release to send."/>
-                </TextBlock>
+                <!-- First-run onboarding. Hidden once the user hits "Get started". -->
+                <StackPanel Visibility="{Binding IsOnboardingVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+                    <TextBlock Style="{DynamicResource BodyTextStyle}"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,6">
+                        <Run Text="Welcome to Clicky." FontWeight="SemiBold"/>
+                        <Run Text=" Your always-on screen companion."/>
+                    </TextBlock>
 
-                <TextBlock Style="{DynamicResource TertiaryTextStyle}"
-                           TextWrapping="Wrap"
-                           Margin="0,0,0,14">
-                    Clicky sees your screen and speaks back. Your mic stays off until you hold the shortcut.
-                </TextBlock>
+                    <TextBlock Style="{DynamicResource TertiaryTextStyle}"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,10">
+                        <Run Text="Hold "/><Run Text="Ctrl + Alt" FontWeight="SemiBold"/><Run Text=" anywhere to talk. Release to send. Clicky sees your screen, answers out loud, and can fly a blue triangle to point at anything you ask about."/>
+                    </TextBlock>
+
+                    <TextBlock Style="{DynamicResource TertiaryTextStyle}"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,14">
+                        Your mic stays off until you hold the shortcut. Responses are spoken back through your speakers.
+                    </TextBlock>
+
+                    <Button Style="{DynamicResource PrimaryButtonStyle}"
+                            Command="{Binding CompleteOnboardingCommand}"
+                            Content="Get started"
+                            HorizontalAlignment="Stretch"
+                            Margin="0,0,0,14"/>
+                </StackPanel>
+
+                <!-- Regular panel body. Hidden during onboarding. -->
+                <StackPanel Visibility="{Binding IsMainContentVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
+
+                    <!-- Primary instruction -->
+                    <TextBlock Style="{DynamicResource BodyTextStyle}"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,6">
+                        <Run Text="Hold "/>
+                        <Run Text="Ctrl + Alt" FontWeight="SemiBold"/>
+                        <Run Text=" to talk. Release to send."/>
+                    </TextBlock>
+
+                    <TextBlock Style="{DynamicResource TertiaryTextStyle}"
+                               TextWrapping="Wrap"
+                               Margin="0,0,0,14">
+                        Clicky sees your screen and speaks back. Your mic stays off until you hold the shortcut.
+                    </TextBlock>
+
+                    <!-- Microphone-denied callout. Shown whenever the mic is
+                         off or blocked by Windows privacy settings; the
+                         button deep-links to ms-settings:privacy-microphone
+                         so the user can fix it in one click. -->
+                    <Border Background="{DynamicResource TranslucentFillLow}"
+                            BorderBrush="{DynamicResource BorderSubtle}"
+                            BorderThickness="0.5"
+                            CornerRadius="{DynamicResource CornerRadiusSmallR}"
+                            Padding="10,8"
+                            Margin="0,0,0,10"
+                            Visibility="{Binding AppState.IsMicrophonePermissionIssue, Converter={StaticResource BooleanToVisibilityConverter}}">
+                        <StackPanel>
+                            <TextBlock Text="Microphone appears to be off"
+                                       Style="{DynamicResource SecondaryTextStyle}"
+                                       Margin="0,0,0,2"/>
+                            <TextBlock Style="{DynamicResource TertiaryTextStyle}"
+                                       TextWrapping="Wrap"
+                                       Margin="0,0,0,6">
+                                Clicky can't start dictation until Windows grants microphone access. Open privacy settings and enable microphone access for desktop apps.
+                            </TextBlock>
+                            <Button Style="{DynamicResource FooterTextButtonStyle}"
+                                    Command="{Binding OpenMicrophonePrivacySettingsCommand}"
+                                    HorizontalContentAlignment="Left"
+                                    Content="Open Windows privacy settings"/>
+                        </StackPanel>
+                    </Border>
+                </StackPanel>
+
+                <!-- Live transcript / model picker / footer — all only
+                     visible after onboarding completes. Wrapped in an outer
+                     StackPanel so the visibility binding sits on one place. -->
+                <StackPanel Visibility="{Binding IsMainContentVisible, Converter={StaticResource BooleanToVisibilityConverter}}">
 
                 <!-- Live transcript (user side). Shown while dictating and
                      briefly after release. Collapsed when empty. -->
@@ -201,11 +265,21 @@
                            Fill="{DynamicResource BorderSubtle}"
                            Margin="0,0,0,10"/>
 
+                <!-- Replay onboarding — mirrors the macOS "Watch
+                     Onboarding Again" footer link. -->
+                <Button Style="{DynamicResource FooterTextButtonStyle}"
+                        Command="{Binding ReplayOnboardingCommand}"
+                        HorizontalContentAlignment="Left"
+                        Margin="0,0,0,2"
+                        Content="Watch welcome again"/>
+
                 <!-- Quit -->
                 <Button Style="{DynamicResource FooterTextButtonStyle}"
                         Command="{Binding QuitCommand}"
                         HorizontalContentAlignment="Left"
                         Content="Quit Clicky"/>
+
+                </StackPanel><!-- /IsMainContentVisible -->
 
             </StackPanel>
         </Border>
@@ -217,6 +291,42 @@
 
             <!-- Converter: collapses an element when its bound string is empty. -->
             <views:StringToVisibilityConverter x:Key="StringToVisibilityConverter"/>
+
+            <!-- Converter: maps bool → Visibility (pass "Invert" as parameter to flip). -->
+            <views:BooleanToVisibilityConverter x:Key="BooleanToVisibilityConverter"/>
+
+            <!-- Primary CTA button used by onboarding "Get started". -->
+            <Style x:Key="PrimaryButtonStyle" TargetType="Button">
+                <Setter Property="Cursor" Value="Hand"/>
+                <Setter Property="Foreground" Value="White"/>
+                <Setter Property="FontFamily" Value="{DynamicResource PrimaryFontFamily}"/>
+                <Setter Property="FontSize" Value="13"/>
+                <Setter Property="FontWeight" Value="SemiBold"/>
+                <Setter Property="Padding" Value="14,8"/>
+                <Setter Property="Background" Value="{DynamicResource OverlayCursorBlue}"/>
+                <Setter Property="BorderThickness" Value="0"/>
+                <Setter Property="SnapsToDevicePixels" Value="True"/>
+                <Setter Property="Template">
+                    <Setter.Value>
+                        <ControlTemplate TargetType="Button">
+                            <Border x:Name="ButtonSurface"
+                                    Background="{TemplateBinding Background}"
+                                    CornerRadius="6"
+                                    Padding="{TemplateBinding Padding}">
+                                <ContentPresenter HorizontalAlignment="Center" VerticalAlignment="Center"/>
+                            </Border>
+                            <ControlTemplate.Triggers>
+                                <Trigger Property="IsMouseOver" Value="True">
+                                    <Setter TargetName="ButtonSurface" Property="Opacity" Value="0.9"/>
+                                </Trigger>
+                                <Trigger Property="IsPressed" Value="True">
+                                    <Setter TargetName="ButtonSurface" Property="Opacity" Value="0.8"/>
+                                </Trigger>
+                            </ControlTemplate.Triggers>
+                        </ControlTemplate>
+                    </Setter.Value>
+                </Setter>
+            </Style>
 
             <!-- Segmented-control option button. Highlights via the Tag
                  property bound to IsSelected. -->

--- a/windows/Clicky/Views/TrayPanelWindow.xaml.cs
+++ b/windows/Clicky/Views/TrayPanelWindow.xaml.cs
@@ -81,6 +81,39 @@ public partial class TrayPanelWindow : Window
         }
     }
 
+    /// <summary>
+    /// Used by the first-run onboarding: centers the panel on the primary
+    /// monitor so the welcome copy is impossible to miss. Falls back to the
+    /// system's default positioning if DPI/metrics queries fail.
+    /// </summary>
+    public void ShowPanelCenteredOnPrimaryScreen()
+    {
+        var windowHandle = new WindowInteropHelper(this).EnsureHandle();
+        var dpiScale = NativeMethods.GetDpiScale(this);
+        if (dpiScale <= 0) dpiScale = 1.0;
+
+        Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+        var panelWidthDevice = DesiredSize.Width * dpiScale;
+        var panelHeightDevice = DesiredSize.Height * dpiScale;
+
+        var primaryWidthDevice = SystemParameters.PrimaryScreenWidth * dpiScale;
+        var primaryHeightDevice = SystemParameters.PrimaryScreenHeight * dpiScale;
+
+        var panelLeftDevice = (primaryWidthDevice - panelWidthDevice) / 2;
+        var panelTopDevice = (primaryHeightDevice - panelHeightDevice) / 2;
+
+        NativeMethods.SetWindowPos(
+            windowHandle,
+            NativeMethods.HWND_TOPMOST,
+            (int)panelLeftDevice,
+            (int)panelTopDevice,
+            (int)panelWidthDevice,
+            (int)panelHeightDevice,
+            NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_SHOWWINDOW);
+
+        Visibility = Visibility.Visible;
+    }
+
     private void ApplyNonActivatingExtendedStyles(object? sender, EventArgs eventArgs)
     {
         var windowHandle = new WindowInteropHelper(this).Handle;

--- a/windows/Clicky/Views/TrayPanelWindow.xaml.cs
+++ b/windows/Clicky/Views/TrayPanelWindow.xaml.cs
@@ -1,0 +1,132 @@
+using System.Windows;
+using System.Windows.Interop;
+using Clicky.Interop;
+using Clicky.ViewModels;
+
+namespace Clicky.Views;
+
+/// <summary>
+/// Borderless popover hosted over the system tray. Matches the macOS floating
+/// NSPanel: non-activating, click-outside dismissal, drop shadow, rounded
+/// corners. Shown on demand by <see cref="App"/> when the tray icon is clicked.
+/// </summary>
+public partial class TrayPanelWindow : Window
+{
+    public TrayPanelWindow(TrayPanelViewModel viewModel)
+    {
+        DataContext = viewModel;
+        InitializeComponent();
+
+        SourceInitialized += ApplyNonActivatingExtendedStyles;
+        Deactivated += HideOnDeactivate;
+    }
+
+    /// <summary>
+    /// Positions the panel above the taskbar tray area and shows it without
+    /// stealing focus. The cursor-position argument is typically the point
+    /// where the user clicked the tray icon — it's used to horizontally align
+    /// the panel near the icon.
+    /// </summary>
+    public void ShowNearTrayCursor(double cursorScreenX, double cursorScreenY)
+    {
+        var windowHandle = new WindowInteropHelper(this).EnsureHandle();
+        var taskbarRect = ReadTaskbarRectOrFallback(cursorScreenX, cursorScreenY);
+        var dpiScale = NativeMethods.GetDpiScale(this);
+
+        Measure(new Size(double.PositiveInfinity, double.PositiveInfinity));
+        var desiredPanelSize = DesiredSize;
+        var panelWidthInDeviceUnits = desiredPanelSize.Width * dpiScale;
+        var panelHeightInDeviceUnits = desiredPanelSize.Height * dpiScale;
+
+        // Anchor horizontally to the cursor, clamped so the full panel stays
+        // on the same monitor as the tray click.
+        var panelLeftDevice = cursorScreenX - (panelWidthInDeviceUnits / 2);
+        var panelTopDevice = taskbarRect.Top - panelHeightInDeviceUnits - 4;
+
+        if (panelLeftDevice < taskbarRect.Left)
+        {
+            panelLeftDevice = taskbarRect.Left;
+        }
+        if (panelLeftDevice + panelWidthInDeviceUnits > taskbarRect.Right)
+        {
+            panelLeftDevice = taskbarRect.Right - panelWidthInDeviceUnits;
+        }
+
+        // If the taskbar is at the top of the screen, flip the panel below it
+        // instead of placing it above (would be off-screen).
+        if (panelTopDevice < 0)
+        {
+            panelTopDevice = taskbarRect.Bottom + 4;
+        }
+
+        NativeMethods.SetWindowPos(
+            windowHandle,
+            NativeMethods.HWND_TOPMOST,
+            (int)panelLeftDevice,
+            (int)panelTopDevice,
+            (int)panelWidthInDeviceUnits,
+            (int)panelHeightInDeviceUnits,
+            NativeMethods.SWP_NOACTIVATE | NativeMethods.SWP_SHOWWINDOW);
+
+        // Don't call Show() — that would activate the window. SetWindowPos
+        // with SWP_SHOWWINDOW + SWP_NOACTIVATE is the right incantation.
+        Visibility = Visibility.Visible;
+    }
+
+    public void HidePanel()
+    {
+        if (IsVisible)
+        {
+            Hide();
+        }
+    }
+
+    private void ApplyNonActivatingExtendedStyles(object? sender, EventArgs eventArgs)
+    {
+        var windowHandle = new WindowInteropHelper(this).Handle;
+        var currentExtendedStyle = NativeMethods.GetExtendedStyle(windowHandle);
+        // Add WS_EX_TOOLWINDOW so the panel never shows in the Alt+Tab list,
+        // and WS_EX_NOACTIVATE so clicking inside it doesn't steal focus
+        // from whatever the user was working in. This mirrors the macOS
+        // "nonactivating" NSPanel behavior.
+        var desiredExtendedStyle = currentExtendedStyle
+            | NativeMethods.WS_EX_TOOLWINDOW
+            | NativeMethods.WS_EX_NOACTIVATE;
+        NativeMethods.SetExtendedStyle(windowHandle, desiredExtendedStyle);
+    }
+
+    private void HideOnDeactivate(object? sender, EventArgs eventArgs)
+    {
+        // Clicking anywhere outside the panel fires Deactivated. Hiding here
+        // gives us click-outside-to-dismiss without installing a global
+        // mouse hook.
+        HidePanel();
+    }
+
+    /// <summary>
+    /// Returns the taskbar bounds via SHAppBarMessage. If the query fails
+    /// (rare — mostly on remote desktop sessions), falls back to the primary
+    /// screen's working area bottom edge at the cursor's screen.
+    /// </summary>
+    private static NativeMethods.RECT ReadTaskbarRectOrFallback(double cursorScreenX, double cursorScreenY)
+    {
+        var appBarData = new NativeMethods.APPBARDATA
+        {
+            cbSize = (uint)System.Runtime.InteropServices.Marshal.SizeOf<NativeMethods.APPBARDATA>(),
+        };
+
+        var queryResult = NativeMethods.SHAppBarMessage(NativeMethods.ABM_GETTASKBARPOS, ref appBarData);
+        if (queryResult != IntPtr.Zero)
+        {
+            return appBarData.rc;
+        }
+
+        return new NativeMethods.RECT
+        {
+            Left = (int)(cursorScreenX - 200),
+            Top = (int)(cursorScreenY - 4),
+            Right = (int)(cursorScreenX + 200),
+            Bottom = (int)cursorScreenY,
+        };
+    }
+}

--- a/windows/Clicky/app.manifest
+++ b/windows/Clicky/app.manifest
@@ -1,0 +1,28 @@
+<?xml version="1.0" encoding="utf-8"?>
+<assembly manifestVersion="1.0" xmlns="urn:schemas-microsoft-com:asm.v1">
+  <assemblyIdentity version="1.0.0.0" name="Clicky.app"/>
+  <trustInfo xmlns="urn:schemas-microsoft-com:asm.v2">
+    <security>
+      <requestedPrivileges xmlns="urn:schemas-microsoft-com:asm.v3">
+        <!-- Run as a regular user. Global hotkey via low-level keyboard hook
+             does NOT require elevation; it only requires UIPI at the same or
+             lower integrity level than target windows. -->
+        <requestedExecutionLevel level="asInvoker" uiAccess="false"/>
+      </requestedPrivileges>
+    </security>
+  </trustInfo>
+  <compatibility xmlns="urn:schemas-microsoft-com:compatibility.v1">
+    <application>
+      <!-- Windows 10 and 11 -->
+      <supportedOS Id="{8e0f7a12-bfb3-4fe8-b9a5-48fd50a15a9a}"/>
+    </application>
+  </compatibility>
+  <application xmlns="urn:schemas-microsoft-com:asm.v3">
+    <windowsSettings>
+      <!-- Per-monitor V2 DPI awareness so the cursor overlay lines up on
+           mixed-DPI multi-monitor setups (e.g. 4K + 1080p). -->
+      <dpiAwareness xmlns="http://schemas.microsoft.com/SMI/2016/WindowsSettings">PerMonitorV2</dpiAwareness>
+      <dpiAware xmlns="http://schemas.microsoft.com/SMI/2005/WindowsSettings">true/pm</dpiAware>
+    </windowsSettings>
+  </application>
+</assembly>

--- a/windows/README.md
+++ b/windows/README.md
@@ -12,7 +12,7 @@ Worker, so the Windows app ships with zero embedded secrets.
 - [x] **M2 — Voice pipeline**: NAudio microphone capture, AssemblyAI v3 streaming transcription, Claude + Gemini SSE chat, ElevenLabs TTS playback. Text-only; vision is added in M3 once screen capture lands.
 - [x] **M3 — Screen capture**: per-monitor GDI `BitBlt` capture (PerMonitorV2-aware), JPEG encode at quality 80, downscale to 1280px longest side, cursor-monitor first. Screens feed into Claude/Gemini as inline images with labels like `"screen 1 of 2 — cursor is on this screen (primary focus) (image dimensions: 1280x800 pixels)"`. System prompt ported verbatim from macOS with the full pointing rules; the trailing `[POINT:…]` tag is stripped before TTS speaks the reply — M4/M5 will start consuming it.
 - [x] **M4 — Cursor overlay**: one transparent, click-through, topmost `OverlayWindow` per connected display (WS_EX_TRANSPARENT + WS_EX_LAYERED + WS_EX_NOACTIVATE + WS_EX_TOOLWINDOW). A 16-DIP equilateral blue triangle (`#3380FF`, rotated -35°, blue glow) follows the system mouse at 60 fps via `DispatcherTimer` + `GetCursorPos`, offset 35 DIPs right / 25 DIPs down. Only the overlay on the cursor's monitor shows the triangle. Visible during `Idle` / `Responding`; hidden during `Listening` / `Processing` (those swap in waveform/spinner in M5/M6).
-- [ ] **M5 — Element pointing**: `[POINT:x,y:label:screenN]` parser, bezier flight animation, speech bubble.
+- [x] **M5 — Element pointing**: `PointingTagParser` splits each reply into spoken text + `(x, y, label, screenN)` target. `VoicePipelineOrchestrator` rescales screenshot pixels to the monitor's native device pixels and asks `OverlayWindowManager` to fly the triangle. `OverlayWindow.BeginElementPointingFlight` runs a quadratic bezier arc with smoothstep easing, tangent-based rotation (+90° so the tip leads travel), and a scale pulse peaking at 1.3× mid-flight — a port of macOS `animateBezierFlightArc`. On arrival the triangle lands 8/12 DIPs past the element, a blue speech bubble spring-bounces in with a random phrase ("right here!", "this one!", etc.) streamed 30-60 ms per character, holds 3 s, fades 500 ms, then the triangle flies back to the cursor. While any overlay is flying, the other overlays hide their cursor-follow triangles — single buddy at a time.
 - [ ] **M6 — Polish**: permission checks, onboarding flow, analytics parity.
 
 ## Requirements
@@ -70,8 +70,9 @@ windows/
       ElevenLabsTtsClient.cs         # /tts MP3 fetch + NAudio playback
       DictationSession.cs            # mic -> AssemblyAI bridge + finalize-with-fallback
       ScreenCaptureService.cs        # per-monitor BitBlt -> JPEG (cursor monitor first)
-      OverlayWindowManager.cs        # per-monitor overlay lifecycle + 60 fps cursor tracker
-      VoicePipelineOrchestrator.cs   # end-to-end push-to-talk -> capture -> AI -> TTS flow
+      OverlayWindowManager.cs        # per-monitor overlay lifecycle + 60 fps cursor tracker + FlyToElement
+      PointingTagParser.cs           # splits a reply into spoken text + [POINT:x,y:label:screenN] target
+      VoicePipelineOrchestrator.cs   # end-to-end push-to-talk -> capture -> AI -> TTS + pointing flow
     ViewModels/
       TrayPanelViewModel.cs    # model picker + quit command bindings
     Views/

--- a/windows/README.md
+++ b/windows/README.md
@@ -1,0 +1,81 @@
+# Clicky — Windows port
+
+Native Windows port of the macOS Clicky app. Written in C# + WPF on .NET 8.
+
+Shares the Cloudflare Worker proxy with the macOS app — `ANTHROPIC_API_KEY`,
+`GEMINI_API_KEY`, `ASSEMBLYAI_API_KEY`, and `ELEVENLABS_API_KEY` all live on the
+Worker, so the Windows app ships with zero embedded secrets.
+
+## Milestone status
+
+- [x] **M1 — Foundation**: tray icon, borderless popover panel, global push-to-talk hotkey infrastructure, settings persistence, design system parity with macOS.
+- [ ] **M2 — Voice pipeline**: microphone capture, AssemblyAI streaming transcription, Claude / Gemini vision calls, ElevenLabs TTS playback.
+- [ ] **M3 — Screen capture**: per-monitor `Windows.Graphics.Capture` with DPI-correct coordinate mapping.
+- [ ] **M4 — Cursor overlay**: transparent per-monitor overlay windows, blue triangle cursor following the system mouse.
+- [ ] **M5 — Element pointing**: `[POINT:x,y:label:screenN]` parser, bezier flight animation, speech bubble.
+- [ ] **M6 — Polish**: permission checks, onboarding flow, analytics parity.
+
+## Requirements
+
+- Windows 10 version 1903 (build 18362) or later — earlier builds lack APIs used by later milestones.
+- [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).
+- Either Visual Studio 2022 (17.8+) with the ".NET desktop development" workload, **or** VS Code with the [C# Dev Kit extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit).
+
+## Build & run
+
+```powershell
+cd windows
+dotnet restore
+dotnet build
+dotnet run --project Clicky
+```
+
+Or open `windows/Clicky.sln` in Visual Studio and press F5.
+
+The app has no main window — it appears as a blue-dot icon in the system tray.
+Click the icon to open the control panel. Hold **Ctrl + Alt** anywhere to talk
+(voice pipeline arrives in M2).
+
+## Project layout
+
+```
+windows/
+  Clicky.sln
+  Clicky/
+    Clicky.csproj
+    app.manifest               # PerMonitorV2 DPI awareness, asInvoker elevation
+    App.xaml / App.xaml.cs     # entry point, tray + hotkey wiring, single-instance
+    AppState.cs                # root observable state (equivalent of CompanionManager)
+    Interop/
+      NativeMethods.cs         # P/Invoke signatures — window styles, appbar, keyboard hook
+    Resources/
+      DesignSystem.xaml        # colors + radii ported 1:1 from macOS DesignSystem.swift
+      clicky-tray.ico          # (optional — app falls back to a generated blue dot)
+    Services/
+      SettingsService.cs       # %APPDATA%\Clicky\settings.json persistence
+      GlobalHotkeyService.cs   # low-level keyboard hook (Ctrl+Alt push-to-talk)
+    ViewModels/
+      TrayPanelViewModel.cs    # model picker + quit command bindings
+    Views/
+      TrayPanelWindow.xaml     # borderless rounded popover UI
+      TrayPanelWindow.xaml.cs  # non-activating window + positioning logic
+```
+
+## How this maps to the macOS app
+
+| Windows | macOS equivalent |
+|---------|------------------|
+| `TaskbarIcon` (H.NotifyIcon.Wpf) | `NSStatusItem` in `MenuBarPanelManager.swift` |
+| `TrayPanelWindow` | `CompanionPanelView` hosted in a borderless `NSPanel` |
+| `GlobalHotkeyService` (WH_KEYBOARD_LL) | `GlobalPushToTalkShortcutMonitor.swift` (CGEvent tap) |
+| `AppState` | `CompanionManager.swift` |
+| `SettingsService` | `UserDefaults` in `CompanionManager` |
+| `DesignSystem.xaml` | `DesignSystem.swift` |
+| Cloudflare Worker | Same Cloudflare Worker — unchanged |
+
+## Tray icon
+
+A real `clicky-tray.ico` (32×32, ICO format) dropped into `Clicky/Resources/`
+and set to `Build Action = Resource` in the `.csproj` will be used at startup.
+Without it, the app generates a solid blue dot in the overlay-cursor color
+(`#3380FF`) as a placeholder so the tray is never empty.

--- a/windows/README.md
+++ b/windows/README.md
@@ -15,11 +15,55 @@ Worker, so the Windows app ships with zero embedded secrets.
 - [x] **M5 — Element pointing**: `PointingTagParser` splits each reply into spoken text + `(x, y, label, screenN)` target. `VoicePipelineOrchestrator` rescales screenshot pixels to the monitor's native device pixels and asks `OverlayWindowManager` to fly the triangle. `OverlayWindow.BeginElementPointingFlight` runs a quadratic bezier arc with smoothstep easing, tangent-based rotation (+90° so the tip leads travel), and a scale pulse peaking at 1.3× mid-flight — a port of macOS `animateBezierFlightArc`. On arrival the triangle lands 8/12 DIPs past the element, a blue speech bubble spring-bounces in with a random phrase ("right here!", "this one!", etc.) streamed 30-60 ms per character, holds 3 s, fades 500 ms, then the triangle flies back to the cursor. While any overlay is flying, the other overlays hide their cursor-follow triangles — single buddy at a time.
 - [x] **M6 — Polish**: `MicrophonePermissionHelper` probes for an active capture endpoint at startup (a privacy-blocked mic moves to the `Disabled` state and is filtered out) and `AppState.IsMicrophonePermissionIssue` surfaces a "Open Windows privacy settings" callout in the tray panel that deep-links to `ms-settings:privacy-microphone`. First-run onboarding: if `HasCompletedOnboarding == false` the panel auto-opens centered on the primary monitor with a welcome block and a "Get started" button that flips the flag; a "Watch welcome again" footer link replays it. `ClickyAnalytics` POSTs directly to PostHog `/capture/` with the same event surface as the macOS `ClickyAnalytics.swift` (`app_opened`, `onboarding_*`, `permission_*`, `push_to_talk_*`, `user_message_sent`, `ai_response_received`, `element_pointed`, `response_error`, `tts_error`) using a stable anonymous per-install `distinct_id` persisted alongside settings. No opt-in toggle — matches macOS. The PostHog write key placeholder in `WorkerConfig.cs` must be swapped to enable telemetry; until then every event is silently dropped client-side.
 
+## One-click install (recommended for non-developers)
+
+If you just want to use Clicky and don't plan to touch the code, double-click
+[windows/install/Install-Clicky.bat](install/Install-Clicky.bat). It runs
+entirely per-user (no administrator rights) and will:
+
+1. Verify the .NET 8 SDK is present (it's the only prerequisite — the
+   installer asks you to install it from
+   <https://dotnet.microsoft.com/download/dotnet/8.0> if missing).
+2. Build Clicky as a self-contained single-file `Clicky.exe` so the target
+   machine doesn't need the .NET runtime separately.
+3. Copy it to `%LOCALAPPDATA%\Programs\Clicky\`.
+4. Create **Start Menu** and **Desktop** shortcuts (`Clicky.lnk`), launched
+   minimised since Clicky lives in the system tray.
+5. Register Clicky in **Apps & Features** so you can uninstall it from
+   Windows Settings like any other app.
+6. Add Clicky to the per-user **Run** key so it launches automatically on
+   login (pass `-NoAutoStart` to skip this, or `-NoLaunch` to finish without
+   starting it immediately).
+7. Launch Clicky — look for the blue dot in the system tray.
+
+Advanced switches (run the `.ps1` directly from a PowerShell prompt):
+
+```powershell
+# Smaller framework-dependent build (requires .NET 8 Desktop Runtime on the target)
+.\windows\install\Install-Clicky.ps1 -FrameworkDependent
+
+# Don't register auto-start / don't launch after install
+.\windows\install\Install-Clicky.ps1 -NoAutoStart -NoLaunch
+```
+
+> **Before first talk, edit the Worker URL.** Open
+> [Clicky/Services/WorkerConfig.cs](Clicky/Services/WorkerConfig.cs) and
+> replace the placeholder Cloudflare Worker base URL with your own. All API
+> keys (Anthropic, Gemini, AssemblyAI, ElevenLabs) live on the Worker — the
+> Windows app ships with zero embedded secrets. Re-run the installer after
+> editing to rebuild. The same file also has a PostHog write key placeholder;
+> swap it to enable analytics, or leave it and every event is silently
+> dropped client-side.
+
+To uninstall: open **Settings → Apps → Installed apps**, find **Clicky**, and
+click Uninstall. Or run
+`%LOCALAPPDATA%\Programs\Clicky\Uninstall-Clicky.ps1`.
+
 ## Requirements
 
 - Windows 10 version 1903 (build 18362) or later — earlier builds lack APIs used by later milestones.
 - [.NET 8 SDK](https://dotnet.microsoft.com/en-us/download/dotnet/8.0).
-- Either Visual Studio 2022 (17.8+) with the ".NET desktop development" workload, **or** VS Code with the [C# Dev Kit extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit).
+- Either Visual Studio 2022 (17.8+) with the ".NET desktop development" workload, **or** VS Code with the [C# Dev Kit extension](https://marketplace.visualstudio.com/items?itemName=ms-dotnettools.csdevkit) (only required if you plan to build/debug from source — the installer above handles builds for end-users).
 
 ## Build & run
 
@@ -50,6 +94,9 @@ assistant's reply streaming out, then Clicky speaks it back via ElevenLabs.
 ```
 windows/
   Clicky.sln
+  install/
+    Install-Clicky.bat             # double-click entry point (calls the .ps1 with ExecutionPolicy Bypass)
+    Install-Clicky.ps1             # per-user installer: build + copy + shortcuts + Run key + Apps&Features entry
   Clicky/
     Clicky.csproj
     app.manifest               # PerMonitorV2 DPI awareness, asInvoker elevation

--- a/windows/README.md
+++ b/windows/README.md
@@ -9,8 +9,8 @@ Worker, so the Windows app ships with zero embedded secrets.
 ## Milestone status
 
 - [x] **M1 — Foundation**: tray icon, borderless popover panel, global push-to-talk hotkey infrastructure, settings persistence, design system parity with macOS.
-- [ ] **M2 — Voice pipeline**: microphone capture, AssemblyAI streaming transcription, Claude / Gemini vision calls, ElevenLabs TTS playback.
-- [ ] **M3 — Screen capture**: per-monitor `Windows.Graphics.Capture` with DPI-correct coordinate mapping.
+- [x] **M2 — Voice pipeline**: NAudio microphone capture, AssemblyAI v3 streaming transcription, Claude + Gemini SSE chat, ElevenLabs TTS playback. Text-only; vision is added in M3 once screen capture lands.
+- [ ] **M3 — Screen capture**: per-monitor `Windows.Graphics.Capture` with DPI-correct coordinate mapping. Feeds captured JPEGs as inline images into the M2 chat clients.
 - [ ] **M4 — Cursor overlay**: transparent per-monitor overlay windows, blue triangle cursor following the system mouse.
 - [ ] **M5 — Element pointing**: `[POINT:x,y:label:screenN]` parser, bezier flight animation, speech bubble.
 - [ ] **M6 — Polish**: permission checks, onboarding flow, analytics parity.
@@ -33,8 +33,15 @@ dotnet run --project Clicky
 Or open `windows/Clicky.sln` in Visual Studio and press F5.
 
 The app has no main window — it appears as a blue-dot icon in the system tray.
-Click the icon to open the control panel. Hold **Ctrl + Alt** anywhere to talk
-(voice pipeline arrives in M2).
+Click the icon to open the control panel. Hold **Ctrl + Alt** anywhere to talk;
+release to send. The panel shows your transcript streaming in, then the
+assistant's reply streaming out, then Clicky speaks it back via ElevenLabs.
+
+> **Configure the Worker URL.** Before talking to Clicky, update
+> [Services/WorkerConfig.cs](Clicky/Services/WorkerConfig.cs) with your own
+> Cloudflare Worker base URL (the Swift app uses the same constant). All
+> provider keys stay on the Worker — the Windows app ships with zero
+> embedded secrets.
 
 ## Project layout
 
@@ -52,13 +59,23 @@ windows/
       DesignSystem.xaml        # colors + radii ported 1:1 from macOS DesignSystem.swift
       clicky-tray.ico          # (optional — app falls back to a generated blue dot)
     Services/
-      SettingsService.cs       # %APPDATA%\Clicky\settings.json persistence
-      GlobalHotkeyService.cs   # low-level keyboard hook (Ctrl+Alt push-to-talk)
+      SettingsService.cs             # %APPDATA%\Clicky\settings.json persistence
+      GlobalHotkeyService.cs         # low-level keyboard hook (Ctrl+Alt push-to-talk)
+      WorkerConfig.cs                # Cloudflare Worker base URL + route constants
+      IChatClient.cs                 # provider-agnostic streaming chat interface
+      ClaudeClient.cs                # /chat SSE port of ClaudeAPI.swift
+      GeminiClient.cs                # /chat-gemini SSE port of GeminiAPI.swift
+      AssemblyAIStreamingClient.cs   # v3 realtime WebSocket transcription
+      MicrophoneCaptureService.cs    # NAudio WaveInEvent, 16 kHz PCM16 mono
+      ElevenLabsTtsClient.cs         # /tts MP3 fetch + NAudio playback
+      DictationSession.cs            # mic -> AssemblyAI bridge + finalize-with-fallback
+      VoicePipelineOrchestrator.cs   # end-to-end push-to-talk -> AI -> TTS flow
     ViewModels/
       TrayPanelViewModel.cs    # model picker + quit command bindings
     Views/
       TrayPanelWindow.xaml     # borderless rounded popover UI
       TrayPanelWindow.xaml.cs  # non-activating window + positioning logic
+      StringToVisibilityConverter.cs # collapses empty-string bindings
 ```
 
 ## How this maps to the macOS app
@@ -71,6 +88,12 @@ windows/
 | `AppState` | `CompanionManager.swift` |
 | `SettingsService` | `UserDefaults` in `CompanionManager` |
 | `DesignSystem.xaml` | `DesignSystem.swift` |
+| `ClaudeClient` / `GeminiClient` | `ClaudeAPI.swift` / `GeminiAPI.swift` |
+| `AssemblyAIStreamingClient` | `AssemblyAIStreamingTranscriptionProvider.swift` |
+| `MicrophoneCaptureService` (NAudio `WaveInEvent`) | `AVAudioEngine.inputNode.installTap` |
+| `ElevenLabsTtsClient` (NAudio `Mp3FileReader` + `WaveOutEvent`) | `ElevenLabsTTSClient.swift` + `AVAudioPlayer` |
+| `DictationSession` | `BuddyDictationManager.swift` |
+| `VoicePipelineOrchestrator` | Transcript→AI→TTS pipeline in `CompanionManager.swift` |
 | Cloudflare Worker | Same Cloudflare Worker — unchanged |
 
 ## Tray icon

--- a/windows/README.md
+++ b/windows/README.md
@@ -10,7 +10,7 @@ Worker, so the Windows app ships with zero embedded secrets.
 
 - [x] **M1 — Foundation**: tray icon, borderless popover panel, global push-to-talk hotkey infrastructure, settings persistence, design system parity with macOS.
 - [x] **M2 — Voice pipeline**: NAudio microphone capture, AssemblyAI v3 streaming transcription, Claude + Gemini SSE chat, ElevenLabs TTS playback. Text-only; vision is added in M3 once screen capture lands.
-- [ ] **M3 — Screen capture**: per-monitor `Windows.Graphics.Capture` with DPI-correct coordinate mapping. Feeds captured JPEGs as inline images into the M2 chat clients.
+- [x] **M3 — Screen capture**: per-monitor GDI `BitBlt` capture (PerMonitorV2-aware), JPEG encode at quality 80, downscale to 1280px longest side, cursor-monitor first. Screens feed into Claude/Gemini as inline images with labels like `"screen 1 of 2 — cursor is on this screen (primary focus) (image dimensions: 1280x800 pixels)"`. System prompt ported verbatim from macOS with the full pointing rules; the trailing `[POINT:…]` tag is stripped before TTS speaks the reply — M4/M5 will start consuming it.
 - [ ] **M4 — Cursor overlay**: transparent per-monitor overlay windows, blue triangle cursor following the system mouse.
 - [ ] **M5 — Element pointing**: `[POINT:x,y:label:screenN]` parser, bezier flight animation, speech bubble.
 - [ ] **M6 — Polish**: permission checks, onboarding flow, analytics parity.
@@ -69,7 +69,8 @@ windows/
       MicrophoneCaptureService.cs    # NAudio WaveInEvent, 16 kHz PCM16 mono
       ElevenLabsTtsClient.cs         # /tts MP3 fetch + NAudio playback
       DictationSession.cs            # mic -> AssemblyAI bridge + finalize-with-fallback
-      VoicePipelineOrchestrator.cs   # end-to-end push-to-talk -> AI -> TTS flow
+      ScreenCaptureService.cs        # per-monitor BitBlt -> JPEG (cursor monitor first)
+      VoicePipelineOrchestrator.cs   # end-to-end push-to-talk -> capture -> AI -> TTS flow
     ViewModels/
       TrayPanelViewModel.cs    # model picker + quit command bindings
     Views/
@@ -93,7 +94,8 @@ windows/
 | `MicrophoneCaptureService` (NAudio `WaveInEvent`) | `AVAudioEngine.inputNode.installTap` |
 | `ElevenLabsTtsClient` (NAudio `Mp3FileReader` + `WaveOutEvent`) | `ElevenLabsTTSClient.swift` + `AVAudioPlayer` |
 | `DictationSession` | `BuddyDictationManager.swift` |
-| `VoicePipelineOrchestrator` | Transcript→AI→TTS pipeline in `CompanionManager.swift` |
+| `ScreenCaptureService` (GDI BitBlt) | `CompanionScreenCaptureUtility.swift` (ScreenCaptureKit) |
+| `VoicePipelineOrchestrator` | Transcript→capture→AI→TTS pipeline in `CompanionManager.swift` |
 | Cloudflare Worker | Same Cloudflare Worker — unchanged |
 
 ## Tray icon

--- a/windows/README.md
+++ b/windows/README.md
@@ -13,7 +13,7 @@ Worker, so the Windows app ships with zero embedded secrets.
 - [x] **M3 — Screen capture**: per-monitor GDI `BitBlt` capture (PerMonitorV2-aware), JPEG encode at quality 80, downscale to 1280px longest side, cursor-monitor first. Screens feed into Claude/Gemini as inline images with labels like `"screen 1 of 2 — cursor is on this screen (primary focus) (image dimensions: 1280x800 pixels)"`. System prompt ported verbatim from macOS with the full pointing rules; the trailing `[POINT:…]` tag is stripped before TTS speaks the reply — M4/M5 will start consuming it.
 - [x] **M4 — Cursor overlay**: one transparent, click-through, topmost `OverlayWindow` per connected display (WS_EX_TRANSPARENT + WS_EX_LAYERED + WS_EX_NOACTIVATE + WS_EX_TOOLWINDOW). A 16-DIP equilateral blue triangle (`#3380FF`, rotated -35°, blue glow) follows the system mouse at 60 fps via `DispatcherTimer` + `GetCursorPos`, offset 35 DIPs right / 25 DIPs down. Only the overlay on the cursor's monitor shows the triangle. Visible during `Idle` / `Responding`; hidden during `Listening` / `Processing` (those swap in waveform/spinner in M5/M6).
 - [x] **M5 — Element pointing**: `PointingTagParser` splits each reply into spoken text + `(x, y, label, screenN)` target. `VoicePipelineOrchestrator` rescales screenshot pixels to the monitor's native device pixels and asks `OverlayWindowManager` to fly the triangle. `OverlayWindow.BeginElementPointingFlight` runs a quadratic bezier arc with smoothstep easing, tangent-based rotation (+90° so the tip leads travel), and a scale pulse peaking at 1.3× mid-flight — a port of macOS `animateBezierFlightArc`. On arrival the triangle lands 8/12 DIPs past the element, a blue speech bubble spring-bounces in with a random phrase ("right here!", "this one!", etc.) streamed 30-60 ms per character, holds 3 s, fades 500 ms, then the triangle flies back to the cursor. While any overlay is flying, the other overlays hide their cursor-follow triangles — single buddy at a time.
-- [ ] **M6 — Polish**: permission checks, onboarding flow, analytics parity.
+- [x] **M6 — Polish**: `MicrophonePermissionHelper` probes for an active capture endpoint at startup (a privacy-blocked mic moves to the `Disabled` state and is filtered out) and `AppState.IsMicrophonePermissionIssue` surfaces a "Open Windows privacy settings" callout in the tray panel that deep-links to `ms-settings:privacy-microphone`. First-run onboarding: if `HasCompletedOnboarding == false` the panel auto-opens centered on the primary monitor with a welcome block and a "Get started" button that flips the flag; a "Watch welcome again" footer link replays it. `ClickyAnalytics` POSTs directly to PostHog `/capture/` with the same event surface as the macOS `ClickyAnalytics.swift` (`app_opened`, `onboarding_*`, `permission_*`, `push_to_talk_*`, `user_message_sent`, `ai_response_received`, `element_pointed`, `response_error`, `tts_error`) using a stable anonymous per-install `distinct_id` persisted alongside settings. No opt-in toggle — matches macOS. The PostHog write key placeholder in `WorkerConfig.cs` must be swapped to enable telemetry; until then every event is silently dropped client-side.
 
 ## Requirements
 
@@ -41,7 +41,9 @@ assistant's reply streaming out, then Clicky speaks it back via ElevenLabs.
 > [Services/WorkerConfig.cs](Clicky/Services/WorkerConfig.cs) with your own
 > Cloudflare Worker base URL (the Swift app uses the same constant). All
 > provider keys stay on the Worker — the Windows app ships with zero
-> embedded secrets.
+> embedded secrets. The same file holds a placeholder PostHog write key —
+> swap it for a real project key to enable analytics, or leave the
+> placeholder in place and `ClickyAnalytics` silently drops every event.
 
 ## Project layout
 
@@ -72,6 +74,8 @@ windows/
       ScreenCaptureService.cs        # per-monitor BitBlt -> JPEG (cursor monitor first)
       OverlayWindowManager.cs        # per-monitor overlay lifecycle + 60 fps cursor tracker + FlyToElement
       PointingTagParser.cs           # splits a reply into spoken text + [POINT:x,y:label:screenN] target
+      MicrophonePermissionHelper.cs  # capture-endpoint probe + ms-settings:privacy-microphone shortcut
+      ClickyAnalytics.cs             # PostHog /capture/ HTTP client, macOS event parity
       VoicePipelineOrchestrator.cs   # end-to-end push-to-talk -> capture -> AI -> TTS + pointing flow
     ViewModels/
       TrayPanelViewModel.cs    # model picker + quit command bindings

--- a/windows/README.md
+++ b/windows/README.md
@@ -11,7 +11,7 @@ Worker, so the Windows app ships with zero embedded secrets.
 - [x] **M1 — Foundation**: tray icon, borderless popover panel, global push-to-talk hotkey infrastructure, settings persistence, design system parity with macOS.
 - [x] **M2 — Voice pipeline**: NAudio microphone capture, AssemblyAI v3 streaming transcription, Claude + Gemini SSE chat, ElevenLabs TTS playback. Text-only; vision is added in M3 once screen capture lands.
 - [x] **M3 — Screen capture**: per-monitor GDI `BitBlt` capture (PerMonitorV2-aware), JPEG encode at quality 80, downscale to 1280px longest side, cursor-monitor first. Screens feed into Claude/Gemini as inline images with labels like `"screen 1 of 2 — cursor is on this screen (primary focus) (image dimensions: 1280x800 pixels)"`. System prompt ported verbatim from macOS with the full pointing rules; the trailing `[POINT:…]` tag is stripped before TTS speaks the reply — M4/M5 will start consuming it.
-- [ ] **M4 — Cursor overlay**: transparent per-monitor overlay windows, blue triangle cursor following the system mouse.
+- [x] **M4 — Cursor overlay**: one transparent, click-through, topmost `OverlayWindow` per connected display (WS_EX_TRANSPARENT + WS_EX_LAYERED + WS_EX_NOACTIVATE + WS_EX_TOOLWINDOW). A 16-DIP equilateral blue triangle (`#3380FF`, rotated -35°, blue glow) follows the system mouse at 60 fps via `DispatcherTimer` + `GetCursorPos`, offset 35 DIPs right / 25 DIPs down. Only the overlay on the cursor's monitor shows the triangle. Visible during `Idle` / `Responding`; hidden during `Listening` / `Processing` (those swap in waveform/spinner in M5/M6).
 - [ ] **M5 — Element pointing**: `[POINT:x,y:label:screenN]` parser, bezier flight animation, speech bubble.
 - [ ] **M6 — Polish**: permission checks, onboarding flow, analytics parity.
 
@@ -70,12 +70,15 @@ windows/
       ElevenLabsTtsClient.cs         # /tts MP3 fetch + NAudio playback
       DictationSession.cs            # mic -> AssemblyAI bridge + finalize-with-fallback
       ScreenCaptureService.cs        # per-monitor BitBlt -> JPEG (cursor monitor first)
+      OverlayWindowManager.cs        # per-monitor overlay lifecycle + 60 fps cursor tracker
       VoicePipelineOrchestrator.cs   # end-to-end push-to-talk -> capture -> AI -> TTS flow
     ViewModels/
       TrayPanelViewModel.cs    # model picker + quit command bindings
     Views/
       TrayPanelWindow.xaml     # borderless rounded popover UI
       TrayPanelWindow.xaml.cs  # non-activating window + positioning logic
+      OverlayWindow.xaml       # transparent click-through per-monitor overlay
+      OverlayWindow.xaml.cs    # blue triangle render + position updates
       StringToVisibilityConverter.cs # collapses empty-string bindings
 ```
 
@@ -95,6 +98,7 @@ windows/
 | `ElevenLabsTtsClient` (NAudio `Mp3FileReader` + `WaveOutEvent`) | `ElevenLabsTTSClient.swift` + `AVAudioPlayer` |
 | `DictationSession` | `BuddyDictationManager.swift` |
 | `ScreenCaptureService` (GDI BitBlt) | `CompanionScreenCaptureUtility.swift` (ScreenCaptureKit) |
+| `OverlayWindow` + `OverlayWindowManager` | `OverlayWindow.swift` (`NSWindow` at `.screenSaver` level) |
 | `VoicePipelineOrchestrator` | Transcript→capture→AI→TTS pipeline in `CompanionManager.swift` |
 | Cloudflare Worker | Same Cloudflare Worker — unchanged |
 

--- a/windows/install/Install-Clicky.bat
+++ b/windows/install/Install-Clicky.bat
@@ -1,0 +1,17 @@
+@echo off
+REM Double-click entry point for the Clicky Windows installer.
+REM Delegates to Install-Clicky.ps1 with ExecutionPolicy Bypass so users
+REM never need to open a PowerShell prompt or tweak their policy first.
+setlocal
+set "SCRIPT_DIR=%~dp0"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%Install-Clicky.ps1" %*
+set "EXITCODE=%ERRORLEVEL%"
+echo.
+if "%EXITCODE%"=="0" (
+    echo Installer finished successfully.
+) else (
+    echo Installer exited with code %EXITCODE%.
+)
+echo.
+pause
+endlocal & exit /b %EXITCODE%

--- a/windows/install/Install-Clicky.ps1
+++ b/windows/install/Install-Clicky.ps1
@@ -1,0 +1,289 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    One-click installer for Clicky on Windows.
+
+.DESCRIPTION
+    Builds Clicky as a self-contained single-file app (no .NET runtime needed
+    on the target machine) and installs it to %LOCALAPPDATA%\Programs\Clicky.
+    Creates Start Menu and Desktop shortcuts, registers Clicky in
+    Apps & Features so it can be uninstalled from Settings, and optionally
+    adds it to the Run key so it launches on login (default: yes — Clicky
+    is a tray app, the user expects it to be there).
+
+    Runs entirely per-user; no administrator rights required.
+
+.PARAMETER FrameworkDependent
+    Produce a smaller framework-dependent build instead of self-contained.
+    The target machine must have the .NET 8 Desktop Runtime installed.
+
+.PARAMETER NoAutoStart
+    Skip the HKCU Run entry so Clicky doesn't start automatically on login.
+
+.PARAMETER NoLaunch
+    Install without launching Clicky at the end.
+
+.EXAMPLE
+    .\Install-Clicky.ps1
+
+.EXAMPLE
+    .\Install-Clicky.ps1 -FrameworkDependent -NoAutoStart
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$FrameworkDependent,
+    [switch]$NoAutoStart,
+    [switch]$NoLaunch
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ---------- Paths ----------
+
+$ScriptDirectory         = Split-Path -Parent $MyInvocation.MyCommand.Path
+$WindowsRepoRoot         = Resolve-Path (Join-Path $ScriptDirectory '..')
+$ProjectFilePath         = Join-Path $WindowsRepoRoot 'Clicky\Clicky.csproj'
+$InstallRoot             = Join-Path $env:LOCALAPPDATA 'Programs\Clicky'
+$InstalledExePath        = Join-Path $InstallRoot 'Clicky.exe'
+$InstalledUninstallerPs1 = Join-Path $InstallRoot 'Uninstall-Clicky.ps1'
+$StartMenuProgramsDir    = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs'
+$StartMenuShortcutPath   = Join-Path $StartMenuProgramsDir 'Clicky.lnk'
+$DesktopShortcutPath     = Join-Path ([Environment]::GetFolderPath('Desktop')) 'Clicky.lnk'
+$UninstallRegistryKey    = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\Clicky'
+$RunRegistryKey          = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
+
+# ---------- Helpers ----------
+
+function Write-Step($message) {
+    Write-Host ""
+    Write-Host "==> $message" -ForegroundColor Cyan
+}
+
+function Write-Info($message) {
+    Write-Host "    $message" -ForegroundColor Gray
+}
+
+function Assert-DotNetSdk {
+    Write-Step 'Checking for .NET 8 SDK'
+    $dotnet = Get-Command dotnet -ErrorAction SilentlyContinue
+    if (-not $dotnet) {
+        throw ".NET 8 SDK not found on PATH. Install it from https://dotnet.microsoft.com/download/dotnet/8.0 and re-run this installer."
+    }
+
+    $versions = & dotnet --list-sdks 2>$null
+    $hasEight = $versions | Where-Object { $_ -match '^\s*8\.' }
+    if (-not $hasEight) {
+        throw ".NET 8 SDK not found. `dotnet --list-sdks` showed:`n$($versions -join "`n")`nInstall .NET 8 from https://dotnet.microsoft.com/download/dotnet/8.0 and re-run."
+    }
+
+    Write-Info ("Found: " + (($hasEight | Select-Object -First 1).Trim()))
+}
+
+function Stop-RunningClicky {
+    $running = Get-Process -Name 'Clicky' -ErrorAction SilentlyContinue
+    if ($running) {
+        Write-Step 'Closing the running Clicky instance'
+        $running | Stop-Process -Force
+        Start-Sleep -Milliseconds 500
+    }
+}
+
+function Invoke-Publish {
+    Write-Step 'Building Clicky (this takes a minute on a cold build)'
+    $publishTempDirectory = Join-Path $env:TEMP ("ClickyPublish-" + [guid]::NewGuid().ToString('N'))
+    New-Item -ItemType Directory -Force -Path $publishTempDirectory | Out-Null
+
+    $publishArgs = @(
+        'publish', $ProjectFilePath,
+        '-c', 'Release',
+        '-r', 'win-x64',
+        '-o', $publishTempDirectory,
+        '-p:PublishSingleFile=true',
+        '-p:IncludeNativeLibrariesForSelfExtract=true',
+        '-p:IncludeAllContentForSelfExtract=true',
+        '--nologo'
+    )
+    if ($FrameworkDependent) {
+        $publishArgs += '--self-contained'
+        $publishArgs += 'false'
+        Write-Info 'Framework-dependent build — end users need the .NET 8 Desktop Runtime.'
+    } else {
+        $publishArgs += '--self-contained'
+        $publishArgs += 'true'
+        Write-Info 'Self-contained build — bundles the .NET runtime. No end-user prerequisites.'
+    }
+
+    & dotnet @publishArgs | Out-Host
+    if ($LASTEXITCODE -ne 0) {
+        throw "dotnet publish failed (exit $LASTEXITCODE)."
+    }
+
+    return $publishTempDirectory
+}
+
+function Copy-ToInstallRoot($publishDir) {
+    Write-Step "Installing to $InstallRoot"
+
+    if (-not (Test-Path $InstallRoot)) {
+        New-Item -ItemType Directory -Force -Path $InstallRoot | Out-Null
+    }
+
+    # Wipe the old payload so orphaned files from a previous install don't
+    # linger. Keep the folder itself so shortcuts / user settings stay put.
+    Get-ChildItem -Path $InstallRoot -Force | ForEach-Object {
+        try { Remove-Item $_.FullName -Recurse -Force -ErrorAction Stop }
+        catch {
+            Write-Warning "Couldn't remove '$($_.FullName)': $($_.Exception.Message). Continuing."
+        }
+    }
+
+    Copy-Item -Path (Join-Path $publishDir '*') -Destination $InstallRoot -Recurse -Force
+    Write-Info ("Installed: " + $InstalledExePath)
+}
+
+function New-WindowsShortcut {
+    param(
+        [Parameter(Mandatory)][string]$ShortcutPath,
+        [Parameter(Mandatory)][string]$TargetExePath,
+        [string]$Description = 'Clicky — hold Ctrl+Alt to talk.'
+    )
+    $shellComObject = New-Object -ComObject WScript.Shell
+    $shortcut = $shellComObject.CreateShortcut($ShortcutPath)
+    $shortcut.TargetPath       = $TargetExePath
+    $shortcut.WorkingDirectory = Split-Path $TargetExePath
+    $shortcut.IconLocation     = "$TargetExePath,0"
+    $shortcut.Description      = $Description
+    $shortcut.WindowStyle      = 7   # minimized — Clicky lives in the tray
+    $shortcut.Save()
+}
+
+function Install-Shortcuts {
+    Write-Step 'Creating Start Menu and Desktop shortcuts'
+    if (-not (Test-Path $StartMenuProgramsDir)) {
+        New-Item -ItemType Directory -Force -Path $StartMenuProgramsDir | Out-Null
+    }
+    New-WindowsShortcut -ShortcutPath $StartMenuShortcutPath -TargetExePath $InstalledExePath
+    New-WindowsShortcut -ShortcutPath $DesktopShortcutPath   -TargetExePath $InstalledExePath
+    Write-Info ("Start Menu: " + $StartMenuShortcutPath)
+    Write-Info ("Desktop:    " + $DesktopShortcutPath)
+}
+
+function Install-Uninstaller {
+    Write-Step 'Writing uninstaller'
+    $uninstallerPs1Body = @'
+#Requires -Version 5.1
+<#
+    Uninstalls Clicky — removes the install folder, shortcuts, Run key,
+    and the Apps & Features entry. Safe to run more than once.
+#>
+$ErrorActionPreference = 'SilentlyContinue'
+
+Get-Process -Name 'Clicky' | Stop-Process -Force -ErrorAction SilentlyContinue
+
+$InstallRoot           = Join-Path $env:LOCALAPPDATA 'Programs\Clicky'
+$StartMenuShortcut     = Join-Path $env:APPDATA 'Microsoft\Windows\Start Menu\Programs\Clicky.lnk'
+$DesktopShortcut       = Join-Path ([Environment]::GetFolderPath('Desktop')) 'Clicky.lnk'
+$UninstallRegistryKey  = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Uninstall\Clicky'
+$RunRegistryKey        = 'HKCU:\Software\Microsoft\Windows\CurrentVersion\Run'
+
+Remove-Item -Path $StartMenuShortcut -Force
+Remove-Item -Path $DesktopShortcut   -Force
+Remove-ItemProperty -Path $RunRegistryKey -Name 'Clicky' -ErrorAction SilentlyContinue
+Remove-Item -Path $UninstallRegistryKey -Recurse -Force
+
+# Schedule the install folder for deletion on reboot via a helper cmd —
+# PowerShell can't remove its own running script, so we spawn cmd to do it
+# after this process exits.
+if (Test-Path $InstallRoot) {
+    $removeCommand = "timeout /t 2 /nobreak > NUL & rmdir /s /q `"$InstallRoot`""
+    Start-Process -FilePath 'cmd.exe' -ArgumentList '/c', $removeCommand -WindowStyle Hidden
+}
+
+Write-Host 'Clicky has been uninstalled.'
+'@
+
+    Set-Content -Path $InstalledUninstallerPs1 -Value $uninstallerPs1Body -Encoding UTF8
+
+    $projectVersion = '1.0.0'
+    try {
+        $assemblyVersion = (Get-Item $InstalledExePath).VersionInfo.ProductVersion
+        if ($assemblyVersion) { $projectVersion = $assemblyVersion }
+    } catch { }
+
+    New-Item -Path $UninstallRegistryKey -Force | Out-Null
+    $powershellExe = (Get-Command powershell).Source
+    $uninstallCommand = ('"{0}" -NoProfile -ExecutionPolicy Bypass -File "{1}"' -f $powershellExe, $InstalledUninstallerPs1)
+
+    Set-ItemProperty $UninstallRegistryKey -Name 'DisplayName'       -Value 'Clicky'
+    Set-ItemProperty $UninstallRegistryKey -Name 'DisplayVersion'    -Value $projectVersion
+    Set-ItemProperty $UninstallRegistryKey -Name 'DisplayIcon'       -Value $InstalledExePath
+    Set-ItemProperty $UninstallRegistryKey -Name 'Publisher'         -Value 'Clicky'
+    Set-ItemProperty $UninstallRegistryKey -Name 'InstallLocation'   -Value $InstallRoot
+    Set-ItemProperty $UninstallRegistryKey -Name 'UninstallString'   -Value $uninstallCommand
+    Set-ItemProperty $UninstallRegistryKey -Name 'NoModify'          -Value 1     -Type DWord
+    Set-ItemProperty $UninstallRegistryKey -Name 'NoRepair'          -Value 1     -Type DWord
+    Set-ItemProperty $UninstallRegistryKey -Name 'InstallDate'       -Value (Get-Date -Format 'yyyyMMdd')
+
+    Write-Info 'Registered in Apps & Features (Start → Settings → Apps → Installed apps).'
+}
+
+function Register-AutoStartIfRequested {
+    if ($NoAutoStart) {
+        Write-Step 'Skipping auto-start registration (-NoAutoStart)'
+        Remove-ItemProperty -Path $RunRegistryKey -Name 'Clicky' -ErrorAction SilentlyContinue
+        return
+    }
+    Write-Step 'Adding Clicky to login auto-start'
+    if (-not (Test-Path $RunRegistryKey)) {
+        New-Item -Path $RunRegistryKey -Force | Out-Null
+    }
+    Set-ItemProperty -Path $RunRegistryKey -Name 'Clicky' -Value ('"{0}"' -f $InstalledExePath)
+    Write-Info 'Clicky will now start automatically when you log in.'
+    Write-Info 'Use `msconfig` → Startup, or Task Manager → Startup apps, to disable later.'
+}
+
+function Start-ClickyIfRequested {
+    if ($NoLaunch) { return }
+    Write-Step 'Launching Clicky'
+    Start-Process -FilePath $InstalledExePath
+    Write-Info 'Clicky lives in your system tray — click the blue dot next to the clock to open it.'
+}
+
+# ---------- Main ----------
+
+try {
+    Write-Host ''
+    Write-Host 'Clicky installer' -ForegroundColor White
+    Write-Host '================' -ForegroundColor White
+
+    Assert-DotNetSdk
+    Stop-RunningClicky
+    $publishDir = Invoke-Publish
+    try {
+        Copy-ToInstallRoot -publishDir $publishDir
+    }
+    finally {
+        Remove-Item -Path $publishDir -Recurse -Force -ErrorAction SilentlyContinue
+    }
+    Install-Shortcuts
+    Install-Uninstaller
+    Register-AutoStartIfRequested
+    Start-ClickyIfRequested
+
+    Write-Host ''
+    Write-Host 'Install complete.' -ForegroundColor Green
+    Write-Host 'Hold Ctrl + Alt anywhere to talk. Release to send.' -ForegroundColor Green
+    Write-Host ''
+    Write-Host 'Before Clicky can actually talk to the AI backend, open' -ForegroundColor Yellow
+    Write-Host '  windows\Clicky\Services\WorkerConfig.cs' -ForegroundColor Yellow
+    Write-Host 'and replace the placeholder Cloudflare Worker URL with your own,' -ForegroundColor Yellow
+    Write-Host 'then re-run this installer.' -ForegroundColor Yellow
+    Write-Host ''
+}
+catch {
+    Write-Host ''
+    Write-Host ('Install failed: ' + $_.Exception.Message) -ForegroundColor Red
+    Write-Host ''
+    exit 1
+}

--- a/windows/install/Install-Clicky.ps1
+++ b/windows/install/Install-Clicky.ps1
@@ -8,7 +8,7 @@
     on the target machine) and installs it to %LOCALAPPDATA%\Programs\Clicky.
     Creates Start Menu and Desktop shortcuts, registers Clicky in
     Apps & Features so it can be uninstalled from Settings, and optionally
-    adds it to the Run key so it launches on login (default: yes — Clicky
+    adds it to the Run key so it launches on login (default: yes -- Clicky
     is a tray app, the user expects it to be there).
 
     Runs entirely per-user; no administrator rights required.
@@ -107,11 +107,11 @@ function Invoke-Publish {
     if ($FrameworkDependent) {
         $publishArgs += '--self-contained'
         $publishArgs += 'false'
-        Write-Info 'Framework-dependent build — end users need the .NET 8 Desktop Runtime.'
+        Write-Info 'Framework-dependent build -- end users need the .NET 8 Desktop Runtime.'
     } else {
         $publishArgs += '--self-contained'
         $publishArgs += 'true'
-        Write-Info 'Self-contained build — bundles the .NET runtime. No end-user prerequisites.'
+        Write-Info 'Self-contained build -- bundles the .NET runtime. No end-user prerequisites.'
     }
 
     & dotnet @publishArgs | Out-Host
@@ -146,7 +146,7 @@ function New-WindowsShortcut {
     param(
         [Parameter(Mandatory)][string]$ShortcutPath,
         [Parameter(Mandatory)][string]$TargetExePath,
-        [string]$Description = 'Clicky — hold Ctrl+Alt to talk.'
+        [string]$Description = 'Clicky - hold Ctrl+Alt to talk.'
     )
     $shellComObject = New-Object -ComObject WScript.Shell
     $shortcut = $shellComObject.CreateShortcut($ShortcutPath)
@@ -154,7 +154,7 @@ function New-WindowsShortcut {
     $shortcut.WorkingDirectory = Split-Path $TargetExePath
     $shortcut.IconLocation     = "$TargetExePath,0"
     $shortcut.Description      = $Description
-    $shortcut.WindowStyle      = 7   # minimized — Clicky lives in the tray
+    $shortcut.WindowStyle      = 7   # minimized -- Clicky lives in the tray
     $shortcut.Save()
 }
 
@@ -174,7 +174,7 @@ function Install-Uninstaller {
     $uninstallerPs1Body = @'
 #Requires -Version 5.1
 <#
-    Uninstalls Clicky — removes the install folder, shortcuts, Run key,
+    Uninstalls Clicky -- removes the install folder, shortcuts, Run key,
     and the Apps & Features entry. Safe to run more than once.
 #>
 $ErrorActionPreference = 'SilentlyContinue'
@@ -192,7 +192,7 @@ Remove-Item -Path $DesktopShortcut   -Force
 Remove-ItemProperty -Path $RunRegistryKey -Name 'Clicky' -ErrorAction SilentlyContinue
 Remove-Item -Path $UninstallRegistryKey -Recurse -Force
 
-# Schedule the install folder for deletion on reboot via a helper cmd —
+# Schedule the install folder for deletion on reboot via a helper cmd --
 # PowerShell can't remove its own running script, so we spawn cmd to do it
 # after this process exits.
 if (Test-Path $InstallRoot) {
@@ -225,7 +225,7 @@ Write-Host 'Clicky has been uninstalled.'
     Set-ItemProperty $UninstallRegistryKey -Name 'NoRepair'          -Value 1     -Type DWord
     Set-ItemProperty $UninstallRegistryKey -Name 'InstallDate'       -Value (Get-Date -Format 'yyyyMMdd')
 
-    Write-Info 'Registered in Apps & Features (Start → Settings → Apps → Installed apps).'
+    Write-Info 'Registered in Apps & Features (Start > Settings > Apps > Installed apps).'
 }
 
 function Register-AutoStartIfRequested {
@@ -240,14 +240,14 @@ function Register-AutoStartIfRequested {
     }
     Set-ItemProperty -Path $RunRegistryKey -Name 'Clicky' -Value ('"{0}"' -f $InstalledExePath)
     Write-Info 'Clicky will now start automatically when you log in.'
-    Write-Info 'Use `msconfig` → Startup, or Task Manager → Startup apps, to disable later.'
+    Write-Info 'Use `msconfig` > Startup, or Task Manager > Startup apps, to disable later.'
 }
 
 function Start-ClickyIfRequested {
     if ($NoLaunch) { return }
     Write-Step 'Launching Clicky'
     Start-Process -FilePath $InstalledExePath
-    Write-Info 'Clicky lives in your system tray — click the blue dot next to the clock to open it.'
+    Write-Info 'Clicky lives in your system tray -- click the blue dot next to the clock to open it.'
 }
 
 # ---------- Main ----------

--- a/worker/.secrets.local.example
+++ b/worker/.secrets.local.example
@@ -1,0 +1,19 @@
+# Clicky Worker secrets -- LOCAL ONLY, never commit.
+#
+# 1. Copy this file to .secrets.local in the same folder.
+# 2. Paste your real API keys after the = sign for each line you want set.
+# 3. Run Configure-Worker.bat (or .ps1) to push them to Cloudflare and deploy.
+#
+# Empty values are skipped (the script will not overwrite an existing
+# Cloudflare secret with an empty value). Lines starting with # are ignored.
+#
+# Where to get the keys:
+#   ANTHROPIC_API_KEY    https://console.anthropic.com/settings/keys
+#   GEMINI_API_KEY       https://aistudio.google.com/apikey
+#   ASSEMBLYAI_API_KEY   https://www.assemblyai.com/app/api-keys
+#   ELEVENLABS_API_KEY   https://elevenlabs.io/app/settings/api-keys
+
+ANTHROPIC_API_KEY=
+GEMINI_API_KEY=
+ASSEMBLYAI_API_KEY=
+ELEVENLABS_API_KEY=

--- a/worker/Configure-Worker.bat
+++ b/worker/Configure-Worker.bat
@@ -1,0 +1,17 @@
+@echo off
+REM Double-click entry point for the Clicky Worker configurator.
+REM Edit .secrets.local in this folder, then run this file (or the Desktop
+REM shortcut "Configure Clicky Worker" that the script creates on first run).
+setlocal
+set "SCRIPT_DIR=%~dp0"
+powershell.exe -NoProfile -ExecutionPolicy Bypass -File "%SCRIPT_DIR%Configure-Worker.ps1" %*
+set "EXITCODE=%ERRORLEVEL%"
+echo.
+if "%EXITCODE%"=="0" (
+    echo Worker configurator finished successfully.
+) else (
+    echo Worker configurator exited with code %EXITCODE%.
+)
+echo.
+pause
+endlocal & exit /b %EXITCODE%

--- a/worker/Configure-Worker.ps1
+++ b/worker/Configure-Worker.ps1
@@ -1,0 +1,270 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+    One-shot Cloudflare Worker setup for Clicky.
+
+.DESCRIPTION
+    Reads API keys from worker/.secrets.local (KEY=VALUE per line, # for
+    comments), pushes each non-empty value to Cloudflare as a Worker secret
+    via `npx wrangler secret put`, and finishes with `npx wrangler deploy`.
+    Logs you into Cloudflare on first run if you are not already authed.
+
+    The first time you run it, a Desktop shortcut "Configure Clicky Worker"
+    is created so future runs are one click away.
+
+    Run this script as many times as you want -- it is idempotent. Edit
+    .secrets.local, double-click the shortcut, done.
+
+.PARAMETER SkipDeploy
+    Push the secrets but skip the final `wrangler deploy`. Useful if you only
+    rotated a key and don't need to redeploy.
+
+.PARAMETER NoShortcut
+    Don't create or refresh the Desktop shortcut on this run.
+
+.EXAMPLE
+    .\Configure-Worker.ps1
+
+.EXAMPLE
+    .\Configure-Worker.ps1 -SkipDeploy
+#>
+
+[CmdletBinding()]
+param(
+    [switch]$SkipDeploy,
+    [switch]$NoShortcut
+)
+
+$ErrorActionPreference = 'Stop'
+
+# ---------- Paths ----------
+
+$ScriptDirectory      = Split-Path -Parent $MyInvocation.MyCommand.Path
+$SecretsFilePath      = Join-Path $ScriptDirectory '.secrets.local'
+$SecretsExamplePath   = Join-Path $ScriptDirectory '.secrets.local.example'
+$BatWrapperPath       = Join-Path $ScriptDirectory 'Configure-Worker.bat'
+$DesktopShortcutPath  = Join-Path ([Environment]::GetFolderPath('Desktop')) 'Configure Clicky Worker.lnk'
+
+# ---------- Helpers ----------
+
+function Write-Step($message) {
+    Write-Host ""
+    Write-Host "==> $message" -ForegroundColor Cyan
+}
+
+function Write-Info($message) {
+    Write-Host "    $message" -ForegroundColor Gray
+}
+
+function Write-Warn($message) {
+    Write-Host "    $message" -ForegroundColor Yellow
+}
+
+function Assert-Node {
+    Write-Step 'Checking for Node.js / npx'
+    $node = Get-Command node -ErrorAction SilentlyContinue
+    $npx  = Get-Command npx  -ErrorAction SilentlyContinue
+    if (-not $node -or -not $npx) {
+        throw "Node.js (which provides npx) was not found on PATH. Install the LTS build from https://nodejs.org/en/download and re-run this script."
+    }
+    Write-Info ("node: " + (& node --version))
+    Write-Info ("npx:  " + (& npx  --version))
+}
+
+function Install-WorkerDependencies {
+    Write-Step 'Ensuring worker dependencies are installed'
+    $nodeModulesDir = Join-Path $ScriptDirectory 'node_modules'
+    if (-not (Test-Path $nodeModulesDir)) {
+        Push-Location $ScriptDirectory
+        try {
+            & npm install
+            if ($LASTEXITCODE -ne 0) {
+                throw "npm install exited with code $LASTEXITCODE."
+            }
+        }
+        finally {
+            Pop-Location
+        }
+    } else {
+        Write-Info 'node_modules already present.'
+    }
+}
+
+function Read-SecretsFile {
+    Write-Step 'Reading .secrets.local'
+    if (-not (Test-Path $SecretsFilePath)) {
+        if (Test-Path $SecretsExamplePath) {
+            Copy-Item $SecretsExamplePath $SecretsFilePath
+            Write-Warn "Created .secrets.local from the example template."
+            Write-Warn "Edit that file, paste your real API keys, then re-run this script."
+            Write-Warn "Opening it in Notepad now..."
+            Start-Process notepad.exe $SecretsFilePath
+            exit 0
+        } else {
+            throw "Neither .secrets.local nor .secrets.local.example was found in $ScriptDirectory."
+        }
+    }
+
+    $secrets = [ordered]@{}
+    foreach ($rawLine in Get-Content -LiteralPath $SecretsFilePath) {
+        $line = $rawLine.Trim()
+        if (-not $line)            { continue }
+        if ($line.StartsWith('#')) { continue }
+        $eq = $line.IndexOf('=')
+        if ($eq -lt 1) { continue }
+        $name  = $line.Substring(0, $eq).Trim()
+        $value = $line.Substring($eq + 1).Trim()
+        # Strip surrounding quotes if the user wrapped the value
+        if ($value.Length -ge 2 -and (
+            ($value.StartsWith('"') -and $value.EndsWith('"')) -or
+            ($value.StartsWith("'") -and $value.EndsWith("'"))
+        )) {
+            $value = $value.Substring(1, $value.Length - 2)
+        }
+        $secrets[$name] = $value
+    }
+
+    $populated = @($secrets.GetEnumerator() | Where-Object { $_.Value })
+    Write-Info ("Found {0} key(s) in .secrets.local; {1} populated, {2} blank." -f $secrets.Count, $populated.Count, ($secrets.Count - $populated.Count))
+    if ($populated.Count -eq 0) {
+        Write-Warn ".secrets.local has no populated keys. Edit it and re-run."
+        Write-Warn $SecretsFilePath
+        Start-Process notepad.exe $SecretsFilePath
+        exit 0
+    }
+    return $secrets
+}
+
+function Assert-WranglerLogin {
+    Write-Step 'Checking Cloudflare login'
+    Push-Location $ScriptDirectory
+    try {
+        $whoami = & npx --yes wrangler whoami 2>&1 | Out-String
+        if ($LASTEXITCODE -ne 0 -or $whoami -match 'You are not authenticated') {
+            Write-Info 'Not logged in -- opening browser for Cloudflare login...'
+            & npx --yes wrangler login
+            if ($LASTEXITCODE -ne 0) {
+                throw "wrangler login exited with code $LASTEXITCODE."
+            }
+        } else {
+            $emailLine = ($whoami -split "`n" | Where-Object { $_ -match 'associated with the email' } | Select-Object -First 1)
+            if ($emailLine) {
+                Write-Info $emailLine.Trim()
+            } else {
+                Write-Info 'Already logged into Cloudflare.'
+            }
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Set-WorkerSecret {
+    param(
+        [Parameter(Mandatory)] [string]$Name,
+        [Parameter(Mandatory)] [string]$Value
+    )
+    Push-Location $ScriptDirectory
+    try {
+        # Pipe the value to wrangler's stdin so it never lands on the command
+        # line (and never shows up in process listings).
+        $output = $Value | & npx --yes wrangler secret put $Name 2>&1 | Out-String
+        if ($LASTEXITCODE -ne 0) {
+            Write-Host $output
+            throw "wrangler secret put $Name failed with exit code $LASTEXITCODE."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Push-AllSecrets {
+    param([Parameter(Mandatory)][System.Collections.Specialized.OrderedDictionary]$Secrets)
+    Write-Step 'Pushing secrets to Cloudflare'
+    foreach ($entry in $Secrets.GetEnumerator()) {
+        if (-not $entry.Value) {
+            Write-Info ("skip {0} (blank in .secrets.local)" -f $entry.Key)
+            continue
+        }
+        Write-Info ("set  {0}" -f $entry.Key)
+        Set-WorkerSecret -Name $entry.Key -Value $entry.Value
+    }
+}
+
+function Invoke-WorkerDeploy {
+    if ($SkipDeploy) {
+        Write-Step 'Skipping deploy (-SkipDeploy)'
+        return
+    }
+    Write-Step 'Deploying Worker'
+    Push-Location $ScriptDirectory
+    try {
+        & npx --yes wrangler deploy
+        if ($LASTEXITCODE -ne 0) {
+            throw "wrangler deploy exited with code $LASTEXITCODE."
+        }
+    }
+    finally {
+        Pop-Location
+    }
+}
+
+function Ensure-DesktopShortcut {
+    if ($NoShortcut) { return }
+    if (-not (Test-Path $BatWrapperPath)) { return }
+    if (Test-Path $DesktopShortcutPath) {
+        # Refresh target/working dir each run so a moved repo still works.
+        try {
+            $shell = New-Object -ComObject WScript.Shell
+            $existing = $shell.CreateShortcut($DesktopShortcutPath)
+            if ($existing.TargetPath -eq $BatWrapperPath) {
+                return
+            }
+        } catch { }
+    }
+    try {
+        $shell    = New-Object -ComObject WScript.Shell
+        $shortcut = $shell.CreateShortcut($DesktopShortcutPath)
+        $shortcut.TargetPath       = $BatWrapperPath
+        $shortcut.WorkingDirectory = $ScriptDirectory
+        $shortcut.IconLocation     = "$env:SystemRoot\System32\SHELL32.dll,316"  # blue gear icon
+        $shortcut.Description      = 'Push API keys from .secrets.local to the Clicky Cloudflare Worker.'
+        $shortcut.Save()
+        Write-Info ("Desktop shortcut: " + $DesktopShortcutPath)
+    } catch {
+        Write-Warn ("Could not create Desktop shortcut: " + $_.Exception.Message)
+    }
+}
+
+# ---------- Main ----------
+
+try {
+    Write-Host ''
+    Write-Host 'Clicky Worker configurator' -ForegroundColor White
+    Write-Host '==========================' -ForegroundColor White
+
+    Assert-Node
+    Install-WorkerDependencies
+    $secrets = Read-SecretsFile
+    Assert-WranglerLogin
+    Push-AllSecrets -Secrets $secrets
+    Invoke-WorkerDeploy
+    Ensure-DesktopShortcut
+
+    Write-Host ''
+    Write-Host 'Worker configured.' -ForegroundColor Green
+    if (-not $SkipDeploy) {
+        Write-Host 'Look in the deploy output above for your Worker URL ' -ForegroundColor Green -NoNewline
+        Write-Host '(https://clicky-proxy.<your-subdomain>.workers.dev).' -ForegroundColor Green
+        Write-Host 'Paste it into windows\Clicky\Services\WorkerConfig.cs and re-run the Clicky installer.' -ForegroundColor Green
+    }
+    Write-Host ''
+}
+catch {
+    Write-Host ''
+    Write-Host ('Configuration failed: ' + $_.Exception.Message) -ForegroundColor Red
+    Write-Host ''
+    exit 1
+}

--- a/worker/package-lock.json
+++ b/worker/package-lock.json
@@ -6,31 +6,28 @@
     "": {
       "name": "clicky-proxy",
       "devDependencies": {
-        "wrangler": "^3.0.0"
+        "wrangler": "^4.85.0"
       }
     },
     "node_modules/@cloudflare/kv-asset-handler": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.3.4.tgz",
-      "integrity": "sha512-YLPHc8yASwjNkmcDMQMY35yiWjoKAKnhUbPRszBRS0YgH+IXtsMp61j+yTcnCE3oO2DgP0U3iejLC8FTtKDC8Q==",
+      "version": "0.4.2",
+      "resolved": "https://registry.npmjs.org/@cloudflare/kv-asset-handler/-/kv-asset-handler-0.4.2.tgz",
+      "integrity": "sha512-SIOD2DxrRRwQ+jgzlXCqoEFiKOFqaPjhnNTGKXSRLvp1HiOvapLaFG2kEr9dYQTYe8rKrd9uvDUzmAITeNyaHQ==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
-      "dependencies": {
-        "mime": "^3.0.0"
-      },
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.0.0"
       }
     },
     "node_modules/@cloudflare/unenv-preset": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.0.2.tgz",
-      "integrity": "sha512-nyzYnlZjjV5xT3LizahG1Iu6mnrCaxglJ04rZLpDwlDVDZ7v46lNsfxhV3A/xtfgQuSHmLnc6SVI+KwBpc3Lwg==",
+      "version": "2.16.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/unenv-preset/-/unenv-preset-2.16.1.tgz",
+      "integrity": "sha512-ECxObrMfyTl5bhQf/lZCXwo5G6xX9IAUo+nDMKK4SZ8m4Jvvxp52vilxyySSWh2YTZz8+HQ07qGH/2rEom1vDw==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "peerDependencies": {
-        "unenv": "2.0.0-rc.14",
-        "workerd": "^1.20250124.0"
+        "unenv": "2.0.0-rc.24",
+        "workerd": ">1.20260305.0 <2.0.0-0"
       },
       "peerDependenciesMeta": {
         "workerd": {
@@ -39,9 +36,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-64": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20250718.0.tgz",
-      "integrity": "sha512-FHf4t7zbVN8yyXgQ/r/GqLPaYZSGUVzeR7RnL28Mwj2djyw2ZergvytVc7fdGcczl6PQh+VKGfZCfUqpJlbi9g==",
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-64/-/workerd-darwin-64-1.20260424.1.tgz",
+      "integrity": "sha512-yFR1XaJbSDLg/qbwtrYaU2xwFXatIPKR5nrMQCN1q/m6+Qe/j6r+kCnFEvOJjMZOm9iCKsE6Qly5clgl4u32qw==",
       "cpu": [
         "x64"
       ],
@@ -56,9 +53,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-darwin-arm64": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20250718.0.tgz",
-      "integrity": "sha512-fUiyUJYyqqp4NqJ0YgGtp4WJh/II/YZsUnEb6vVy5Oeas8lUOxnN+ZOJ8N/6/5LQCVAtYCChRiIrBbfhTn5Z8Q==",
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-darwin-arm64/-/workerd-darwin-arm64-1.20260424.1.tgz",
+      "integrity": "sha512-LqWKcE7x/9KyC2iQvKPeb20hKST3dYXDZlYTvFymgR1DfLS0OFOCzVGTloVNd7WqvK4SkdzBYfxo7QMIAeBK0w==",
       "cpu": [
         "arm64"
       ],
@@ -73,9 +70,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-64": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20250718.0.tgz",
-      "integrity": "sha512-5+eb3rtJMiEwp08Kryqzzu8d1rUcK+gdE442auo5eniMpT170Dz0QxBrqkg2Z48SFUPYbj+6uknuA5tzdRSUSg==",
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-64/-/workerd-linux-64-1.20260424.1.tgz",
+      "integrity": "sha512-YlEBFbAYZHe/ylzl8WEYQEU/jr+0XMqXaST2oBk5oVjksdb1NGuJaggluCdZAzuJJ8UqdTmyhY5u/qrasbiFWA==",
       "cpu": [
         "x64"
       ],
@@ -90,9 +87,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-linux-arm64": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20250718.0.tgz",
-      "integrity": "sha512-Aa2M/DVBEBQDdATMbn217zCSFKE+ud/teS+fFS+OQqKABLn0azO2qq6ANAHYOIE6Q3Sq4CxDIQr8lGdaJHwUog==",
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-linux-arm64/-/workerd-linux-arm64-1.20260424.1.tgz",
+      "integrity": "sha512-qJ0X0m6cL8fWDUPDg8K4IxYZXNJI6XbeOihqjnqKbAClrjdPDn8VUSd+z2XiCQ5NylMtMrpa/skC9UfaR6mh8g==",
       "cpu": [
         "arm64"
       ],
@@ -107,9 +104,9 @@
       }
     },
     "node_modules/@cloudflare/workerd-windows-64": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20250718.0.tgz",
-      "integrity": "sha512-dY16RXKffmugnc67LTbyjdDHZn5NoTF1yHEf2fN4+OaOnoGSp3N1x77QubTDwqZ9zECWxgQfDLjddcH8dWeFhg==",
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/@cloudflare/workerd-windows-64/-/workerd-windows-64-1.20260424.1.tgz",
+      "integrity": "sha512-tZ7Z9qmYNAP6z1/+8r/zKbk8F8DZmpmwNzMeN+zkde2Wnhfr3FBqOkJXT/5zmli8HPoWrIXxSiyqcNDMy8V2Zg==",
       "cpu": [
         "x64"
       ],
@@ -137,9 +134,9 @@
       }
     },
     "node_modules/@emnapi/runtime": {
-      "version": "1.9.2",
-      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.9.2.tgz",
-      "integrity": "sha512-3U4+MIWHImeyu1wnmVygh5WlgfYDtyf0k8AbLhMFxOipihf6nrWC4syIm/SwEeec0mNSafiiNnMJwbza/Is6Lw==",
+      "version": "1.10.0",
+      "resolved": "https://registry.npmjs.org/@emnapi/runtime/-/runtime-1.10.0.tgz",
+      "integrity": "sha512-ewvYlk86xUoGI0zQRNq/mC+16R1QeDlKQy21Ki3oSYXNgLb45GV1P6A0M+/s6nyCuNDqe5VpaY84BzXGwVbwFA==",
       "dev": true,
       "license": "MIT",
       "optional": true,
@@ -147,34 +144,27 @@
         "tslib": "^2.4.0"
       }
     },
-    "node_modules/@esbuild-plugins/node-globals-polyfill": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-globals-polyfill/-/node-globals-polyfill-0.2.3.tgz",
-      "integrity": "sha512-r3MIryXDeXDOZh7ih1l/yE9ZLORCd5e8vWg02azWRGj5SPTuoh69A2AIyn0Z31V/kHBfZ4HgWJ+OK3GTTwLmnw==",
+    "node_modules/@esbuild/aix-ppc64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/aix-ppc64/-/aix-ppc64-0.27.3.tgz",
+      "integrity": "sha512-9fJMTNFTWZMh5qwrBItuziu834eOCUcEqymSH7pY+zoMVEZg3gcPuBNxH1EvfVYe9h0x/Ptw8KBzv7qxb7l8dg==",
+      "cpu": [
+        "ppc64"
+      ],
       "dev": true,
-      "license": "ISC",
-      "peerDependencies": {
-        "esbuild": "*"
-      }
-    },
-    "node_modules/@esbuild-plugins/node-modules-polyfill": {
-      "version": "0.2.2",
-      "resolved": "https://registry.npmjs.org/@esbuild-plugins/node-modules-polyfill/-/node-modules-polyfill-0.2.2.tgz",
-      "integrity": "sha512-LXV7QsWJxRuMYvKbiznh+U1ilIop3g2TeKRzUxOG5X3YITc8JyyTa90BmLwqqv0YnX4v32CSlG+vsziZp9dMvA==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "escape-string-regexp": "^4.0.0",
-        "rollup-plugin-node-polyfills": "^0.2.1"
-      },
-      "peerDependencies": {
-        "esbuild": "*"
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "aix"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.17.19.tgz",
-      "integrity": "sha512-rIKddzqhmav7MSmoFCmDIb6e2W57geRsM94gV2l38fzhXMwq7hZoClug9USI2pFRGL06f4IOPHHpFNOkWieR8A==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm/-/android-arm-0.27.3.tgz",
+      "integrity": "sha512-i5D1hPY7GIQmXlXhs2w8AWHhenb00+GxjxRncS2ZM7YNVGNfaMxgzSGuO8o8SJzRc/oZwU2bcScvVERk03QhzA==",
       "cpu": [
         "arm"
       ],
@@ -185,13 +175,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.17.19.tgz",
-      "integrity": "sha512-KBMWvEZooR7+kzY0BtbTQn0OAYY7CsiydT63pVEaPtVYF0hXbUaOyZog37DKxK7NF3XacBJOpYT4adIJh+avxA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-arm64/-/android-arm64-0.27.3.tgz",
+      "integrity": "sha512-YdghPYUmj/FX2SYKJ0OZxf+iaKgMsKHVPF1MAq/P8WirnSpCStzKJFjOjzsW0QQ7oIAiccHdcqjbHmJxRb/dmg==",
       "cpu": [
         "arm64"
       ],
@@ -202,13 +192,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/android-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.17.19.tgz",
-      "integrity": "sha512-uUTTc4xGNDT7YSArp/zbtmbhO0uEEK9/ETW29Wk1thYUJBz3IVnvgEiEwEa9IeLyvnpKrWK64Utw2bgUmDveww==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/android-x64/-/android-x64-0.27.3.tgz",
+      "integrity": "sha512-IN/0BNTkHtk8lkOM8JWAYFg4ORxBkZQf9zXiEOfERX/CzxW3Vg1ewAhU7QSWQpVIzTW+b8Xy+lGzdYXV6UZObQ==",
       "cpu": [
         "x64"
       ],
@@ -219,13 +209,13 @@
         "android"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.17.19.tgz",
-      "integrity": "sha512-80wEoCfF/hFKM6WE1FyBHc9SfUblloAWx6FJkFWTWiCoht9Mc0ARGEM47e67W9rI09YoUxJL68WHfDRYEAvOhg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-arm64/-/darwin-arm64-0.27.3.tgz",
+      "integrity": "sha512-Re491k7ByTVRy0t3EKWajdLIr0gz2kKKfzafkth4Q8A5n1xTHrkqZgLLjFEHVD+AXdUGgQMq+Godfq45mGpCKg==",
       "cpu": [
         "arm64"
       ],
@@ -236,13 +226,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/darwin-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.17.19.tgz",
-      "integrity": "sha512-IJM4JJsLhRYr9xdtLytPLSH9k/oxR3boaUIYiHkAawtwNOXKE8KoU8tMvryogdcT8AU+Bflmh81Xn6Q0vTZbQw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/darwin-x64/-/darwin-x64-0.27.3.tgz",
+      "integrity": "sha512-vHk/hA7/1AckjGzRqi6wbo+jaShzRowYip6rt6q7VYEDX4LEy1pZfDpdxCBnGtl+A5zq8iXDcyuxwtv3hNtHFg==",
       "cpu": [
         "x64"
       ],
@@ -253,13 +243,13 @@
         "darwin"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.17.19.tgz",
-      "integrity": "sha512-pBwbc7DufluUeGdjSU5Si+P3SoMF5DQ/F/UmTSb8HXO80ZEAJmrykPyzo1IfNbAoaqw48YRpv8shwd1NoI0jcQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-arm64/-/freebsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-ipTYM2fjt3kQAYOvo6vcxJx3nBYAzPjgTCk7QEgZG8AUO3ydUhvelmhrbOheMnGOlaSFUoHXB6un+A7q4ygY9w==",
       "cpu": [
         "arm64"
       ],
@@ -270,13 +260,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/freebsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.17.19.tgz",
-      "integrity": "sha512-4lu+n8Wk0XlajEhbEffdy2xy53dpR06SlzvhGByyg36qJw6Kpfk7cp45DR/62aPH9mtJRmIyrXAS5UWBrJT6TQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/freebsd-x64/-/freebsd-x64-0.27.3.tgz",
+      "integrity": "sha512-dDk0X87T7mI6U3K9VjWtHOXqwAMJBNN2r7bejDsc+j03SEjtD9HrOl8gVFByeM0aJksoUuUVU9TBaZa2rgj0oA==",
       "cpu": [
         "x64"
       ],
@@ -287,13 +277,13 @@
         "freebsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.17.19.tgz",
-      "integrity": "sha512-cdmT3KxjlOQ/gZ2cjfrQOtmhG4HJs6hhvm3mWSRDPtZ/lP5oe8FWceS10JaSJC13GBd4eH/haHnqf7hhGNLerA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm/-/linux-arm-0.27.3.tgz",
+      "integrity": "sha512-s6nPv2QkSupJwLYyfS+gwdirm0ukyTFNl3KTgZEAiJDd+iHZcbTPPcWCcRYH+WlNbwChgH2QkE9NSlNrMT8Gfw==",
       "cpu": [
         "arm"
       ],
@@ -304,13 +294,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.17.19.tgz",
-      "integrity": "sha512-ct1Tg3WGwd3P+oZYqic+YZF4snNl2bsnMKRkb3ozHmnM0dGWuxcPTTntAF6bOP0Sp4x0PjSF+4uHQ1xvxfRKqg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-arm64/-/linux-arm64-0.27.3.tgz",
+      "integrity": "sha512-sZOuFz/xWnZ4KH3YfFrKCf1WyPZHakVzTiqji3WDc0BCl2kBwiJLCXpzLzUBLgmp4veFZdvN5ChW4Eq/8Fc2Fg==",
       "cpu": [
         "arm64"
       ],
@@ -321,13 +311,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.17.19.tgz",
-      "integrity": "sha512-w4IRhSy1VbsNxHRQpeGCHEmibqdTUx61Vc38APcsRbuVgK0OPEnQ0YD39Brymn96mOx48Y2laBQGqgZ0j9w6SQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ia32/-/linux-ia32-0.27.3.tgz",
+      "integrity": "sha512-yGlQYjdxtLdh0a3jHjuwOrxQjOZYD/C9PfdbgJJF3TIZWnm/tMd/RcNiLngiu4iwcBAOezdnSLAwQDPqTmtTYg==",
       "cpu": [
         "ia32"
       ],
@@ -338,13 +328,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-loong64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.17.19.tgz",
-      "integrity": "sha512-2iAngUbBPMq439a+z//gE+9WBldoMp1s5GWsUSgqHLzLJ9WoZLZhpwWuym0u0u/4XmZ3gpHmzV84PonE+9IIdQ==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-loong64/-/linux-loong64-0.27.3.tgz",
+      "integrity": "sha512-WO60Sn8ly3gtzhyjATDgieJNet/KqsDlX5nRC5Y3oTFcS1l0KWba+SEa9Ja1GfDqSF1z6hif/SkpQJbL63cgOA==",
       "cpu": [
         "loong64"
       ],
@@ -355,13 +345,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-mips64el": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.17.19.tgz",
-      "integrity": "sha512-LKJltc4LVdMKHsrFe4MGNPp0hqDFA1Wpt3jE1gEyM3nKUvOiO//9PheZZHfYRfYl6AwdTH4aTcXSqBerX0ml4A==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-mips64el/-/linux-mips64el-0.27.3.tgz",
+      "integrity": "sha512-APsymYA6sGcZ4pD6k+UxbDjOFSvPWyZhjaiPyl/f79xKxwTnrn5QUnXR5prvetuaSMsb4jgeHewIDCIWljrSxw==",
       "cpu": [
         "mips64el"
       ],
@@ -372,13 +362,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-ppc64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.17.19.tgz",
-      "integrity": "sha512-/c/DGybs95WXNS8y3Ti/ytqETiW7EU44MEKuCAcpPto3YjQbyK3IQVKfF6nbghD7EcLUGl0NbiL5Rt5DMhn5tg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-ppc64/-/linux-ppc64-0.27.3.tgz",
+      "integrity": "sha512-eizBnTeBefojtDb9nSh4vvVQ3V9Qf9Df01PfawPcRzJH4gFSgrObw+LveUyDoKU3kxi5+9RJTCWlj4FjYXVPEA==",
       "cpu": [
         "ppc64"
       ],
@@ -389,13 +379,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-riscv64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.17.19.tgz",
-      "integrity": "sha512-FC3nUAWhvFoutlhAkgHf8f5HwFWUL6bYdvLc/TTuxKlvLi3+pPzdZiFKSWz/PF30TB1K19SuCxDTI5KcqASJqA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-riscv64/-/linux-riscv64-0.27.3.tgz",
+      "integrity": "sha512-3Emwh0r5wmfm3ssTWRQSyVhbOHvqegUDRd0WhmXKX2mkHJe1SFCMJhagUleMq+Uci34wLSipf8Lagt4LlpRFWQ==",
       "cpu": [
         "riscv64"
       ],
@@ -406,13 +396,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-s390x": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.17.19.tgz",
-      "integrity": "sha512-IbFsFbxMWLuKEbH+7sTkKzL6NJmG2vRyy6K7JJo55w+8xDk7RElYn6xvXtDW8HCfoKBFK69f3pgBJSUSQPr+4Q==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-s390x/-/linux-s390x-0.27.3.tgz",
+      "integrity": "sha512-pBHUx9LzXWBc7MFIEEL0yD/ZVtNgLytvx60gES28GcWMqil8ElCYR4kvbV2BDqsHOvVDRrOxGySBM9Fcv744hw==",
       "cpu": [
         "s390x"
       ],
@@ -423,13 +413,13 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/linux-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.17.19.tgz",
-      "integrity": "sha512-68ngA9lg2H6zkZcyp22tsVt38mlhWde8l3eJLWkyLrp4HwMUr3c1s/M2t7+kHIhvMjglIBrFpncX1SzMckomGw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/linux-x64/-/linux-x64-0.27.3.tgz",
+      "integrity": "sha512-Czi8yzXUWIQYAtL/2y6vogER8pvcsOsk5cpwL4Gk5nJqH5UZiVByIY8Eorm5R13gq+DQKYg0+JyQoytLQas4dA==",
       "cpu": [
         "x64"
       ],
@@ -440,13 +430,30 @@
         "linux"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/netbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-arm64/-/netbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-sDpk0RgmTCR/5HguIZa9n9u+HVKf40fbEUt+iTzSnCaGvY9kFP0YKBWZtJaraonFnqef5SlJ8/TiPAxzyS+UoA==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "netbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/netbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-CwFq42rXCR8TYIjIfpXCbRX0rp1jo6cPIUPSaWwzbVI4aOfX96OXY8M6KNmtPcg7QjYeDmN+DD0Wp3LaBOLf4Q==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/netbsd-x64/-/netbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-P14lFKJl/DdaE00LItAukUdZO5iqNH7+PjoBm+fLQjtxfcfFE20Xf5CrLsmZdq5LFFZzb5JMZ9grUwvtVYzjiA==",
       "cpu": [
         "x64"
       ],
@@ -457,13 +464,30 @@
         "netbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openbsd-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-arm64/-/openbsd-arm64-0.27.3.tgz",
+      "integrity": "sha512-AIcMP77AvirGbRl/UZFTq5hjXK+2wC7qFRGoHSDrZ5v5b8DK/GYpXW3CPRL53NkvDqb9D+alBiC/dV0Fb7eJcw==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openbsd"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/openbsd-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.17.19.tgz",
-      "integrity": "sha512-cnq5brJYrSZ2CF6c35eCmviIN3k3RczmHz8eYaVlNasVqsNY+JKohZU5MKmaOI+KkllCdzOKKdPs762VCPC20g==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openbsd-x64/-/openbsd-x64-0.27.3.tgz",
+      "integrity": "sha512-DnW2sRrBzA+YnE70LKqnM3P+z8vehfJWHXECbwBmH/CU51z6FiqTQTHFenPlHmo3a8UgpLyH3PT+87OViOh1AQ==",
       "cpu": [
         "x64"
       ],
@@ -474,13 +498,30 @@
         "openbsd"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
+      }
+    },
+    "node_modules/@esbuild/openharmony-arm64": {
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/openharmony-arm64/-/openharmony-arm64-0.27.3.tgz",
+      "integrity": "sha512-NinAEgr/etERPTsZJ7aEZQvvg/A6IsZG/LgZy+81wON2huV7SrK3e63dU0XhyZP4RKGyTm7aOgmQk0bGp0fy2g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "openharmony"
+      ],
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/sunos-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.17.19.tgz",
-      "integrity": "sha512-vCRT7yP3zX+bKWFeP/zdS6SqdWB8OIpaRq/mbXQxTGHnIxspRtigpkUcDMlSCOejlHowLqII7K2JKevwyRP2rg==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/sunos-x64/-/sunos-x64-0.27.3.tgz",
+      "integrity": "sha512-PanZ+nEz+eWoBJ8/f8HKxTTD172SKwdXebZ0ndd953gt1HRBbhMsaNqjTyYLGLPdoWHy4zLU7bDVJztF5f3BHA==",
       "cpu": [
         "x64"
       ],
@@ -491,13 +532,13 @@
         "sunos"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-arm64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.17.19.tgz",
-      "integrity": "sha512-yYx+8jwowUstVdorcMdNlzklLYhPxjniHWFKgRqH7IFlUEa0Umu3KuYplf1HUZZ422e3NU9F4LGb+4O0Kdcaag==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-arm64/-/win32-arm64-0.27.3.tgz",
+      "integrity": "sha512-B2t59lWWYrbRDw/tjiWOuzSsFh1Y/E95ofKz7rIVYSQkUYBjfSgf6oeYPNWHToFRr2zx52JKApIcAS/D5TUBnA==",
       "cpu": [
         "arm64"
       ],
@@ -508,13 +549,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-ia32": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.17.19.tgz",
-      "integrity": "sha512-eggDKanJszUtCdlVs0RB+h35wNlb5v4TWEkq4vZcmVt5u/HiDZrTXe2bWFQUez3RgNHwx/x4sk5++4NSSicKkw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-ia32/-/win32-ia32-0.27.3.tgz",
+      "integrity": "sha512-QLKSFeXNS8+tHW7tZpMtjlNb7HKau0QDpwm49u0vUp9y1WOF+PEzkU84y9GqYaAVW8aH8f3GcBck26jh54cX4Q==",
       "cpu": [
         "ia32"
       ],
@@ -525,13 +566,13 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/win32-x64": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.17.19.tgz",
-      "integrity": "sha512-lAhycmKnVOuRYNtRtatQR1LPQf2oYCkRGkSFnseDAKPl8lu5SOsK/e1sXe5a0Pc5kHIHe6P2I/ilntNv2xf3cA==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/@esbuild/win32-x64/-/win32-x64-0.27.3.tgz",
+      "integrity": "sha512-4uJGhsxuptu3OcpVAzli+/gWusVGwZZHTlS63hh++ehExkVT8SgiEf7/uC/PclrPPkLhZqGgCTjd0VWLo6xMqA==",
       "cpu": [
         "x64"
       ],
@@ -542,23 +583,23 @@
         "win32"
       ],
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       }
     },
-    "node_modules/@fastify/busboy": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/@fastify/busboy/-/busboy-2.1.1.tgz",
-      "integrity": "sha512-vBZP4NlzfOlerQTnba4aqZoMhE/a9HY7HRqoOPaETQcSQuWEIyZMHGfVu6w9wGtGK5fED5qRs2DteVCjOH60sA==",
+    "node_modules/@img/colour": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/@img/colour/-/colour-1.1.0.tgz",
+      "integrity": "sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
     "node_modules/@img/sharp-darwin-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.33.5.tgz",
-      "integrity": "sha512-UT4p+iz/2H4twwAoLCqfA9UH5pI6DggwKEGuaPy7nCVQ8ZsiY5PIcrRvD1DzuY3qYL07NtIQcWnBSY/heikIFQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-arm64/-/sharp-darwin-arm64-0.34.5.tgz",
+      "integrity": "sha512-imtQ3WMJXbMY4fxb/Ndp6HBTNVtWCUI0WdobyheGf5+ad6xX8VIDO8u2xE4qc/fr08CKG/7dDseFtn6M6g/r3w==",
       "cpu": [
         "arm64"
       ],
@@ -575,13 +616,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-arm64": "1.0.4"
+        "@img/sharp-libvips-darwin-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-darwin-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.33.5.tgz",
-      "integrity": "sha512-fyHac4jIc1ANYGRDxtiqelIbdWkIuQaI84Mv45KvGRRxSAa7o7d1ZKAOBaYbnepLC1WqxfpimdeWfvqqSGwR2Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-darwin-x64/-/sharp-darwin-x64-0.34.5.tgz",
+      "integrity": "sha512-YNEFAF/4KQ/PeW0N+r+aVVsoIY0/qxxikF2SWdp+NRkmMB7y9LBZAVqQ4yhGCm/H3H270OSykqmQMKLBhBJDEw==",
       "cpu": [
         "x64"
       ],
@@ -598,13 +639,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-darwin-x64": "1.0.4"
+        "@img/sharp-libvips-darwin-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-libvips-darwin-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.0.4.tgz",
-      "integrity": "sha512-XblONe153h0O2zuFfTAbQYAX2JhYmDHeWikp1LM9Hul9gVPjFY427k6dFEcOL72O01QxQsWi761svJ/ev9xEDg==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-arm64/-/sharp-libvips-darwin-arm64-1.2.4.tgz",
+      "integrity": "sha512-zqjjo7RatFfFoP0MkQ51jfuFZBnVE2pRiaydKJ1G/rHZvnsrHAOcQALIi9sA5co5xenQdTugCvtb1cuf78Vf4g==",
       "cpu": [
         "arm64"
       ],
@@ -619,9 +660,9 @@
       }
     },
     "node_modules/@img/sharp-libvips-darwin-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.0.4.tgz",
-      "integrity": "sha512-xnGR8YuZYfJGmWPvmlunFaWJsb9T/AO2ykoP3Fz/0X5XV2aoYBPkX6xqCQvUTKKiLddarLaxpzNe+b1hjeWHAQ==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-darwin-x64/-/sharp-libvips-darwin-x64-1.2.4.tgz",
+      "integrity": "sha512-1IOd5xfVhlGwX+zXv2N93k0yMONvUlANylbJw1eTah8K/Jtpi15KC+WSiaX/nBmbm2HxRM1gZ0nSdjSsrZbGKg==",
       "cpu": [
         "x64"
       ],
@@ -636,16 +677,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm": {
-      "version": "1.0.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.0.5.tgz",
-      "integrity": "sha512-gvcC4ACAOPRNATg/ov8/MnbxFDJqf/pDePbBnuBDcjsI8PssmjoKMAz4LtLaVi+OnSb5FK/yIOamqDwGmXW32g==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm/-/sharp-libvips-linux-arm-1.2.4.tgz",
+      "integrity": "sha512-bFI7xcKFELdiNCVov8e44Ia4u2byA+l3XtsAj+Q8tfCwO6BQ8iDojYdvoPMqsKDkuoOo+X6HZA0s0q11ANMQ8A==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -656,16 +694,47 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.0.4.tgz",
-      "integrity": "sha512-9B+taZ8DlyyqzZQnoeIvDVR/2F4EbMepXMc/NdVbkzsJbzkUjhXv/70GQJ7tdLA4YJgNP25zukcxpX2/SueNrA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-arm64/-/sharp-libvips-linux-arm64-1.2.4.tgz",
+      "integrity": "sha512-excjX8DfsIcJ10x1Kzr4RcWe1edC9PquDRRPx3YVCvQv+U5p7Yin2s32ftzikXojb1PIFc/9Mt28/y+iRklkrw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
       ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-ppc64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-ppc64/-/sharp-libvips-linux-ppc64-1.2.4.tgz",
+      "integrity": "sha512-FMuvGijLDYG6lW+b/UvyilUWu5Ayu+3r2d1S8notiGCIyYU/76eig1UfMmkZ7vwgOrzKzlQbFSuQfgm7GYUPpA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-libvips-linux-riscv64": {
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-riscv64/-/sharp-libvips-linux-riscv64-1.2.4.tgz",
+      "integrity": "sha512-oVDbcR4zUC0ce82teubSm+x6ETixtKZBh/qbREIOcI3cULzDyb18Sr/Wcyx7NRQeQzOiHTNbZFF1UwPS2scyGA==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -676,16 +745,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-s390x": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.0.4.tgz",
-      "integrity": "sha512-u7Wz6ntiSSgGSGcjZ55im6uvTrOxSIS8/dgoVMoiGE9I6JAfU50yH5BoDlYA1tcuGS7g/QNtetJnxA6QEsCVTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-s390x/-/sharp-libvips-linux-s390x-1.2.4.tgz",
+      "integrity": "sha512-qmp9VrzgPgMoGZyPvrQHqk02uyjA0/QrTO26Tqk6l4ZV0MPWIW6LTkqOIov+J1yEu7MbFQaDpwdwJKhbJvuRxQ==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -696,16 +762,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linux-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.0.4.tgz",
-      "integrity": "sha512-MmWmQ3iPFZr0Iev+BAgVMb3ZyC4KeFc3jFxnNbEPas60e1cIfevbtuyf9nDGIzOaW9PdnDciJm+wFFaTlj5xYw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linux-x64/-/sharp-libvips-linux-x64-1.2.4.tgz",
+      "integrity": "sha512-tJxiiLsmHc9Ax1bz3oaOYBURTXGIRDODBqhveVHonrHJ9/+k89qbLl0bcJns+e4t4rvaNBxaEZsFtSfAdquPrw==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -716,16 +779,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-arm64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.0.4.tgz",
-      "integrity": "sha512-9Ti+BbTYDcsbp4wfYib8Ctm1ilkugkA/uscUn6UXK1ldpC1JjiXbLfFZtRlBhjPZ5o1NCLiDbg8fhUPKStHoTA==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-arm64/-/sharp-libvips-linuxmusl-arm64-1.2.4.tgz",
+      "integrity": "sha512-FVQHuwx1IIuNow9QAbYUzJ+En8KcVm9Lk5+uGUQJHaZmMECZmOlix9HnH7n1TRkXMS0pGxIJokIVB9SuqZGGXw==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -736,16 +796,13 @@
       }
     },
     "node_modules/@img/sharp-libvips-linuxmusl-x64": {
-      "version": "1.0.4",
-      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.0.4.tgz",
-      "integrity": "sha512-viYN1KX9m+/hGkJtvYYp+CCLgnJXwiQB39damAO7WMdKWlIhmYTfHjwSbQeUK/20vY154mwezd9HflVFM1wVSw==",
+      "version": "1.2.4",
+      "resolved": "https://registry.npmjs.org/@img/sharp-libvips-linuxmusl-x64/-/sharp-libvips-linuxmusl-x64-1.2.4.tgz",
+      "integrity": "sha512-+LpyBk7L44ZIXwz/VYfglaX/okxezESc6UxDSoyo2Ks6Jxc4Y7sGjpgU9s4PMgqgjj1gZCylTieNamqA1MF7Dg==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "LGPL-3.0-or-later",
       "optional": true,
       "os": [
@@ -756,16 +813,13 @@
       }
     },
     "node_modules/@img/sharp-linux-arm": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.33.5.tgz",
-      "integrity": "sha512-JTS1eldqZbJxjvKaAkxhZmBqPRGmxgu+qFKSInv8moZ2AmT5Yib3EQ1c6gp493HvrvV8QgdOXdyaIBrhvFhBMQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm/-/sharp-linux-arm-0.34.5.tgz",
+      "integrity": "sha512-9dLqsvwtg1uuXBGZKsxem9595+ujv0sJ6Vi8wcTANSFpwV/GONat5eCkzQo/1O6zRIkh0m/8+5BjrRr7jDUSZw==",
       "cpu": [
         "arm"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -778,20 +832,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm": "1.0.5"
+        "@img/sharp-libvips-linux-arm": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.33.5.tgz",
-      "integrity": "sha512-JMVv+AMRyGOHtO1RFBiJy/MBsgz0x4AWrT6QoEVVTyh1E39TrCUpTRI7mx9VksGX4awWASxqCYLCV4wBZHAYxA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-arm64/-/sharp-linux-arm64-0.34.5.tgz",
+      "integrity": "sha512-bKQzaJRY/bkPOXyKx5EVup7qkaojECG6NLYswgktOZjaXecSAeCWiZwwiFf3/Y+O1HrauiE3FVsGxFg8c24rZg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -804,20 +855,63 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-arm64": "1.0.4"
+        "@img/sharp-libvips-linux-arm64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-ppc64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-ppc64/-/sharp-linux-ppc64-0.34.5.tgz",
+      "integrity": "sha512-7zznwNaqW6YtsfrGGDA6BRkISKAAE1Jo0QdpNYXNMHu2+0dTrPflTLNkpc8l7MUP5M16ZJcUvysVWWrMefZquA==",
+      "cpu": [
+        "ppc64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-ppc64": "1.2.4"
+      }
+    },
+    "node_modules/@img/sharp-linux-riscv64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-riscv64/-/sharp-linux-riscv64-0.34.5.tgz",
+      "integrity": "sha512-51gJuLPTKa7piYPaVs8GmByo7/U7/7TZOq+cnXJIHZKavIRHAP77e3N2HEl3dgiqdD/w0yUfiJnII77PuDDFdw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0",
+      "optional": true,
+      "os": [
+        "linux"
+      ],
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      },
+      "optionalDependencies": {
+        "@img/sharp-libvips-linux-riscv64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-s390x": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.33.5.tgz",
-      "integrity": "sha512-y/5PCd+mP4CA/sPDKl2961b+C9d+vPAveS33s6Z3zfASk2j5upL6fXVPZi7ztePZ5CuH+1kW8JtvxgbuXHRa4Q==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-s390x/-/sharp-linux-s390x-0.34.5.tgz",
+      "integrity": "sha512-nQtCk0PdKfho3eC5MrbQoigJ2gd1CgddUMkabUj+rBevs8tZ2cULOx46E7oyX+04WGfABgIwmMC0VqieTiR4jg==",
       "cpu": [
         "s390x"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -830,20 +924,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-s390x": "1.0.4"
+        "@img/sharp-libvips-linux-s390x": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linux-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.33.5.tgz",
-      "integrity": "sha512-opC+Ok5pRNAzuvq1AG0ar+1owsu842/Ab+4qvU879ippJBHvyY5n2mxF1izXqkPYlGuP/M556uh53jRLJmzTWA==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linux-x64/-/sharp-linux-x64-0.34.5.tgz",
+      "integrity": "sha512-MEzd8HPKxVxVenwAa+JRPwEC7QFjoPWuS5NZnBt6B3pu7EG2Ge0id1oLHZpPJdn3OQK+BQDiw9zStiHBTJQQQQ==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "glibc"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -856,20 +947,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linux-x64": "1.0.4"
+        "@img/sharp-libvips-linux-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-arm64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.33.5.tgz",
-      "integrity": "sha512-XrHMZwGQGvJg2V/oRSUfSAfjfPxO+4DkiRh6p2AFjLQztWUuY/o8Mq0eMQVIY7HJ1CDQUJlxGGZRw1a5bqmd1g==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-arm64/-/sharp-linuxmusl-arm64-0.34.5.tgz",
+      "integrity": "sha512-fprJR6GtRsMt6Kyfq44IsChVZeGN97gTD331weR1ex1c1rypDEABN6Tm2xa1wE6lYb5DdEnk03NZPqA7Id21yg==",
       "cpu": [
         "arm64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -882,20 +970,17 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-linuxmusl-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.33.5.tgz",
-      "integrity": "sha512-WT+d/cgqKkkKySYmqoZ8y3pxx7lx9vVejxW/W4DOFMYVSkErR+w7mf2u8m/y4+xHe7yY9DAXQMWQhpnMuFfScw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-linuxmusl-x64/-/sharp-linuxmusl-x64-0.34.5.tgz",
+      "integrity": "sha512-Jg8wNT1MUzIvhBFxViqrEhWDGzqymo3sV7z7ZsaWbZNDLXRJZoRGrjulp60YYtV4wfY8VIKcWidjojlLcWrd8Q==",
       "cpu": [
         "x64"
       ],
       "dev": true,
-      "libc": [
-        "musl"
-      ],
       "license": "Apache-2.0",
       "optional": true,
       "os": [
@@ -908,13 +993,13 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4"
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4"
       }
     },
     "node_modules/@img/sharp-wasm32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.33.5.tgz",
-      "integrity": "sha512-ykUW4LVGaMcU9lu9thv85CbRMAwfeadCJHRsg2GmeRa/cJxsVY9Rbd57JcMxBkKHag5U/x7TSBpScF4U8ElVzg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-wasm32/-/sharp-wasm32-0.34.5.tgz",
+      "integrity": "sha512-OdWTEiVkY2PHwqkbBI8frFxQQFekHaSSkUIJkwzclWZe64O1X4UlUjqqqLaPbUpMOQk6FBu/HtlGXNblIs0huw==",
       "cpu": [
         "wasm32"
       ],
@@ -922,8 +1007,28 @@
       "license": "Apache-2.0 AND LGPL-3.0-or-later AND MIT",
       "optional": true,
       "dependencies": {
-        "@emnapi/runtime": "^1.2.0"
+        "@emnapi/runtime": "^1.7.0"
       },
+      "engines": {
+        "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/libvips"
+      }
+    },
+    "node_modules/@img/sharp-win32-arm64": {
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-arm64/-/sharp-win32-arm64-0.34.5.tgz",
+      "integrity": "sha512-WQ3AgWCWYSb2yt+IG8mnC6Jdk9Whs7O0gxphblsLvdhSpSTtmu69ZG1Gkb6NuvxsNACwiPV6cNSZNzt0KPsw7g==",
+      "cpu": [
+        "arm64"
+      ],
+      "dev": true,
+      "license": "Apache-2.0 AND LGPL-3.0-or-later",
+      "optional": true,
+      "os": [
+        "win32"
+      ],
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
       },
@@ -932,9 +1037,9 @@
       }
     },
     "node_modules/@img/sharp-win32-ia32": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.33.5.tgz",
-      "integrity": "sha512-T36PblLaTwuVJ/zw/LaH0PdZkRz5rd3SmMHX8GSmR7vtNSP5Z6bQkExdSK7xGWyxLw4sUknBuugTelgw2faBbQ==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-ia32/-/sharp-win32-ia32-0.34.5.tgz",
+      "integrity": "sha512-FV9m/7NmeCmSHDD5j4+4pNI8Cp3aW+JvLoXcTUo0IqyjSfAZJ8dIUmijx1qaJsIiU+Hosw6xM5KijAWRJCSgNg==",
       "cpu": [
         "ia32"
       ],
@@ -952,9 +1057,9 @@
       }
     },
     "node_modules/@img/sharp-win32-x64": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.33.5.tgz",
-      "integrity": "sha512-MpY/o8/8kj+EcnxwvrP4aTJSWw/aZ7JIGR4aBeZkZw5B7/Jn+tY9/VNwtcoGmdT7GfggGIU4kygOMSbYnOrAbg==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/@img/sharp-win32-x64/-/sharp-win32-x64-0.34.5.tgz",
+      "integrity": "sha512-+29YMsqY2/9eFEiW93eqWnuLcWcufowXewwSNIT6UwZdUUCrM3oFjMWH/Z6/TMmb4hlFenmfAVbpWeup2jryCw==",
       "cpu": [
         "x64"
       ],
@@ -999,38 +1104,54 @@
         "@jridgewell/sourcemap-codec": "^1.4.10"
       }
     },
-    "node_modules/acorn": {
-      "version": "8.14.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
-      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "acorn": "bin/acorn"
-      },
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-walk": {
-      "version": "8.3.2",
-      "resolved": "https://registry.npmjs.org/acorn-walk/-/acorn-walk-8.3.2.tgz",
-      "integrity": "sha512-cjkyv4OtNCIeqhHrfS81QWXoCBPExR/J62oyEqepVw8WaQeSqpW2uhuLPh1m9eWhDuOo/jUXVTlifvesOWp/4A==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=0.4.0"
-      }
-    },
-    "node_modules/as-table": {
-      "version": "1.0.55",
-      "resolved": "https://registry.npmjs.org/as-table/-/as-table-1.0.55.tgz",
-      "integrity": "sha512-xvsWESUJn0JN421Xb9MQw6AsMHRCUknCe0Wjlxvjud80mU4E6hQf1A6NzQKcYNmYw62MfzEtXc+badstZP3JpQ==",
+    "node_modules/@poppinss/colors": {
+      "version": "4.1.6",
+      "resolved": "https://registry.npmjs.org/@poppinss/colors/-/colors-4.1.6.tgz",
+      "integrity": "sha512-H9xkIdFswbS8n1d6vmRd8+c10t2Qe+rZITbbDHHkQixH5+2x1FDGmi/0K+WgWiqQFKPSlIYB7jlH6Kpfn6Fleg==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "printable-characters": "^1.0.42"
+        "kleur": "^4.1.5"
       }
+    },
+    "node_modules/@poppinss/dumper": {
+      "version": "0.6.5",
+      "resolved": "https://registry.npmjs.org/@poppinss/dumper/-/dumper-0.6.5.tgz",
+      "integrity": "sha512-NBdYIb90J7LfOI32dOewKI1r7wnkiH6m920puQ3qHUeZkxNkQiFnXVWoE6YtFSv6QOiPPf7ys6i+HWWecDz7sw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@poppinss/colors": "^4.1.5",
+        "@sindresorhus/is": "^7.0.2",
+        "supports-color": "^10.0.0"
+      }
+    },
+    "node_modules/@poppinss/exception": {
+      "version": "1.2.3",
+      "resolved": "https://registry.npmjs.org/@poppinss/exception/-/exception-1.2.3.tgz",
+      "integrity": "sha512-dCED+QRChTVatE9ibtoaxc+WkdzOSjYTKi/+uacHWIsfodVfpsueo3+DKpgU5Px8qXjgmXkSvhXvSCz3fnP9lw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@sindresorhus/is": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-7.2.0.tgz",
+      "integrity": "sha512-P1Cz1dWaFfR4IR+U13mqqiGsLFf1KbayybWwdd2vfctdV6hDpUkgCY0nKOLLTMSoRd/jJNjtbqzf13K8DCCXQw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sindresorhus/is?sponsor=1"
+      }
+    },
+    "node_modules/@speed-highlight/core": {
+      "version": "1.2.15",
+      "resolved": "https://registry.npmjs.org/@speed-highlight/core/-/core-1.2.15.tgz",
+      "integrity": "sha512-BMq1K3DsElxDWawkX6eLg9+CKJrTVGCBAWVuHXVUV2u0s2711qiChLSId6ikYPfxhdYocLNt3wWwSvDiTvFabw==",
+      "dev": true,
+      "license": "CC0-1.0"
     },
     "node_modules/blake3-wasm": {
       "version": "2.1.5",
@@ -1039,78 +1160,19 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/color": {
-      "version": "4.2.3",
-      "resolved": "https://registry.npmjs.org/color/-/color-4.2.3.tgz",
-      "integrity": "sha512-1rXeuUUiGGrykh+CeBdu5Ie7OJwinCgQY0bc7GCRxy5xVHy+moaqkpL/jqQq0MtQOeYcrqEz4abc5f0KtU7W4A==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-convert": "^2.0.1",
-        "color-string": "^1.9.0"
-      },
-      "engines": {
-        "node": ">=12.5.0"
-      }
-    },
-    "node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true
-    },
-    "node_modules/color-string": {
-      "version": "1.9.1",
-      "resolved": "https://registry.npmjs.org/color-string/-/color-string-1.9.1.tgz",
-      "integrity": "sha512-shrVawQFojnZv6xM40anx4CkoDP+fZsw/ZerEMsW/pyzsRbElpsL/DBVW7q3ExxwusdNXI3lXpuhEZkzs8p5Eg==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "color-name": "^1.0.0",
-        "simple-swizzle": "^0.2.2"
-      }
-    },
     "node_modules/cookie": {
-      "version": "0.7.2",
-      "resolved": "https://registry.npmjs.org/cookie/-/cookie-0.7.2.tgz",
-      "integrity": "sha512-yki5XnKuf750l50uGTllt6kKILY4nQ1eNIQatoXEByZ5dWgnKqbnqmTrBE5B4N7lrMJKQ2ytWMiTO2o0v6Ew/w==",
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/cookie/-/cookie-1.1.1.tgz",
+      "integrity": "sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">= 0.6"
+        "node": ">=18"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/express"
       }
-    },
-    "node_modules/data-uri-to-buffer": {
-      "version": "2.0.2",
-      "resolved": "https://registry.npmjs.org/data-uri-to-buffer/-/data-uri-to-buffer-2.0.2.tgz",
-      "integrity": "sha512-ND9qDTLc6diwj+Xe5cdAgVTbLVdXbtxTJRXRhli8Mowuaan+0EJOtdqJ0QCHNSSPyoXGx9HX2/VMnKeC34AChA==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/defu": {
-      "version": "6.1.6",
-      "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.6.tgz",
-      "integrity": "sha512-f8mefEW4WIVg4LckePx3mALjQSPQgFlg9U8yaPdlsbdYcHQyj9n2zL2LJEA52smeYxOvmd/nB7TpMtHGMTHcug==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/detect-libc": {
       "version": "2.1.2",
@@ -1118,15 +1180,24 @@
       "integrity": "sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==",
       "dev": true,
       "license": "Apache-2.0",
-      "optional": true,
       "engines": {
         "node": ">=8"
       }
     },
+    "node_modules/error-stack-parser-es": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/error-stack-parser-es/-/error-stack-parser-es-1.0.5.tgz",
+      "integrity": "sha512-5qucVt2XcuGMcEGgWI7i+yZpmpByQ8J1lHhcL7PwqCwu9FPP3VUXzT4ltHe5i2z9dePwEHcDVOAfSnHsOlCXRA==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
     "node_modules/esbuild": {
-      "version": "0.17.19",
-      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.17.19.tgz",
-      "integrity": "sha512-XQ0jAPFkK/u3LcVRcvVHQcTIqD6E2H1fvZMA5dQPSOWb3suUbWbfbRf94pjc0bNzRYLfIrDRQXr7X+LHIm5oHw==",
+      "version": "0.27.3",
+      "resolved": "https://registry.npmjs.org/esbuild/-/esbuild-0.27.3.tgz",
+      "integrity": "sha512-8VwMnyGCONIs6cWue2IdpHxHnAjzxnw2Zr7MkVxB2vjmQ2ivqGFb4LEG3SMnv0Gb2F/G/2yA8zUaiL1gywDCCg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "MIT",
@@ -1134,72 +1205,36 @@
         "esbuild": "bin/esbuild"
       },
       "engines": {
-        "node": ">=12"
+        "node": ">=18"
       },
       "optionalDependencies": {
-        "@esbuild/android-arm": "0.17.19",
-        "@esbuild/android-arm64": "0.17.19",
-        "@esbuild/android-x64": "0.17.19",
-        "@esbuild/darwin-arm64": "0.17.19",
-        "@esbuild/darwin-x64": "0.17.19",
-        "@esbuild/freebsd-arm64": "0.17.19",
-        "@esbuild/freebsd-x64": "0.17.19",
-        "@esbuild/linux-arm": "0.17.19",
-        "@esbuild/linux-arm64": "0.17.19",
-        "@esbuild/linux-ia32": "0.17.19",
-        "@esbuild/linux-loong64": "0.17.19",
-        "@esbuild/linux-mips64el": "0.17.19",
-        "@esbuild/linux-ppc64": "0.17.19",
-        "@esbuild/linux-riscv64": "0.17.19",
-        "@esbuild/linux-s390x": "0.17.19",
-        "@esbuild/linux-x64": "0.17.19",
-        "@esbuild/netbsd-x64": "0.17.19",
-        "@esbuild/openbsd-x64": "0.17.19",
-        "@esbuild/sunos-x64": "0.17.19",
-        "@esbuild/win32-arm64": "0.17.19",
-        "@esbuild/win32-ia32": "0.17.19",
-        "@esbuild/win32-x64": "0.17.19"
+        "@esbuild/aix-ppc64": "0.27.3",
+        "@esbuild/android-arm": "0.27.3",
+        "@esbuild/android-arm64": "0.27.3",
+        "@esbuild/android-x64": "0.27.3",
+        "@esbuild/darwin-arm64": "0.27.3",
+        "@esbuild/darwin-x64": "0.27.3",
+        "@esbuild/freebsd-arm64": "0.27.3",
+        "@esbuild/freebsd-x64": "0.27.3",
+        "@esbuild/linux-arm": "0.27.3",
+        "@esbuild/linux-arm64": "0.27.3",
+        "@esbuild/linux-ia32": "0.27.3",
+        "@esbuild/linux-loong64": "0.27.3",
+        "@esbuild/linux-mips64el": "0.27.3",
+        "@esbuild/linux-ppc64": "0.27.3",
+        "@esbuild/linux-riscv64": "0.27.3",
+        "@esbuild/linux-s390x": "0.27.3",
+        "@esbuild/linux-x64": "0.27.3",
+        "@esbuild/netbsd-arm64": "0.27.3",
+        "@esbuild/netbsd-x64": "0.27.3",
+        "@esbuild/openbsd-arm64": "0.27.3",
+        "@esbuild/openbsd-x64": "0.27.3",
+        "@esbuild/openharmony-arm64": "0.27.3",
+        "@esbuild/sunos-x64": "0.27.3",
+        "@esbuild/win32-arm64": "0.27.3",
+        "@esbuild/win32-ia32": "0.27.3",
+        "@esbuild/win32-x64": "0.27.3"
       }
-    },
-    "node_modules/escape-string-regexp": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz",
-      "integrity": "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/estree-walker": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-0.6.1.tgz",
-      "integrity": "sha512-SqmZANLWS0mnatqbSfRP5g8OXZC12Fgg1IwNtLsyHDzJizORW4khDfjPqJZsemPWBB2uqykUah5YpQ6epsqC/w==",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/exit-hook": {
-      "version": "2.2.1",
-      "resolved": "https://registry.npmjs.org/exit-hook/-/exit-hook-2.2.1.tgz",
-      "integrity": "sha512-eNTPlAD67BmP31LDINZ3U7HSF8l57TxOY2PmBJ1shpCvpnxBF93mWCE8YHBnXs8qiUZJc9WDcWIeC3a2HIAMfw==",
-      "dev": true,
-      "license": "MIT",
-      "engines": {
-        "node": ">=6"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/exsolve": {
-      "version": "1.0.8",
-      "resolved": "https://registry.npmjs.org/exsolve/-/exsolve-1.0.8.tgz",
-      "integrity": "sha512-LmDxfWXwcTArk8fUEnOfSZpHOJ6zOMUJKOtFLFqJLoKJetuQG874Uc7/Kki7zFLzYybmZhp1M7+98pfMqeX8yA==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/fsevents": {
       "version": "2.3.3",
@@ -1216,97 +1251,36 @@
         "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
-    "node_modules/get-source": {
-      "version": "2.0.12",
-      "resolved": "https://registry.npmjs.org/get-source/-/get-source-2.0.12.tgz",
-      "integrity": "sha512-X5+4+iD+HoSeEED+uwrQ07BOQr0kEDFMVqqpBuI+RaZBpBpHCuXxo70bjar6f0b0u/DQJsJ7ssurpP0V60Az+w==",
-      "dev": true,
-      "license": "Unlicense",
-      "dependencies": {
-        "data-uri-to-buffer": "^2.0.0",
-        "source-map": "^0.6.1"
-      }
-    },
-    "node_modules/glob-to-regexp": {
-      "version": "0.4.1",
-      "resolved": "https://registry.npmjs.org/glob-to-regexp/-/glob-to-regexp-0.4.1.tgz",
-      "integrity": "sha512-lkX1HJXwyMcprw/5YUZc2s7DrpAiHB21/V+E1rHUrVNokkvB6bqMzT0VfV6/86ZNabt1k14YOIaT7nDvOX3Iiw==",
-      "dev": true,
-      "license": "BSD-2-Clause"
-    },
-    "node_modules/is-arrayish": {
-      "version": "0.3.4",
-      "resolved": "https://registry.npmjs.org/is-arrayish/-/is-arrayish-0.3.4.tgz",
-      "integrity": "sha512-m6UrgzFVUYawGBh1dUsWR5M2Clqic9RVXC/9f8ceNlv2IcO9j9J/z8UoCLPqtsPBFNzEpfR3xftohbfqDx8EQA==",
+    "node_modules/kleur": {
+      "version": "4.1.5",
+      "resolved": "https://registry.npmjs.org/kleur/-/kleur-4.1.5.tgz",
+      "integrity": "sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==",
       "dev": true,
       "license": "MIT",
-      "optional": true
-    },
-    "node_modules/magic-string": {
-      "version": "0.25.9",
-      "resolved": "https://registry.npmjs.org/magic-string/-/magic-string-0.25.9.tgz",
-      "integrity": "sha512-RmF0AsMzgt25qzqqLc1+MbHmhdx0ojF2Fvs4XnOqz2ZOBXzzkEwc/dJQZCYHAn7v1jbVOjAZfK8msRn4BxO4VQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "sourcemap-codec": "^1.4.8"
-      }
-    },
-    "node_modules/mime": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/mime/-/mime-3.0.0.tgz",
-      "integrity": "sha512-jSCU7/VB1loIWBZe14aEYHU/+1UMEHoaO7qxCOVJOw9GgH72VAWppxNcjU+x9a2k3GSIBXNKxXQFqRvvZ7vr3A==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mime": "cli.js"
-      },
       "engines": {
-        "node": ">=10.0.0"
+        "node": ">=6"
       }
     },
     "node_modules/miniflare": {
-      "version": "3.20250718.3",
-      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-3.20250718.3.tgz",
-      "integrity": "sha512-JuPrDJhwLrNLEJiNLWO7ZzJrv/Vv9kZuwMYCfv0LskQDM6Eonw4OvywO3CH/wCGjgHzha/qyjUh8JQ068TjDgQ==",
+      "version": "4.20260424.0",
+      "resolved": "https://registry.npmjs.org/miniflare/-/miniflare-4.20260424.0.tgz",
+      "integrity": "sha512-B6MKBBd5TJ19daUc3Ae9rWctn1nDA/VCXykXfCsp9fTxyfGxnZY27tJs1caxgE9MWEMMKGbGHouqVtgKbKGxmw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
         "@cspotcode/source-map-support": "0.8.1",
-        "acorn": "8.14.0",
-        "acorn-walk": "8.3.2",
-        "exit-hook": "2.2.1",
-        "glob-to-regexp": "0.4.1",
-        "stoppable": "1.1.0",
-        "undici": "^5.28.5",
-        "workerd": "1.20250718.0",
+        "sharp": "^0.34.5",
+        "undici": "7.24.8",
+        "workerd": "1.20260424.1",
         "ws": "8.18.0",
-        "youch": "3.3.4",
-        "zod": "3.22.3"
+        "youch": "4.1.0-beta.10"
       },
       "bin": {
         "miniflare": "bootstrap.js"
       },
       "engines": {
-        "node": ">=16.13"
+        "node": ">=18.0.0"
       }
-    },
-    "node_modules/mustache": {
-      "version": "4.2.0",
-      "resolved": "https://registry.npmjs.org/mustache/-/mustache-4.2.0.tgz",
-      "integrity": "sha512-71ippSywq5Yb7/tVYyGbkBggbU8H3u5Rz56fH60jGFgr8uHwxs+aSKeqmluIVzM0m0kB7xQjKS6qPfd0b2ZoqQ==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "mustache": "bin/mustache"
-      }
-    },
-    "node_modules/ohash": {
-      "version": "2.0.11",
-      "resolved": "https://registry.npmjs.org/ohash/-/ohash-2.0.11.tgz",
-      "integrity": "sha512-RdR9FQrFwNBNXAr4GixM8YaRZRJ5PUWbKYbE5eOsrwAjJW0q2REGcf79oYPsLyskQCZG1PLN+S/K1V00joZAoQ==",
-      "dev": true,
-      "license": "MIT"
     },
     "node_modules/path-to-regexp": {
       "version": "6.3.0",
@@ -1322,53 +1296,12 @@
       "dev": true,
       "license": "MIT"
     },
-    "node_modules/printable-characters": {
-      "version": "1.0.42",
-      "resolved": "https://registry.npmjs.org/printable-characters/-/printable-characters-1.0.42.tgz",
-      "integrity": "sha512-dKp+C4iXWK4vVYZmYSd0KBH5F/h1HoZRsbJ82AVKRO3PEo8L4lBS/vLwhVtpwwuYcoIsVY+1JYKR268yn480uQ==",
-      "dev": true,
-      "license": "Unlicense"
-    },
-    "node_modules/rollup-plugin-inject": {
-      "version": "3.0.2",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-inject/-/rollup-plugin-inject-3.0.2.tgz",
-      "integrity": "sha512-ptg9PQwzs3orn4jkgXJ74bfs5vYz1NCZlSQMBUA0wKcGp5i5pA1AO3fOUEte8enhGUC+iapTCzEWw2jEFFUO/w==",
-      "deprecated": "This package has been deprecated and is no longer maintained. Please use @rollup/plugin-inject.",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "estree-walker": "^0.6.1",
-        "magic-string": "^0.25.3",
-        "rollup-pluginutils": "^2.8.1"
-      }
-    },
-    "node_modules/rollup-plugin-node-polyfills": {
-      "version": "0.2.1",
-      "resolved": "https://registry.npmjs.org/rollup-plugin-node-polyfills/-/rollup-plugin-node-polyfills-0.2.1.tgz",
-      "integrity": "sha512-4kCrKPTJ6sK4/gLL/U5QzVT8cxJcofO0OU74tnB19F40cmuAKSzH5/siithxlofFEjwvw1YAhPmbvGNA6jEroA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "rollup-plugin-inject": "^3.0.0"
-      }
-    },
-    "node_modules/rollup-pluginutils": {
-      "version": "2.8.2",
-      "resolved": "https://registry.npmjs.org/rollup-pluginutils/-/rollup-pluginutils-2.8.2.tgz",
-      "integrity": "sha512-EEp9NhnUkwY8aif6bxgovPHMoMoNr2FulJziTndpt5H9RdwC47GSGuII9XxpSdzVGM0GWrNPHV6ie1LTNJPaLQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "estree-walker": "^0.6.1"
-      }
-    },
     "node_modules/semver": {
       "version": "7.7.4",
       "resolved": "https://registry.npmjs.org/semver/-/semver-7.7.4.tgz",
       "integrity": "sha512-vFKC2IEtQnVhpT78h1Yp8wzwrf8CM+MzKMHGJZfBtzhZNycRFnXsHk6E5TxIkkMsgNS7mdX3AGB7x2QM2di4lA==",
       "dev": true,
       "license": "ISC",
-      "optional": true,
       "bin": {
         "semver": "bin/semver.js"
       },
@@ -1377,17 +1310,16 @@
       }
     },
     "node_modules/sharp": {
-      "version": "0.33.5",
-      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.33.5.tgz",
-      "integrity": "sha512-haPVm1EkS9pgvHrQ/F3Xy+hgcuMV0Wm9vfIBSiwZ05k+xgb0PkBQpGsAA/oWdDobNaZTH5ppvHtzCFbnSEwHVw==",
+      "version": "0.34.5",
+      "resolved": "https://registry.npmjs.org/sharp/-/sharp-0.34.5.tgz",
+      "integrity": "sha512-Ou9I5Ft9WNcCbXrU9cMgPBcCK8LiwLqcbywW3t4oDV37n1pzpuNLsYiAV8eODnjbtQlSDwZ2cUEeQz4E54Hltg==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
-      "optional": true,
       "dependencies": {
-        "color": "^4.2.3",
-        "detect-libc": "^2.0.3",
-        "semver": "^7.6.3"
+        "@img/colour": "^1.0.0",
+        "detect-libc": "^2.1.2",
+        "semver": "^7.7.3"
       },
       "engines": {
         "node": "^18.17.0 || ^20.3.0 || >=21.0.0"
@@ -1396,76 +1328,43 @@
         "url": "https://opencollective.com/libvips"
       },
       "optionalDependencies": {
-        "@img/sharp-darwin-arm64": "0.33.5",
-        "@img/sharp-darwin-x64": "0.33.5",
-        "@img/sharp-libvips-darwin-arm64": "1.0.4",
-        "@img/sharp-libvips-darwin-x64": "1.0.4",
-        "@img/sharp-libvips-linux-arm": "1.0.5",
-        "@img/sharp-libvips-linux-arm64": "1.0.4",
-        "@img/sharp-libvips-linux-s390x": "1.0.4",
-        "@img/sharp-libvips-linux-x64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-arm64": "1.0.4",
-        "@img/sharp-libvips-linuxmusl-x64": "1.0.4",
-        "@img/sharp-linux-arm": "0.33.5",
-        "@img/sharp-linux-arm64": "0.33.5",
-        "@img/sharp-linux-s390x": "0.33.5",
-        "@img/sharp-linux-x64": "0.33.5",
-        "@img/sharp-linuxmusl-arm64": "0.33.5",
-        "@img/sharp-linuxmusl-x64": "0.33.5",
-        "@img/sharp-wasm32": "0.33.5",
-        "@img/sharp-win32-ia32": "0.33.5",
-        "@img/sharp-win32-x64": "0.33.5"
+        "@img/sharp-darwin-arm64": "0.34.5",
+        "@img/sharp-darwin-x64": "0.34.5",
+        "@img/sharp-libvips-darwin-arm64": "1.2.4",
+        "@img/sharp-libvips-darwin-x64": "1.2.4",
+        "@img/sharp-libvips-linux-arm": "1.2.4",
+        "@img/sharp-libvips-linux-arm64": "1.2.4",
+        "@img/sharp-libvips-linux-ppc64": "1.2.4",
+        "@img/sharp-libvips-linux-riscv64": "1.2.4",
+        "@img/sharp-libvips-linux-s390x": "1.2.4",
+        "@img/sharp-libvips-linux-x64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-arm64": "1.2.4",
+        "@img/sharp-libvips-linuxmusl-x64": "1.2.4",
+        "@img/sharp-linux-arm": "0.34.5",
+        "@img/sharp-linux-arm64": "0.34.5",
+        "@img/sharp-linux-ppc64": "0.34.5",
+        "@img/sharp-linux-riscv64": "0.34.5",
+        "@img/sharp-linux-s390x": "0.34.5",
+        "@img/sharp-linux-x64": "0.34.5",
+        "@img/sharp-linuxmusl-arm64": "0.34.5",
+        "@img/sharp-linuxmusl-x64": "0.34.5",
+        "@img/sharp-wasm32": "0.34.5",
+        "@img/sharp-win32-arm64": "0.34.5",
+        "@img/sharp-win32-ia32": "0.34.5",
+        "@img/sharp-win32-x64": "0.34.5"
       }
     },
-    "node_modules/simple-swizzle": {
-      "version": "0.2.4",
-      "resolved": "https://registry.npmjs.org/simple-swizzle/-/simple-swizzle-0.2.4.tgz",
-      "integrity": "sha512-nAu1WFPQSMNr2Zn9PGSZK9AGn4t/y97lEm+MXTtUDwfP0ksAIX4nO+6ruD9Jwut4C49SB1Ws+fbXsm/yScWOHw==",
-      "dev": true,
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-arrayish": "^0.3.1"
-      }
-    },
-    "node_modules/source-map": {
-      "version": "0.6.1",
-      "resolved": "https://registry.npmjs.org/source-map/-/source-map-0.6.1.tgz",
-      "integrity": "sha512-UjgapumWlbMhkBgzT7Ykc5YXUT46F0iKu8SGXq0bcwP5dz/h0Plj6enJqjz1Zbq2l5WaqYnrVbwWOWMyF3F47g==",
-      "dev": true,
-      "license": "BSD-3-Clause",
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/sourcemap-codec": {
-      "version": "1.4.8",
-      "resolved": "https://registry.npmjs.org/sourcemap-codec/-/sourcemap-codec-1.4.8.tgz",
-      "integrity": "sha512-9NykojV5Uih4lgo5So5dtw+f0JgJX30KCNI8gwhz2J9A15wD0Ml6tjHKwf6fTSa6fAdVBdZeNOs9eJ71qCk8vA==",
-      "deprecated": "Please use @jridgewell/sourcemap-codec instead",
-      "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/stacktracey": {
-      "version": "2.2.0",
-      "resolved": "https://registry.npmjs.org/stacktracey/-/stacktracey-2.2.0.tgz",
-      "integrity": "sha512-ETyQEz+CzXiLjEbyJqpbp+/T79RQD/6wqFucRBIlVNZfYq2Ay7wbretD4cxpbymZlaPWx58aIhPEY1Cr8DlVvg==",
-      "dev": true,
-      "license": "Unlicense",
-      "dependencies": {
-        "as-table": "^1.0.36",
-        "get-source": "^2.0.12"
-      }
-    },
-    "node_modules/stoppable": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/stoppable/-/stoppable-1.1.0.tgz",
-      "integrity": "sha512-KXDYZ9dszj6bzvnEMRYvxgeTHU74QBFL54XKtP3nyMuJ81CFYtABZ3bAzL2EdFUaEwJOBOgENyFj3R7oTzDyyw==",
+    "node_modules/supports-color": {
+      "version": "10.2.2",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-10.2.2.tgz",
+      "integrity": "sha512-SS+jx45GF1QjgEXQx4NJZV9ImqmO2NPz5FNsIHrsDjh2YsHnawpan7SNQ1o8NuhrbHZy9AZhIoCUiCeaW/C80g==",
       "dev": true,
       "license": "MIT",
       "engines": {
-        "node": ">=4",
-        "npm": ">=6"
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/supports-color?sponsor=1"
       }
     },
     "node_modules/tslib": {
@@ -1476,44 +1375,30 @@
       "license": "0BSD",
       "optional": true
     },
-    "node_modules/ufo": {
-      "version": "1.6.3",
-      "resolved": "https://registry.npmjs.org/ufo/-/ufo-1.6.3.tgz",
-      "integrity": "sha512-yDJTmhydvl5lJzBmy/hyOAA0d+aqCBuwl818haVdYCRrWV84o7YyeVm4QlVHStqNrrJSTb6jKuFAVqAFsr+K3Q==",
-      "dev": true,
-      "license": "MIT"
-    },
     "node_modules/undici": {
-      "version": "5.29.0",
-      "resolved": "https://registry.npmjs.org/undici/-/undici-5.29.0.tgz",
-      "integrity": "sha512-raqeBD6NQK4SkWhQzeYKd1KmIG6dllBOTt55Rmkt4HtI9mwdWtJljnrXjAFUBLTSN67HWrOIZ3EPF4kjUw80Bg==",
+      "version": "7.24.8",
+      "resolved": "https://registry.npmjs.org/undici/-/undici-7.24.8.tgz",
+      "integrity": "sha512-6KQ/+QxK49Z/p3HO6E5ZCZWNnCasyZLa5ExaVYyvPxUwKtbCPMKELJOqh7EqOle0t9cH/7d2TaaTRRa6Nhs4YQ==",
       "dev": true,
       "license": "MIT",
-      "dependencies": {
-        "@fastify/busboy": "^2.0.0"
-      },
       "engines": {
-        "node": ">=14.0"
+        "node": ">=20.18.1"
       }
     },
     "node_modules/unenv": {
-      "version": "2.0.0-rc.14",
-      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.14.tgz",
-      "integrity": "sha512-od496pShMen7nOy5VmVJCnq8rptd45vh6Nx/r2iPbrba6pa6p+tS2ywuIHRZ/OBvSbQZB0kWvpO9XBNVFXHD3Q==",
+      "version": "2.0.0-rc.24",
+      "resolved": "https://registry.npmjs.org/unenv/-/unenv-2.0.0-rc.24.tgz",
+      "integrity": "sha512-i7qRCmY42zmCwnYlh9H2SvLEypEFGye5iRmEMKjcGi7zk9UquigRjFtTLz0TYqr0ZGLZhaMHl/foy1bZR+Cwlw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "defu": "^6.1.4",
-        "exsolve": "^1.0.1",
-        "ohash": "^2.0.10",
-        "pathe": "^2.0.3",
-        "ufo": "^1.5.4"
+        "pathe": "^2.0.3"
       }
     },
     "node_modules/workerd": {
-      "version": "1.20250718.0",
-      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20250718.0.tgz",
-      "integrity": "sha512-kqkIJP/eOfDlUyBzU7joBg+tl8aB25gEAGqDap+nFWb+WHhnooxjGHgxPBy3ipw2hnShPFNOQt5lFRxbwALirg==",
+      "version": "1.20260424.1",
+      "resolved": "https://registry.npmjs.org/workerd/-/workerd-1.20260424.1.tgz",
+      "integrity": "sha512-oKsB0Xo/mfkYMdSACoS06XZg09VUK4rXwHfF/1t3P++sMbwzf4UHQvMO57+zxpEB2nVrY/ZkW0bYFGq4GdAFSQ==",
       "dev": true,
       "hasInstallScript": true,
       "license": "Apache-2.0",
@@ -1524,44 +1409,41 @@
         "node": ">=16"
       },
       "optionalDependencies": {
-        "@cloudflare/workerd-darwin-64": "1.20250718.0",
-        "@cloudflare/workerd-darwin-arm64": "1.20250718.0",
-        "@cloudflare/workerd-linux-64": "1.20250718.0",
-        "@cloudflare/workerd-linux-arm64": "1.20250718.0",
-        "@cloudflare/workerd-windows-64": "1.20250718.0"
+        "@cloudflare/workerd-darwin-64": "1.20260424.1",
+        "@cloudflare/workerd-darwin-arm64": "1.20260424.1",
+        "@cloudflare/workerd-linux-64": "1.20260424.1",
+        "@cloudflare/workerd-linux-arm64": "1.20260424.1",
+        "@cloudflare/workerd-windows-64": "1.20260424.1"
       }
     },
     "node_modules/wrangler": {
-      "version": "3.114.17",
-      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-3.114.17.tgz",
-      "integrity": "sha512-tAvf7ly+tB+zwwrmjsCyJ2pJnnc7SZhbnNwXbH+OIdVas3zTSmjcZOjmLKcGGptssAA3RyTKhcF9BvKZzMUycA==",
+      "version": "4.85.0",
+      "resolved": "https://registry.npmjs.org/wrangler/-/wrangler-4.85.0.tgz",
+      "integrity": "sha512-93cwt2RPb1qdcmEgPzH7ybiLN4BIKoWpscIX6SywjHrQOeIZrQk2haoc3XMLKtQTmzapxza9OuDD+kMHpsuuhg==",
       "dev": true,
       "license": "MIT OR Apache-2.0",
       "dependencies": {
-        "@cloudflare/kv-asset-handler": "0.3.4",
-        "@cloudflare/unenv-preset": "2.0.2",
-        "@esbuild-plugins/node-globals-polyfill": "0.2.3",
-        "@esbuild-plugins/node-modules-polyfill": "0.2.2",
+        "@cloudflare/kv-asset-handler": "0.4.2",
+        "@cloudflare/unenv-preset": "2.16.1",
         "blake3-wasm": "2.1.5",
-        "esbuild": "0.17.19",
-        "miniflare": "3.20250718.3",
+        "esbuild": "0.27.3",
+        "miniflare": "4.20260424.0",
         "path-to-regexp": "6.3.0",
-        "unenv": "2.0.0-rc.14",
-        "workerd": "1.20250718.0"
+        "unenv": "2.0.0-rc.24",
+        "workerd": "1.20260424.1"
       },
       "bin": {
         "wrangler": "bin/wrangler.js",
         "wrangler2": "bin/wrangler.js"
       },
       "engines": {
-        "node": ">=16.17.0"
+        "node": ">=20.3.0"
       },
       "optionalDependencies": {
-        "fsevents": "~2.3.2",
-        "sharp": "^0.33.5"
+        "fsevents": "~2.3.2"
       },
       "peerDependencies": {
-        "@cloudflare/workers-types": "^4.20250408.0"
+        "@cloudflare/workers-types": "^4.20260424.1"
       },
       "peerDependenciesMeta": {
         "@cloudflare/workers-types": {
@@ -1592,25 +1474,28 @@
       }
     },
     "node_modules/youch": {
-      "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/youch/-/youch-3.3.4.tgz",
-      "integrity": "sha512-UeVBXie8cA35DS6+nBkls68xaBBXCye0CNznrhszZjTbRVnJKQuNsyLKBTTL4ln1o1rh2PKtv35twV7irj5SEg==",
+      "version": "4.1.0-beta.10",
+      "resolved": "https://registry.npmjs.org/youch/-/youch-4.1.0-beta.10.tgz",
+      "integrity": "sha512-rLfVLB4FgQneDr0dv1oddCVZmKjcJ6yX6mS4pU82Mq/Dt9a3cLZQ62pDBL4AUO+uVrCvtWz3ZFUL2HFAFJ/BXQ==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
-        "cookie": "^0.7.1",
-        "mustache": "^4.2.0",
-        "stacktracey": "^2.1.8"
+        "@poppinss/colors": "^4.1.5",
+        "@poppinss/dumper": "^0.6.4",
+        "@speed-highlight/core": "^1.2.7",
+        "cookie": "^1.0.2",
+        "youch-core": "^0.3.3"
       }
     },
-    "node_modules/zod": {
-      "version": "3.22.3",
-      "resolved": "https://registry.npmjs.org/zod/-/zod-3.22.3.tgz",
-      "integrity": "sha512-EjIevzuJRiRPbVH4mGc8nApb/lVLKVpmUhAaR5R5doKGfAnGJ6Gr3CViAVjP+4FWSxCsybeWQdcgCtbX+7oZug==",
+    "node_modules/youch-core": {
+      "version": "0.3.3",
+      "resolved": "https://registry.npmjs.org/youch-core/-/youch-core-0.3.3.tgz",
+      "integrity": "sha512-ho7XuGjLaJ2hWHoK8yFnsUGy2Y5uDpqSTq1FkHLK4/oqKtyUU1AFbOOxY4IpC9f0fTLjwYbslUz0Po5BpD1wrA==",
       "dev": true,
       "license": "MIT",
-      "funding": {
-        "url": "https://github.com/sponsors/colinhacks"
+      "dependencies": {
+        "@poppinss/exception": "^1.2.2",
+        "error-stack-parser-es": "^1.0.5"
       }
     }
   }

--- a/worker/package.json
+++ b/worker/package.json
@@ -6,6 +6,6 @@
     "deploy": "wrangler deploy"
   },
   "devDependencies": {
-    "wrangler": "^3.0.0"
+    "wrangler": "^4.85.0"
   }
 }

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -1,16 +1,18 @@
 /**
  * Clicky Proxy Worker
  *
- * Proxies requests to Claude and ElevenLabs APIs so the app never
+ * Proxies requests to Claude, Gemini, and ElevenLabs APIs so the app never
  * ships with raw API keys. Keys are stored as Cloudflare secrets.
  *
  * Routes:
- *   POST /chat  → Anthropic Messages API (streaming)
- *   POST /tts   → ElevenLabs TTS API
+ *   POST /chat         → Anthropic Messages API (streaming)
+ *   POST /chat-gemini  → Google Gemini streamGenerateContent API (streaming SSE)
+ *   POST /tts          → ElevenLabs TTS API
  */
 
 interface Env {
   ANTHROPIC_API_KEY: string;
+  GEMINI_API_KEY: string;
   ELEVENLABS_API_KEY: string;
   ELEVENLABS_VOICE_ID: string;
   ASSEMBLYAI_API_KEY: string;
@@ -27,6 +29,10 @@ export default {
     try {
       if (url.pathname === "/chat") {
         return await handleChat(request, env);
+      }
+
+      if (url.pathname === "/chat-gemini") {
+        return await handleGeminiChat(request, env);
       }
 
       if (url.pathname === "/tts") {
@@ -64,6 +70,64 @@ async function handleChat(request: Request, env: Env): Promise<Response> {
   if (!response.ok) {
     const errorBody = await response.text();
     console.error(`[/chat] Anthropic API error ${response.status}: ${errorBody}`);
+    return new Response(errorBody, {
+      status: response.status,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    headers: {
+      "content-type": response.headers.get("content-type") || "text/event-stream",
+      "cache-control": "no-cache",
+    },
+  });
+}
+
+async function handleGeminiChat(request: Request, env: Env): Promise<Response> {
+  // Gemini's API puts the model in the URL path (not the body like Anthropic).
+  // The app sends the model in a top-level `model` field in the JSON body;
+  // we extract it here, construct the upstream URL, and forward the rest.
+  const bodyText = await request.text();
+
+  let parsedBody: { model?: string; [key: string]: unknown };
+  try {
+    parsedBody = JSON.parse(bodyText);
+  } catch (parseError) {
+    return new Response(
+      JSON.stringify({ error: `Invalid JSON body: ${String(parseError)}` }),
+      { status: 400, headers: { "content-type": "application/json" } }
+    );
+  }
+
+  const requestedGeminiModel = parsedBody.model;
+  if (typeof requestedGeminiModel !== "string" || requestedGeminiModel.length === 0) {
+    return new Response(
+      JSON.stringify({ error: "Missing or invalid 'model' field in request body" }),
+      { status: 400, headers: { "content-type": "application/json" } }
+    );
+  }
+
+  // Strip the model field from the body before forwarding — Gemini doesn't
+  // expect it in the body and it's only used for URL construction.
+  const { model: _omittedModel, ...geminiRequestBody } = parsedBody;
+
+  const upstreamURL = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(
+    requestedGeminiModel
+  )}:streamGenerateContent?alt=sse&key=${env.GEMINI_API_KEY}`;
+
+  const response = await fetch(upstreamURL, {
+    method: "POST",
+    headers: {
+      "content-type": "application/json",
+    },
+    body: JSON.stringify(geminiRequestBody),
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    console.error(`[/chat-gemini] Gemini API error ${response.status}: ${errorBody}`);
     return new Response(errorBody, {
       status: response.status,
       headers: { "content-type": "application/json" },


### PR DESCRIPTION
## Summary
- **Gemini provider**: new `/chat-gemini` route on the Cloudflare Worker, `GeminiAPI.swift` mirroring `ClaudeAPI`'s streaming interface, and provider dispatch in `CompanionManager`. Model picker now shows Claude (Sonnet/Opus) and Gemini (Flash/Pro).
- **Windows port — M1**: C# + WPF on .NET 8 (`windows/`). Tray icon, borderless non-activating popover, global Ctrl+Alt push-to-talk via low-level keyboard hook, settings persistence, design-system parity (`DesignSystem.xaml`). Zero embedded secrets — shares the same Worker proxy.
- **Docs**: `AGENTS.md` updated to cross-platform framing; `windows/README.md` covers build steps and milestone roadmap (M2 voice → M3 capture → M4 overlay → M5 pointing → M6 polish).

## Test plan
- [ ] macOS: build in Xcode 16, switch between Claude/Gemini models, confirm streaming + vision both work against the Worker.
- [ ] Windows: `dotnet run --project windows/Clicky`, confirm tray icon, click opens popover near tray, Ctrl+Alt fires press/release events, settings persist to `%APPDATA%\Clicky\settings.json`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)