### PR TITLE
Remove third-party data collection and disable auto-update

### DIFF
--- a/leanring-buddy.xcodeproj/project.pbxproj
+++ b/leanring-buddy.xcodeproj/project.pbxproj
@@ -8,7 +8,6 @@
 
 /* Begin PBXBuildFile section */
 		AA00BB032F6500030039DA55 /* Sparkle in Frameworks */ = {isa = PBXBuildFile; productRef = AA00BB022F6500020039DA55 /* Sparkle */; };
-		AA00BB062F6500060039DA55 /* PostHog in Frameworks */ = {isa = PBXBuildFile; productRef = AA00BB052F6500050039DA55 /* PostHog */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXContainerItemProxy section */
@@ -58,7 +57,6 @@
 			buildActionMask = 2147483647;
 			files = (
 				AA00BB032F6500030039DA55 /* Sparkle in Frameworks */,
-				AA00BB062F6500060039DA55 /* PostHog in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -120,7 +118,6 @@
 			name = "leanring-buddy";
 			packageProductDependencies = (
 				AA00BB022F6500020039DA55 /* Sparkle */,
-				AA00BB052F6500050039DA55 /* PostHog */,
 			);
 			productName = "leanring-buddy";
 			productReference = 28F22CBF2F56440300A0FC59 /* Clicky.app */;
@@ -206,7 +203,6 @@
 			minimizedProjectReferenceProxies = 1;
 			packageReferences = (
 				AA00BB012F6500010039DA55 /* XCRemoteSwiftPackageReference "Sparkle" */,
-				AA00BB042F6500040039DA55 /* XCRemoteSwiftPackageReference "posthog-ios" */,
 			);
 			preferredProjectObjectVersion = 77;
 			productRefGroup = 28F22CC02F56440300A0FC59 /* Products */;
@@ -608,14 +604,6 @@
 				minimumVersion = 2.9.0;
 			};
 		};
-		AA00BB042F6500040039DA55 /* XCRemoteSwiftPackageReference "posthog-ios" */ = {
-			isa = XCRemoteSwiftPackageReference;
-			repositoryURL = "https://github.com/PostHog/posthog-ios.git";
-			requirement = {
-				kind = upToNextMajorVersion;
-				minimumVersion = 3.0.0;
-			};
-		};
 /* End XCRemoteSwiftPackageReference section */
 
 /* Begin XCSwiftPackageProductDependency section */
@@ -623,11 +611,6 @@
 			isa = XCSwiftPackageProductDependency;
 			package = AA00BB012F6500010039DA55 /* XCRemoteSwiftPackageReference "Sparkle" */;
 			productName = Sparkle;
-		};
-		AA00BB052F6500050039DA55 /* PostHog */ = {
-			isa = XCSwiftPackageProductDependency;
-			package = AA00BB042F6500040039DA55 /* XCRemoteSwiftPackageReference "posthog-ios" */;
-			productName = PostHog;
 		};
 /* End XCSwiftPackageProductDependency section */
 	};

