### PR TITLE
Fix overlay positioning on secondary monitors

### DIFF
--- a/leanring-buddy/OverlayWindow.swift
+++ b/leanring-buddy/OverlayWindow.swift
@@ -799,10 +799,6 @@ class OverlayWindowManager {
             )
 
             let hostingView = NSHostingView(rootView: contentView)
-            // NSHostingView lives inside the overlay window's local coordinate
-            // system, so its origin must start at (0, 0). Using the global
-            // screen frame here pushes secondary-display content outside the
-            // window bounds, which makes the buddy disappear off the primary screen.
             hostingView.frame = NSRect(origin: .zero, size: screen.frame.size)
             hostingView.autoresizingMask = [.width, .height]
             window.contentView = hostingView

--- a/leanring-buddy/OverlayWindow.swift
+++ b/leanring-buddy/OverlayWindow.swift
@@ -799,7 +799,12 @@ class OverlayWindowManager {
             )
 
             let hostingView = NSHostingView(rootView: contentView)
-            hostingView.frame = screen.frame
+            // NSHostingView lives inside the overlay window's local coordinate
+            // system, so its origin must start at (0, 0). Using the global
+            // screen frame here pushes secondary-display content outside the
+            // window bounds, which makes the buddy disappear off the primary screen.
+            hostingView.frame = NSRect(origin: .zero, size: screen.frame.size)
+            hostingView.autoresizingMask = [.width, .height]
             window.contentView = hostingView
 
             overlayWindows.append(window)


### PR DESCRIPTION
**Summary:**

This PR fixes a multi-monitor positioning issue where the buddy overlay could render outside the visible bounds on non-primary displays.


**What was happening**

The hosting view inside each overlay window was being positioned using global screen coordinates. On secondary monitors, that could place content outside the window’s local coordinate space, making the buddy appear only on the first screen.

**What changed**

Updated the overlay hosting view to:
use a local origin of (0, 0)
size to the current screen’s dimensions
resize with the window via autoresizing mask

It's just one file with changes so should be super easy!