### PR TITLE
Fix blank Settings window redirect

### DIFF
--- a/leanring-buddy/leanring_buddyApp.swift
+++ b/leanring-buddy/leanring_buddyApp.swift
@@ -16,11 +16,22 @@ struct leanring_buddyApp: App {
     @NSApplicationDelegateAdaptor(CompanionAppDelegate.self) var appDelegate
 
     var body: some Scene {
-        // The app lives entirely in the menu bar panel managed by the AppDelegate.
-        // This empty Settings scene satisfies SwiftUI's requirement for at least
-        // one scene but is never shown (LSUIElement=true removes the app menu).
+        // SwiftUI requires at least one scene. Users can reach this via
+        // Cmd+, so show a helpful redirect instead of a blank window.
         Settings {
-            EmptyView()
+            VStack(spacing: 12) {
+                Image(systemName: "menubar.arrow.up.rectangle")
+                    .font(.system(size: 32))
+                    .foregroundColor(.secondary)
+
+                Text("Clicky lives in your menu bar")
+                    .font(.system(size: 14, weight: .medium))
+
+                Text("Click the menu bar icon to open controls.")
+                    .font(.system(size: 12))
+                    .foregroundColor(.secondary)
+            }
+            .frame(width: 260, height: 140)
         }
     }
 }

--- a/leanring-buddy/leanring_buddyApp.swift
+++ b/leanring-buddy/leanring_buddyApp.swift
@@ -19,20 +19,30 @@ struct leanring_buddyApp: App {
         // SwiftUI requires at least one scene. Users can reach this via
         // Cmd+, so show a helpful redirect instead of a blank window.
         Settings {
-            VStack(spacing: 12) {
-                Image(systemName: "menubar.arrow.up.rectangle")
-                    .font(.system(size: 32))
-                    .foregroundColor(.secondary)
-
-                Text("Clicky lives in your menu bar")
-                    .font(.system(size: 14, weight: .medium))
-
-                Text("Click the menu bar icon to open controls.")
-                    .font(.system(size: 12))
-                    .foregroundColor(.secondary)
-            }
-            .frame(width: 260, height: 140)
+            SettingsRedirectView()
         }
+    }
+}
+
+private struct SettingsRedirectView: View {
+    var body: some View {
+        VStack(spacing: 12) {
+            Image(systemName: "menubar.arrow.up.rectangle")
+                .font(.system(size: 32))
+                .foregroundColor(.secondary)
+                .accessibilityHidden(true)
+
+            Text("Clicky lives in your menu bar")
+                .font(.system(size: 14, weight: .medium))
+
+            Text("Open the menu bar icon for controls and permissions. API keys are configured in the Worker setup, not here.")
+                .font(.system(size: 12))
+                .foregroundColor(.secondary)
+                .multilineTextAlignment(.center)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .padding(24)
+        .frame(width: 340, minHeight: 170)
     }
 }
 


### PR DESCRIPTION
## Summary
- replaces the blank SwiftUI Settings scene with a small redirect view
- points users to the menu bar controls and permissions instead of leaving an empty window
- clarifies that provider API keys are configured through the Worker setup, not the app Settings window

## Root cause
The menu-bar-only app still exposes SwiftUI's Settings scene through Cmd+,. That scene was `EmptyView()`, so users who opened Settings saw a blank window and assumed API-key configuration was missing.

## Validation
- `swiftc -parse leanring-buddy/*.swift`
- `git diff --check origin/main...HEAD`

Fixes #12. Supersedes/patches #20, since I could not push directly to the contributor fork.