--- a/leanring-buddy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
+++ b/leanring-buddy.xcodeproj/project.xcworkspace/xcshareddata/swiftpm/Package.resolved
@@ -2,24 +2,6 @@
   "originHash" : "3c6fb67fefedcfcd00708e24ca8088151f21dccfc0ade32ea80c406646277e89",
   "pins" : [
     {
-      "identity" : "plcrashreporter",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/microsoft/plcrashreporter.git",
-      "state" : {
-        "revision" : "0254f941c646b1ed17b243654723d0f071e990d0",
-        "version" : "1.12.2"
-      }
-    },
-    {
-      "identity" : "posthog-ios",
-      "kind" : "remoteSourceControl",
-      "location" : "https://github.com/PostHog/posthog-ios.git",
-      "state" : {
-        "revision" : "09da1be6a614325a6a464c6d2017a9ac858d1b5a",
-        "version" : "3.47.0"
-      }
-    },
-    {
       "identity" : "sparkle",
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/sparkle-project/Sparkle",

--- a/leanring-buddy/ClickyAnalytics.swift
+++ b/leanring-buddy/ClickyAnalytics.swift
@@ -2,120 +2,54 @@
 //  ClickyAnalytics.swift
 //  leanring-buddy
 //
-//  Centralized PostHog analytics wrapper. All event names and properties
-//  are defined here so instrumentation is consistent and easy to audit.
+//  Analytics were intentionally disabled in this fork — no usage data,
+//  transcripts, or AI responses are sent anywhere. All functions remain
+//  as no-ops so existing call sites compile unchanged.
 //
 
 import Foundation
-import PostHog
 
 enum ClickyAnalytics {
 
     // MARK: - Setup
 
-    static func configure() {
-        let config = PostHogConfig(
-            apiKey: "phc_xcQPygmhTMzzYh8wNW92CCwoXmnzqyChAixh8zgpqC3C",
-            host: "https://us.i.posthog.com"
-        )
-        PostHogSDK.shared.setup(config)
-    }
+    static func configure() {}
 
     // MARK: - App Lifecycle
 
-    /// Fired once on every app launch in applicationDidFinishLaunching.
-    static func trackAppOpened() {
-        let version = Bundle.main.infoDictionary?["CFBundleShortVersionString"] as? String ?? "unknown"
-        PostHogSDK.shared.capture("app_opened", properties: [
-            "app_version": version
-        ])
-    }
+    static func trackAppOpened() {}
 
     // MARK: - Onboarding
 
-    /// User clicked the Start button to begin onboarding for the first time.
-    static func trackOnboardingStarted() {
-        PostHogSDK.shared.capture("onboarding_started")
-    }
+    static func trackOnboardingStarted() {}
 
-    /// User clicked "Watch Onboarding Again" from the panel footer.
-    static func trackOnboardingReplayed() {
-        PostHogSDK.shared.capture("onboarding_replayed")
-    }
+    static func trackOnboardingReplayed() {}
 
-    /// The onboarding video finished playing to the end.
-    static func trackOnboardingVideoCompleted() {
-        PostHogSDK.shared.capture("onboarding_video_completed")
-    }
+    static func trackOnboardingVideoCompleted() {}
 
-    /// The 40s onboarding demo interaction where Clicky points at something.
-    static func trackOnboardingDemoTriggered() {
-        PostHogSDK.shared.capture("onboarding_demo_triggered")
-    }
+    static func trackOnboardingDemoTriggered() {}
 
     // MARK: - Permissions
 
-    /// All three permissions (accessibility, screen recording, mic) are granted.
-    static func trackAllPermissionsGranted() {
-        PostHogSDK.shared.capture("all_permissions_granted")
-    }
+    static func trackAllPermissionsGranted() {}
 
-    /// A single permission was granted. Called when polling detects a change.
-    static func trackPermissionGranted(permission: String) {
-        PostHogSDK.shared.capture("permission_granted", properties: [
-            "permission": permission
-        ])
-    }
+    static func trackPermissionGranted(permission: String) {}
 
     // MARK: - Voice Interaction
 
-    /// User pressed the push-to-talk shortcut (control+option) to start talking.
-    static func trackPushToTalkStarted() {
-        PostHogSDK.shared.capture("push_to_talk_started")
-    }
+    static func trackPushToTalkStarted() {}
 
-    /// User released the shortcut — transcript is being finalized.
-    static func trackPushToTalkReleased() {
-        PostHogSDK.shared.capture("push_to_talk_released")
-    }
+    static func trackPushToTalkReleased() {}
 
-    /// Transcription completed and the user's message is being sent to the AI.
-    static func trackUserMessageSent(transcript: String) {
-        PostHogSDK.shared.capture("user_message_sent", properties: [
-            "transcript": transcript,
-            "character_count": transcript.count
-        ])
-    }
+    static func trackUserMessageSent(transcript: String) {}
 
-    /// Claude responded and the response is being spoken via TTS.
-    static func trackAIResponseReceived(response: String) {
-        PostHogSDK.shared.capture("ai_response_received", properties: [
-            "response": response,
-            "character_count": response.count
-        ])
-    }
+    static func trackAIResponseReceived(response: String) {}
 
-    /// Claude's response included a [POINT:x,y:label] coordinate tag,
-    /// so the buddy is flying to point at a UI element.
-    static func trackElementPointed(elementLabel: String?) {
-        PostHogSDK.shared.capture("element_pointed", properties: [
-            "element_label": elementLabel ?? "unknown"
-        ])
-    }
+    static func trackElementPointed(elementLabel: String?) {}
 
     // MARK: - Errors
 
-    /// An error occurred during the AI response pipeline.
-    static func trackResponseError(error: String) {
-        PostHogSDK.shared.capture("response_error", properties: [
-            "error": error
-        ])
-    }
+    static func trackResponseError(error: String) {}
 
-    /// An error occurred during TTS playback.
-    static func trackTTSError(error: String) {
-        PostHogSDK.shared.capture("tts_error", properties: [
-            "error": error
-        ])
-    }
+    static func trackTTSError(error: String) {}
 }

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -10,7 +10,6 @@
 import AVFoundation
 import Combine
 import Foundation
-import PostHog
 import ScreenCaptureKit
 import SwiftUI
 
@@ -149,27 +148,15 @@ final class CompanionManager: ObservableObject {
     /// Whether the user has submitted their email during onboarding.
     @Published var hasSubmittedEmail: Bool = UserDefaults.standard.bool(forKey: "hasSubmittedEmail")
 
-    /// Submits the user's email to FormSpark and identifies them in PostHog.
+    /// Records that the user has dismissed the email prompt. The email itself
+    /// is never sent anywhere — analytics and the FormSpark submission were
+    /// removed in this fork.
     func submitEmail(_ email: String) {
         let trimmedEmail = email.trimmingCharacters(in: .whitespacesAndNewlines)
         guard !trimmedEmail.isEmpty else { return }
 
         hasSubmittedEmail = true
         UserDefaults.standard.set(true, forKey: "hasSubmittedEmail")
-
-        // Identify user in PostHog
-        PostHogSDK.shared.identify(trimmedEmail, userProperties: [
-            "email": trimmedEmail
-        ])
-
-        // Submit to FormSpark
-        Task {
-            var request = URLRequest(url: URL(string: "https://submit-form.com/RWbGJxmIs")!)
-            request.httpMethod = "POST"
-            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
-            request.httpBody = try? JSONSerialization.data(withJSONObject: ["email": trimmedEmail])
-            _ = try? await URLSession.shared.data(for: request)
-        }
     }
 
     func start() {

--- a/leanring-buddy/Info.plist
+++ b/leanring-buddy/Info.plist
@@ -4,10 +4,6 @@
 <dict>
 	<key>LSUIElement</key>
 	<true/>
-	<key>SUFeedURL</key>
-	<string>https://raw.githubusercontent.com/julianjear/makesomething-mac-app/main/appcast.xml</string>
-	<key>SUPublicEDKey</key>
-	<string>/l3d2rw5ZZFRU3AadP/w2Zf8FHfhA6bKv16BQOV5OSk=</string>
 	<key>VoiceTranscriptionProvider</key>
 	<string>assemblyai</string>
 	<key>NSMicrophoneUsageDescription</key>


### PR DESCRIPTION
Three changes to make this fork safe to run on a personal machine without leaking conversation contents or accepting remote code updates:

- Strip PostHog analytics entirely. The SDK was capturing full push-to-talk transcripts and full Claude responses as event properties, plus identifying the user by email. ClickyAnalytics functions are now no-ops, the PostHog import and Swift Package dependency are removed.
- Remove SUFeedURL and SUPublicEDKey from Info.plist. The feed pointed at an unrelated GitHub account that could have pushed arbitrary updates if Sparkle were enabled.
- Remove the FormSpark POST in submitEmail. The email entered during onboarding is no longer sent to any third party.