### PR TITLE
Guard auto-copy clipboard writes

### DIFF
--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -139,6 +139,15 @@ final class CompanionManager: ObservableObject {
         }
     }
 
+    /// Whether Clicky's responses are automatically copied to the clipboard.
+    /// Defaults to OFF. Persisted to UserDefaults.
+    @Published var isAutoCopyResponseEnabled: Bool = UserDefaults.standard.bool(forKey: "isAutoCopyResponseEnabled")
+
+    func setAutoCopyResponseEnabled(_ enabled: Bool) {
+        isAutoCopyResponseEnabled = enabled
+        UserDefaults.standard.set(enabled, forKey: "isAutoCopyResponseEnabled")
+    }
+
     /// Whether the user has completed onboarding at least once. Persisted
     /// to UserDefaults so the Start button only appears on first launch.
     var hasCompletedOnboarding: Bool {
@@ -679,6 +688,12 @@ final class CompanionManager: ObservableObject {
                     print("🎯 Element pointing: (\(Int(pointCoordinate.x)), \(Int(pointCoordinate.y))) → \"\(parseResult.elementLabel ?? "element")\"")
                 } else {
                     print("🎯 Element pointing: \(parseResult.elementLabel ?? "no element")")
+                }
+
+                // Copy the clean response to the clipboard if the user has enabled auto-copy
+                if isAutoCopyResponseEnabled {
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(spokenText, forType: .string)
                 }
 
                 // Save this exchange to conversation history (with the point tag

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -690,10 +690,13 @@ final class CompanionManager: ObservableObject {
                     print("🎯 Element pointing: \(parseResult.elementLabel ?? "no element")")
                 }
 
-                // Copy the clean response to the clipboard if the user has enabled auto-copy
-                if isAutoCopyResponseEnabled {
+                let trimmedSpokenText = spokenText.trimmingCharacters(in: .whitespacesAndNewlines)
+
+                // Copy only when there is meaningful text to write, so auto-copy
+                // never clears the user's clipboard for point-only responses.
+                if isAutoCopyResponseEnabled && !trimmedSpokenText.isEmpty {
                     NSPasteboard.general.clearContents()
-                    NSPasteboard.general.setString(spokenText, forType: .string)
+                    NSPasteboard.general.setString(trimmedSpokenText, forType: .string)
                 }
 
                 // Save this exchange to conversation history (with the point tag
@@ -714,7 +717,7 @@ final class CompanionManager: ObservableObject {
 
                 // Play the response via TTS. Keep the spinner (processing state)
                 // until the audio actually starts playing, then switch to responding.
-                if !spokenText.trimmingCharacters(in: .whitespacesAndNewlines).isEmpty {
+                if !trimmedSpokenText.isEmpty {
                     do {
                         try await elevenLabsTTSClient.speakText(spokenText)
                         // speakText returns after player.play() — audio is now playing

--- a/leanring-buddy/CompanionPanelView.swift
+++ b/leanring-buddy/CompanionPanelView.swift
@@ -62,6 +62,9 @@ struct CompanionPanelView: View {
                 Spacer()
                     .frame(height: 16)
 
+                autoCopyResponseToggleRow
+                    .padding(.horizontal, 16)
+
                 dmFarzaButton
                     .padding(.horizontal, 16)
             }
@@ -544,6 +547,35 @@ struct CompanionPanelView: View {
     }
 
 
+
+    // MARK: - Auto-Copy Response Toggle
+
+    private var autoCopyResponseToggleRow: some View {
+        HStack {
+            HStack(spacing: 8) {
+                Image(systemName: "doc.on.clipboard")
+                    .font(.system(size: 12, weight: .medium))
+                    .foregroundColor(DS.Colors.textTertiary)
+                    .frame(width: 16)
+
+                Text("Copy responses")
+                    .font(.system(size: 13, weight: .medium))
+                    .foregroundColor(DS.Colors.textSecondary)
+            }
+
+            Spacer()
+
+            Toggle("", isOn: Binding(
+                get: { companionManager.isAutoCopyResponseEnabled },
+                set: { companionManager.setAutoCopyResponseEnabled($0) }
+            ))
+            .toggleStyle(.switch)
+            .labelsHidden()
+            .tint(DS.Colors.accent)
+            .scaleEffect(0.8)
+        }
+        .padding(.vertical, 4)
+    }
 
     // MARK: - Show Clicky Cursor Toggle
 


### PR DESCRIPTION
## Summary
- carries over the auto-copy response toggle from #23
- guards clipboard writes behind a non-empty trimmed response check
- avoids calling `NSPasteboard.clearContents()` for point-only or whitespace-only responses

## Root cause
The PR cleared the general pasteboard whenever auto-copy was enabled, even if `[POINT:...]` parsing left `spokenText` empty. That could wipe the user's clipboard without replacing it.

## Validation
- `swiftc -parse leanring-buddy/*.swift`
- `git diff --check`
- checked PR #23 review context and verified there are no inline review threads; the only actionable comment is the Qodo pasteboard guard

Supersedes/patches #23, since I could not push directly to the contributor fork.