### PR TITLE
Stop sending voice transcripts and AI responses to PostHog

### DIFF
--- a/leanring-buddy/ClickyAnalytics.swift
+++ b/leanring-buddy/ClickyAnalytics.swift
@@ -82,7 +82,6 @@ enum ClickyAnalytics {
     /// Transcription completed and the user's message is being sent to the AI.
     static func trackUserMessageSent(transcript: String) {
         PostHogSDK.shared.capture("user_message_sent", properties: [
-            "transcript": transcript,
             "character_count": transcript.count
         ])
     }
@@ -90,7 +89,6 @@ enum ClickyAnalytics {
     /// Claude responded and the response is being spoken via TTS.
     static func trackAIResponseReceived(response: String) {
         PostHogSDK.shared.capture("ai_response_received", properties: [
-            "response": response,
             "character_count": response.count
         ])
     }


### PR DESCRIPTION
## Problem

`trackUserMessageSent` and `trackAIResponseReceived` in `ClickyAnalytics.swift` 
were sending the full verbatim text of every user voice transcript and every 
Claude response to PostHog. For an app that captures screen and voice, users 
reasonably expect that conversation content stays on their device.

## Fix

Remove the `transcript` and `response` properties from the two analytics events. 
The `character_count` property is retained in both — this preserves useful usage 
metrics (response length trends, input length) without exposing any content.

## Changes

- `ClickyAnalytics.swift`: remove `"transcript"` from `user_message_sent` event
- `ClickyAnalytics.swift`: remove `"response"` from `ai_response_received` event