### PR TITLE
Add niche discovery with app-aware suggestions

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,46 @@
+name: E2E Niche Discovery
+
+on:
+  push:
+    branches:
+      - main
+      - feature/niche-discovery
+  pull_request:
+    branches:
+      - main
+      - feature/niche-discovery
+
+jobs:
+  niche-discovery-e2e:
+    name: Niche discovery E2E (macOS)
+    runs-on: macos-14
+    timeout-minutes: 30
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: "20"
+
+      - name: Run niche-discovery E2E
+        run: |
+          chmod +x tests/e2e/run-all.sh tests/e2e/niche-discovery.sh
+          ./tests/e2e/run-all.sh
+
+      - name: Upload E2E logs on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: niche-discovery-e2e-logs
+          if-no-files-found: ignore
+          path: |
+            /tmp/clicky-e2e-niche-app.log
+            /tmp/clicky-e2e-niche-persist.log
+            /tmp/clicky-e2e-niche-prompt.log
+            /tmp/clicky-e2e-niche-build.log
+            /tmp/clicky-e2e-niche-worker.log
+            ~/.clicky/e2e-last-system-prompt.txt
+            ~/.clicky/e2e-niche-discovery.json

--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -40,6 +40,7 @@ jobs:
             /tmp/clicky-e2e-niche-app.log
             /tmp/clicky-e2e-niche-persist.log
             /tmp/clicky-e2e-niche-prompt.log
+            /tmp/clicky-e2e-niche-app-aware.log
             /tmp/clicky-e2e-niche-build.log
             /tmp/clicky-e2e-niche-worker.log
             ~/.clicky/e2e-last-system-prompt.txt

--- a/leanring-buddy/ClickyAnalytics.swift
+++ b/leanring-buddy/ClickyAnalytics.swift
@@ -118,4 +118,19 @@ enum ClickyAnalytics {
             "error": error
         ])
     }
+
+    // MARK: - Niche Discovery
+
+    static func trackNicheSelected(niche: String) {
+        PostHogSDK.shared.capture("niche_selected", properties: [
+            "niche": niche
+        ])
+    }
+
+    static func trackSuggestionTapped(niche: String, promptID: String) {
+        PostHogSDK.shared.capture("suggestion_tapped", properties: [
+            "niche": niche,
+            "prompt_id": promptID
+        ])
+    }
 }

--- a/leanring-buddy/ClickyE2EConfiguration.swift
+++ b/leanring-buddy/ClickyE2EConfiguration.swift
@@ -1,0 +1,92 @@
+//
+//  ClickyE2EConfiguration.swift
+//  leanring-buddy
+//
+//  Launch flags used by automated end-to-end tests.
+//
+
+import Foundation
+
+enum ClickyE2EConfiguration {
+    static var isEnabled: Bool {
+        ProcessInfo.processInfo.arguments.contains("-CLICKY_E2E=1")
+    }
+
+    static var workerBaseURL: String? {
+        argumentValue(for: "-CLICKY_WORKER_URL=")
+    }
+
+    static var injectTranscript: String? {
+        argumentValue(for: "-CLICKY_INJECT_TRANSCRIPT=")
+    }
+
+    static var injectTranscript2: String? {
+        argumentValue(for: "-CLICKY_INJECT_TRANSCRIPT_2=")
+    }
+
+    static var injectTranscript3: String? {
+        argumentValue(for: "-CLICKY_INJECT_TRANSCRIPT_3=")
+    }
+
+    static var e2eSetNicheRawValue: String? {
+        argumentValue(for: "-CLICKY_E2E_SET_NICHE=")
+    }
+
+    static var e2eTapSuggestionID: String? {
+        argumentValue(for: "-CLICKY_E2E_TAP_SUGGESTION=")
+    }
+
+    static var lastSystemPromptFileURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".clicky/e2e-last-system-prompt.txt")
+    }
+
+    static var nicheDiscoveryFileURL: URL {
+        FileManager.default.homeDirectoryForCurrentUser
+            .appendingPathComponent(".clicky/e2e-niche-discovery.json")
+    }
+
+    struct NicheDiscoveryE2ESnapshot: Codable {
+        let selectedNiche: String
+        let suggestionCount: Int
+        let firstSuggestionId: String
+        let voicePromptClauseContains: String
+    }
+
+    static func applyLaunchOverrides() {
+        guard isEnabled else { return }
+
+        UserDefaults.standard.set(true, forKey: "hasCompletedOnboarding")
+        UserDefaults.standard.set(true, forKey: "hasSubmittedEmail")
+        UserDefaults.standard.set(true, forKey: "isClickyCursorEnabled")
+    }
+
+    static func writeLastSystemPromptForE2E(_ systemPrompt: String) {
+        guard isEnabled else { return }
+
+        let directory = lastSystemPromptFileURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+        try? systemPrompt.write(to: lastSystemPromptFileURL, atomically: true, encoding: .utf8)
+    }
+
+    static func writeNicheDiscoveryForE2E(_ snapshot: NicheDiscoveryE2ESnapshot) {
+        guard isEnabled else { return }
+
+        let directory = nicheDiscoveryFileURL.deletingLastPathComponent()
+        try? FileManager.default.createDirectory(at: directory, withIntermediateDirectories: true)
+
+        let encoder = JSONEncoder()
+        encoder.outputFormatting = [.sortedKeys, .prettyPrinted]
+        guard let data = try? encoder.encode(snapshot) else { return }
+        try? data.write(to: nicheDiscoveryFileURL, options: .atomic)
+    }
+
+    private static func argumentValue(for prefix: String) -> String? {
+        ProcessInfo.processInfo.arguments
+            .first(where: { $0.hasPrefix(prefix) })
+            .map { String($0.dropFirst(prefix.count)) }
+            .flatMap { value in
+                value.isEmpty ? nil : value
+            }
+    }
+}

--- a/leanring-buddy/ClickyE2EConfiguration.swift
+++ b/leanring-buddy/ClickyE2EConfiguration.swift
@@ -36,6 +36,10 @@ enum ClickyE2EConfiguration {
         argumentValue(for: "-CLICKY_E2E_TAP_SUGGESTION=")
     }
 
+    static var e2eFrontmostBundleId: String? {
+        argumentValue(for: "-CLICKY_E2E_FRONTMOST_BUNDLE_ID=")
+    }
+
     static var lastSystemPromptFileURL: URL {
         FileManager.default.homeDirectoryForCurrentUser
             .appendingPathComponent(".clicky/e2e-last-system-prompt.txt")
@@ -51,6 +55,8 @@ enum ClickyE2EConfiguration {
         let suggestionCount: Int
         let firstSuggestionId: String
         let voicePromptClauseContains: String
+        let suggestionContext: String?
+        let isAppAware: Bool
     }
 
     static func applyLaunchOverrides() {

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -76,9 +76,11 @@ final class CompanionManager: ObservableObject {
     }
 
     private let nicheDiscoveryManager = NicheDiscoveryManager()
+    private var frontmostAppObserver: NSObjectProtocol?
 
     @Published private(set) var selectedUserNiche: NicheDiscoveryManager.Niche?
     @Published private(set) var nicheSuggestions: [NicheSuggestion] = []
+    @Published private(set) var nicheSuggestionContextLabel: String?
 
     private lazy var claudeAPI: ClaudeAPI = {
         return ClaudeAPI(proxyURL: "\(Self.workerBaseURL)/chat", model: selectedModel)
@@ -121,8 +123,26 @@ final class CompanionManager: ObservableObject {
     func setUserNiche(_ niche: NicheDiscoveryManager.Niche) {
         nicheDiscoveryManager.setNiche(niche)
         selectedUserNiche = niche
-        nicheSuggestions = nicheDiscoveryManager.suggestionsForCurrentNiche()
+        refreshNicheSuggestions()
         ClickyAnalytics.trackNicheSelected(niche: niche.rawValue)
+    }
+
+    func refreshNicheSuggestions() {
+        guard let selectedUserNiche else {
+            nicheSuggestions = []
+            nicheSuggestionContextLabel = nil
+            return
+        }
+
+        let frontmostBundleId = frontmostApplicationBundleId()
+        nicheSuggestions = nicheDiscoveryManager.suggestions(
+            for: selectedUserNiche,
+            frontmostBundleId: frontmostBundleId
+        )
+        nicheSuggestionContextLabel = nicheDiscoveryManager.contextLabel(
+            for: selectedUserNiche,
+            frontmostBundleId: frontmostBundleId
+        )
     }
 
     func trackNicheSuggestionTapped(suggestion: NicheSuggestion) {
@@ -132,7 +152,30 @@ final class CompanionManager: ObservableObject {
 
     private func bootstrapNicheDiscovery() {
         selectedUserNiche = nicheDiscoveryManager.selectedNiche
-        nicheSuggestions = nicheDiscoveryManager.suggestionsForCurrentNiche()
+        refreshNicheSuggestions()
+    }
+
+    private func frontmostApplicationBundleId() -> String? {
+        if let overrideBundleId = ClickyE2EConfiguration.e2eFrontmostBundleId {
+            return overrideBundleId
+        }
+        return NSWorkspace.shared.frontmostApplication?.bundleIdentifier
+    }
+
+    private func startFrontmostAppObservation() {
+        frontmostAppObserver = NSWorkspace.shared.notificationCenter.addObserver(
+            forName: NSWorkspace.didActivateApplicationNotification,
+            object: nil,
+            queue: .main
+        ) { [weak self] _ in
+            self?.refreshNicheSuggestions()
+        }
+    }
+
+    deinit {
+        if let frontmostAppObserver {
+            NSWorkspace.shared.notificationCenter.removeObserver(frontmostAppObserver)
+        }
     }
 
     private func nicheClauseForVoicePrompt() -> String? {
@@ -203,7 +246,9 @@ final class CompanionManager: ObservableObject {
             selectedNiche: selectedUserNiche.rawValue,
             suggestionCount: suggestions.count,
             firstSuggestionId: firstSuggestion.id,
-            voicePromptClauseContains: e2eNicheClauseAssertionToken(for: selectedUserNiche)
+            voicePromptClauseContains: e2eNicheClauseAssertionToken(for: selectedUserNiche),
+            suggestionContext: nicheSuggestionContextLabel,
+            isAppAware: nicheSuggestionContextLabel != nil
         )
         ClickyE2EConfiguration.writeNicheDiscoveryForE2E(snapshot)
     }
@@ -282,6 +327,7 @@ final class CompanionManager: ObservableObject {
 
     func start() {
         bootstrapNicheDiscovery()
+        startFrontmostAppObservation()
         refreshAllPermissions()
         print("🔑 Clicky start — accessibility: \(hasAccessibilityPermission), screen: \(hasScreenRecordingPermission), mic: \(hasMicrophonePermission), screenContent: \(hasScreenContentPermission), onboarded: \(hasCompletedOnboarding)")
         startPermissionPolling()

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -8,6 +8,7 @@
 //
 
 import AVFoundation
+import AppKit
 import Combine
 import Foundation
 import PostHog
@@ -70,7 +71,14 @@ final class CompanionManager: ObservableObject {
 
     /// Base URL for the Cloudflare Worker proxy. All API requests route
     /// through this so keys never ship in the app binary.
-    private static let workerBaseURL = "https://your-worker-name.your-subdomain.workers.dev"
+    private static var workerBaseURL: String {
+        ClickyE2EConfiguration.workerBaseURL ?? "https://your-worker-name.your-subdomain.workers.dev"
+    }
+
+    private let nicheDiscoveryManager = NicheDiscoveryManager()
+
+    @Published private(set) var selectedUserNiche: NicheDiscoveryManager.Niche?
+    @Published private(set) var nicheSuggestions: [NicheSuggestion] = []
 
     private lazy var claudeAPI: ClaudeAPI = {
         return ClaudeAPI(proxyURL: "\(Self.workerBaseURL)/chat", model: selectedModel)
@@ -109,6 +117,106 @@ final class CompanionManager: ObservableObject {
 
     /// The Claude model used for voice responses. Persisted to UserDefaults.
     @Published var selectedModel: String = UserDefaults.standard.string(forKey: "selectedClaudeModel") ?? "claude-sonnet-4-6"
+
+    func setUserNiche(_ niche: NicheDiscoveryManager.Niche) {
+        nicheDiscoveryManager.setNiche(niche)
+        selectedUserNiche = niche
+        nicheSuggestions = nicheDiscoveryManager.suggestionsForCurrentNiche()
+        ClickyAnalytics.trackNicheSelected(niche: niche.rawValue)
+    }
+
+    func trackNicheSuggestionTapped(suggestion: NicheSuggestion) {
+        guard let selectedUserNiche else { return }
+        ClickyAnalytics.trackSuggestionTapped(niche: selectedUserNiche.rawValue, promptID: suggestion.id)
+    }
+
+    private func bootstrapNicheDiscovery() {
+        selectedUserNiche = nicheDiscoveryManager.selectedNiche
+        nicheSuggestions = nicheDiscoveryManager.suggestionsForCurrentNiche()
+    }
+
+    private func nicheClauseForVoicePrompt() -> String? {
+        guard let selectedUserNiche else { return nil }
+        return nicheDiscoveryManager.voiceSystemPromptClause(for: selectedUserNiche)
+    }
+
+    private func buildVoiceResponseSystemPrompt() -> String {
+        var prompt = Self.companionVoiceResponseSystemPrompt
+        if let clause = nicheClauseForVoicePrompt() {
+            prompt += "\n\n\(clause)"
+        }
+        return prompt
+    }
+
+    func injectTranscriptForE2E(_ transcript: String) async {
+        await withCheckedContinuation { (continuation: CheckedContinuation<Void, Never>) in
+            sendTranscriptToClaudeWithScreenshot(transcript: transcript) {
+                continuation.resume()
+            }
+        }
+    }
+
+    func runE2ENicheDiscoveryChecksIfNeeded() {
+        guard ClickyE2EConfiguration.isEnabled else { return }
+
+        if let nicheRawValue = ClickyE2EConfiguration.e2eSetNicheRawValue,
+           let niche = NicheDiscoveryManager.Niche(rawValue: nicheRawValue) {
+            setUserNiche(niche)
+        }
+
+        if let suggestionID = ClickyE2EConfiguration.e2eTapSuggestionID {
+            tapNicheSuggestionForE2E(promptID: suggestionID)
+        }
+
+        writeNicheDiscoveryDebugJSONIfNeeded()
+    }
+
+    func runE2EInjectSequenceIfNeeded() {
+        guard ClickyE2EConfiguration.isEnabled else { return }
+        guard let thirdTranscript = ClickyE2EConfiguration.injectTranscript3 else { return }
+
+        Task {
+            try? await Task.sleep(nanoseconds: 2_000_000_000)
+            await injectTranscriptForE2E(thirdTranscript)
+        }
+    }
+
+    private func tapNicheSuggestionForE2E(promptID: String) {
+        guard let suggestion = nicheSuggestions.first(where: { $0.id == promptID }) else {
+            print("⚠️ E2E: no niche suggestion with id \(promptID)")
+            return
+        }
+        trackNicheSuggestionTapped(suggestion: suggestion)
+    }
+
+    private func writeNicheDiscoveryDebugJSONIfNeeded() {
+        guard ClickyE2EConfiguration.isEnabled else { return }
+        guard let selectedUserNiche else { return }
+
+        let suggestions = nicheSuggestions
+        guard let firstSuggestion = suggestions.first else {
+            print("⚠️ E2E: no niche suggestions loaded for \(selectedUserNiche.rawValue)")
+            return
+        }
+
+        let snapshot = ClickyE2EConfiguration.NicheDiscoveryE2ESnapshot(
+            selectedNiche: selectedUserNiche.rawValue,
+            suggestionCount: suggestions.count,
+            firstSuggestionId: firstSuggestion.id,
+            voicePromptClauseContains: e2eNicheClauseAssertionToken(for: selectedUserNiche)
+        )
+        ClickyE2EConfiguration.writeNicheDiscoveryForE2E(snapshot)
+    }
+
+    private func e2eNicheClauseAssertionToken(for niche: NicheDiscoveryManager.Niche) -> String {
+        switch niche {
+        case .contentCreator: return "content creator"
+        case .developer: return "developer"
+        case .student: return "student"
+        case .designer: return "designer"
+        case .other: return "many apps"
+        }
+    }
 
     func setSelectedModel(_ model: String) {
         selectedModel = model
@@ -173,6 +281,7 @@ final class CompanionManager: ObservableObject {
     }
 
     func start() {
+        bootstrapNicheDiscovery()
         refreshAllPermissions()
         print("🔑 Clicky start — accessibility: \(hasAccessibilityPermission), screen: \(hasScreenRecordingPermission), mic: \(hasMicrophonePermission), screenContent: \(hasScreenContentPermission), onboarded: \(hasCompletedOnboarding)")
         startPermissionPolling()
@@ -583,11 +692,15 @@ final class CompanionManager: ObservableObject {
     /// the spinner/processing state until TTS audio begins playing.
     /// Claude's response may include a [POINT:x,y:label] tag which triggers
     /// the buddy to fly to that element on screen.
-    private func sendTranscriptToClaudeWithScreenshot(transcript: String) {
+    private func sendTranscriptToClaudeWithScreenshot(
+        transcript: String,
+        onComplete: (@MainActor () -> Void)? = nil
+    ) {
         currentResponseTask?.cancel()
         elevenLabsTTSClient.stopPlayback()
 
         currentResponseTask = Task {
+            defer { onComplete?() }
             // Stay in processing (spinner) state — no streaming text displayed
             voiceState = .processing
 
@@ -610,9 +723,12 @@ final class CompanionManager: ObservableObject {
                     (userPlaceholder: entry.userTranscript, assistantResponse: entry.assistantResponse)
                 }
 
+                let systemPrompt = buildVoiceResponseSystemPrompt()
+                ClickyE2EConfiguration.writeLastSystemPromptForE2E(systemPrompt)
+
                 let (fullResponseText, _) = try await claudeAPI.analyzeImageStreaming(
                     images: labeledImages,
-                    systemPrompt: Self.companionVoiceResponseSystemPrompt,
+                    systemPrompt: systemPrompt,
                     conversationHistory: historyForAPI,
                     userPrompt: transcript,
                     onTextChunk: { _ in

--- a/leanring-buddy/CompanionPanelView.swift
+++ b/leanring-buddy/CompanionPanelView.swift
@@ -8,11 +8,13 @@
 //
 
 import AVFoundation
+import AppKit
 import SwiftUI
 
 struct CompanionPanelView: View {
     @ObservedObject var companionManager: CompanionManager
     @State private var emailInput: String = ""
+    @State private var nicheSuggestionHintMessage: String?
 
     var body: some View {
         VStack(alignment: .leading, spacing: 0) {
@@ -24,6 +26,14 @@ struct CompanionPanelView: View {
             permissionsCopySection
                 .padding(.top, 16)
                 .padding(.horizontal, 16)
+
+            if companionManager.allPermissionsGranted {
+                Spacer()
+                    .frame(height: 12)
+
+                nicheDiscoverySection
+                    .padding(.horizontal, 16)
+            }
 
             if companionManager.hasCompletedOnboarding && companionManager.allPermissionsGranted {
                 Spacer()
@@ -594,6 +604,117 @@ struct CompanionPanelView: View {
                 .foregroundColor(DS.Colors.textTertiary)
         }
         .padding(.vertical, 4)
+    }
+
+    // MARK: - Niche Discovery
+
+    private var nicheDiscoverySection: some View {
+        VStack(alignment: .leading, spacing: 8) {
+            Text("What do you use Clicky for?")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(DS.Colors.textSecondary)
+
+            Text("Hold Control+Option, ask out loud, and Clicky will look at your screen and point.")
+                .font(.system(size: 10))
+                .foregroundColor(DS.Colors.textTertiary)
+                .fixedSize(horizontal: false, vertical: true)
+
+            nichePickerChips
+
+            if let selectedNiche = companionManager.selectedUserNiche {
+                Text("Try saying one of these:")
+                    .font(.system(size: 11, weight: .medium))
+                    .foregroundColor(DS.Colors.textTertiary)
+                    .padding(.top, 2)
+
+                ForEach(companionManager.nicheSuggestions) { suggestion in
+                    nicheSuggestionCard(suggestion)
+                }
+
+                if let nicheSuggestionHintMessage {
+                    Text(nicheSuggestionHintMessage)
+                        .font(.system(size: 10, weight: .medium))
+                        .foregroundColor(DS.Colors.accent)
+                        .fixedSize(horizontal: false, vertical: true)
+                }
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var nichePickerChips: some View {
+        LazyVGrid(
+            columns: [GridItem(.adaptive(minimum: 72), spacing: 6)],
+            alignment: .leading,
+            spacing: 6
+        ) {
+            ForEach(NicheDiscoveryManager.Niche.allCases) { niche in
+                nicheChipButton(niche)
+            }
+        }
+    }
+
+    private func nicheChipButton(_ niche: NicheDiscoveryManager.Niche) -> some View {
+        let isSelected = companionManager.selectedUserNiche == niche
+        return Button(action: {
+            companionManager.setUserNiche(niche)
+            nicheSuggestionHintMessage = nil
+        }) {
+            Text(niche.displayName)
+                .font(.system(size: 11, weight: .medium))
+                .foregroundColor(isSelected ? DS.Colors.textPrimary : DS.Colors.textTertiary)
+                .padding(.horizontal, 10)
+                .padding(.vertical, 5)
+                .background(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .fill(isSelected ? Color.white.opacity(0.12) : Color.white.opacity(0.05))
+                )
+                .overlay(
+                    RoundedRectangle(cornerRadius: 6, style: .continuous)
+                        .stroke(isSelected ? DS.Colors.accent.opacity(0.5) : DS.Colors.borderSubtle, lineWidth: 0.5)
+                )
+        }
+        .buttonStyle(.plain)
+        .pointerCursor()
+    }
+
+    private func nicheSuggestionCard(_ suggestion: NicheSuggestion) -> some View {
+        Button(action: {
+            NSPasteboard.general.clearContents()
+            NSPasteboard.general.setString(suggestion.prompt, forType: .string)
+            companionManager.trackNicheSuggestionTapped(suggestion: suggestion)
+            nicheSuggestionHintMessage = "Copied — hold Control+Option and say this while looking at your screen."
+        }) {
+            HStack(alignment: .top, spacing: 8) {
+                Image(systemName: "mic.fill")
+                    .font(.system(size: 10, weight: .semibold))
+                    .foregroundColor(DS.Colors.accent)
+                    .padding(.top, 2)
+
+                Text(suggestion.prompt)
+                    .font(.system(size: 11))
+                    .foregroundColor(DS.Colors.textSecondary)
+                    .multilineTextAlignment(.leading)
+                    .fixedSize(horizontal: false, vertical: true)
+
+                Spacer(minLength: 0)
+
+                Image(systemName: "doc.on.doc")
+                    .font(.system(size: 10, weight: .medium))
+                    .foregroundColor(DS.Colors.textTertiary)
+            }
+            .padding(10)
+            .background(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .fill(Color.white.opacity(0.04))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 8, style: .continuous)
+                    .stroke(DS.Colors.borderSubtle, lineWidth: 0.5)
+            )
+        }
+        .buttonStyle(.plain)
+        .pointerCursor()
     }
 
     // MARK: - Model Picker

--- a/leanring-buddy/CompanionPanelView.swift
+++ b/leanring-buddy/CompanionPanelView.swift
@@ -622,7 +622,7 @@ struct CompanionPanelView: View {
             nichePickerChips
 
             if let selectedNiche = companionManager.selectedUserNiche {
-                Text("Try saying one of these:")
+                Text(companionManager.nicheSuggestionContextLabel ?? "Try saying one of these:")
                     .font(.system(size: 11, weight: .medium))
                     .foregroundColor(DS.Colors.textTertiary)
                     .padding(.top, 2)

--- a/leanring-buddy/NicheAppSuggestionMapping.swift
+++ b/leanring-buddy/NicheAppSuggestionMapping.swift
@@ -1,0 +1,326 @@
+//
+//  NicheAppSuggestionMapping.swift
+//  leanring-buddy
+//
+//  Maps common macOS app bundle IDs to niche-specific example prompts shown
+//  when the frontmost app matches the user's selected niche.
+//
+
+import Foundation
+
+enum NicheAppSuggestionMapping {
+    private struct AppSuggestionEntry {
+        let niche: NicheDiscoveryManager.Niche
+        let appDisplayName: String
+        let suggestions: [NicheSuggestion]
+    }
+
+    private static let entriesByBundleId: [String: AppSuggestionEntry] = [
+        "com.apple.dt.Xcode": AppSuggestionEntry(
+            niche: .developer,
+            appDisplayName: "Xcode",
+            suggestions: [
+                NicheSuggestion(
+                    id: "xcode-source-control",
+                    prompt: "How do I commit from Xcode? Point at the Source Control menu."
+                ),
+                NicheSuggestion(
+                    id: "xcode-run-scheme",
+                    prompt: "Which scheme should I run? Point at the run destination picker."
+                ),
+                NicheSuggestion(
+                    id: "xcode-breakpoint",
+                    prompt: "Walk me through adding a breakpoint here — point at the gutter."
+                ),
+                NicheSuggestion(
+                    id: "xcode-debug-area",
+                    prompt: "Where do I see console output while debugging? Point at it."
+                ),
+                NicheSuggestion(
+                    id: "xcode-navigator",
+                    prompt: "How do I find a file in this project? Point at the navigator."
+                )
+            ]
+        ),
+        "com.apple.Terminal": AppSuggestionEntry(
+            niche: .developer,
+            appDisplayName: "Terminal",
+            suggestions: [
+                NicheSuggestion(
+                    id: "terminal-run-command",
+                    prompt: "What command should I run here for this project? Point at the prompt."
+                ),
+                NicheSuggestion(
+                    id: "terminal-git-status",
+                    prompt: "Walk me through checking git status — point at what to type."
+                ),
+                NicheSuggestion(
+                    id: "terminal-path",
+                    prompt: "Am I in the right folder? Point at the current path."
+                )
+            ]
+        ),
+        "com.microsoft.VSCode": AppSuggestionEntry(
+            niche: .developer,
+            appDisplayName: "VS Code",
+            suggestions: [
+                NicheSuggestion(
+                    id: "vscode-command-palette",
+                    prompt: "How do I open the command palette here? Point at it."
+                ),
+                NicheSuggestion(
+                    id: "vscode-run-task",
+                    prompt: "Where do I run a build task in VS Code? Point at the menu."
+                ),
+                NicheSuggestion(
+                    id: "vscode-debug",
+                    prompt: "How do I start debugging this file? Point at the run button."
+                )
+            ]
+        ),
+        "com.apple.FinalCut": AppSuggestionEntry(
+            niche: .contentCreator,
+            appDisplayName: "Final Cut Pro",
+            suggestions: [
+                NicheSuggestion(
+                    id: "finalcut-export",
+                    prompt: "How do I export this timeline? Point at the share or export button."
+                ),
+                NicheSuggestion(
+                    id: "finalcut-color",
+                    prompt: "Where is the color inspector? Point at it on screen."
+                ),
+                NicheSuggestion(
+                    id: "finalcut-blade",
+                    prompt: "How do I split this clip? Point at the blade tool."
+                ),
+                NicheSuggestion(
+                    id: "finalcut-audio",
+                    prompt: "Where do I adjust audio levels on this clip? Point at the controls."
+                )
+            ]
+        ),
+        "com.apple.iMovieApp": AppSuggestionEntry(
+            niche: .contentCreator,
+            appDisplayName: "iMovie",
+            suggestions: [
+                NicheSuggestion(
+                    id: "imovie-export",
+                    prompt: "How do I export this project? Point at the share button."
+                ),
+                NicheSuggestion(
+                    id: "imovie-trim",
+                    prompt: "How do I trim this clip? Point at the right control."
+                ),
+                NicheSuggestion(
+                    id: "imovie-transition",
+                    prompt: "Where do I add a transition between clips? Point at it."
+                )
+            ]
+        ),
+        "com.figma.Desktop": AppSuggestionEntry(
+            niche: .designer,
+            appDisplayName: "Figma",
+            suggestions: [
+                NicheSuggestion(
+                    id: "figma-export",
+                    prompt: "How do I export this frame? Point at the export panel."
+                ),
+                NicheSuggestion(
+                    id: "figma-components",
+                    prompt: "Where are components in this file? Point at the assets panel."
+                ),
+                NicheSuggestion(
+                    id: "figma-auto-layout",
+                    prompt: "How do I turn on auto layout for this frame? Point at the control."
+                ),
+                NicheSuggestion(
+                    id: "figma-prototype",
+                    prompt: "How do I preview this prototype? Point at the play button."
+                )
+            ]
+        ),
+        "com.bohemiancoding.sketch3": AppSuggestionEntry(
+            niche: .designer,
+            appDisplayName: "Sketch",
+            suggestions: [
+                NicheSuggestion(
+                    id: "sketch-export",
+                    prompt: "How do I export these artboards? Point at the export controls."
+                ),
+                NicheSuggestion(
+                    id: "sketch-symbols",
+                    prompt: "Where do I find symbols in this document? Point at the panel."
+                ),
+                NicheSuggestion(
+                    id: "sketch-layout",
+                    prompt: "How do I align these layers? Point at the alignment tools."
+                )
+            ]
+        ),
+        "com.apple.Notes": AppSuggestionEntry(
+            niche: .student,
+            appDisplayName: "Notes",
+            suggestions: [
+                NicheSuggestion(
+                    id: "notes-checklist",
+                    prompt: "How do I turn this into a checklist? Point at the format button."
+                ),
+                NicheSuggestion(
+                    id: "notes-folder",
+                    prompt: "Where should I file this note? Point at the folder sidebar."
+                ),
+                NicheSuggestion(
+                    id: "notes-share",
+                    prompt: "How do I share this note with a classmate? Point at share."
+                )
+            ]
+        ),
+        "com.apple.iWork.Pages": AppSuggestionEntry(
+            niche: .student,
+            appDisplayName: "Pages",
+            suggestions: [
+                NicheSuggestion(
+                    id: "pages-format",
+                    prompt: "How do I fix the formatting on this paragraph? Point at the inspector."
+                ),
+                NicheSuggestion(
+                    id: "pages-export-pdf",
+                    prompt: "How do I export this as a PDF? Point at the export menu."
+                ),
+                NicheSuggestion(
+                    id: "pages-citation",
+                    prompt: "Where do I add footnotes or citations? Point at the menu."
+                )
+            ]
+        ),
+        "com.apple.TextEdit": AppSuggestionEntry(
+            niche: .other,
+            appDisplayName: "TextEdit",
+            suggestions: [
+                NicheSuggestion(
+                    id: "textedit-plain-text",
+                    prompt: "How do I switch this to plain text? Point at the format menu."
+                ),
+                NicheSuggestion(
+                    id: "textedit-find",
+                    prompt: "Where is find and replace? Point at the menu item."
+                ),
+                NicheSuggestion(
+                    id: "textedit-save-as",
+                    prompt: "How do I save this in a different format? Point at Save As."
+                )
+            ]
+        ),
+        "com.apple.Safari": AppSuggestionEntry(
+            niche: .other,
+            appDisplayName: "Safari",
+            suggestions: [
+                NicheSuggestion(
+                    id: "safari-tab-group",
+                    prompt: "How do I organize these tabs? Point at the tab group control."
+                ),
+                NicheSuggestion(
+                    id: "safari-reader",
+                    prompt: "How do I open reader view on this page? Point at the button."
+                ),
+                NicheSuggestion(
+                    id: "safari-downloads",
+                    prompt: "Where did my download go? Point at the downloads button."
+                )
+            ]
+        ),
+        "com.apple.mail": AppSuggestionEntry(
+            niche: .other,
+            appDisplayName: "Mail",
+            suggestions: [
+                NicheSuggestion(
+                    id: "mail-compose",
+                    prompt: "How do I attach a file to this email? Point at the attach button."
+                ),
+                NicheSuggestion(
+                    id: "mail-search",
+                    prompt: "How do I search for an old message? Point at the search field."
+                ),
+                NicheSuggestion(
+                    id: "mail-rules",
+                    prompt: "Where do I set up a mail rule? Point at the preferences menu."
+                )
+            ]
+        ),
+        "com.apple.finder": AppSuggestionEntry(
+            niche: .other,
+            appDisplayName: "Finder",
+            suggestions: [
+                NicheSuggestion(
+                    id: "finder-quick-look",
+                    prompt: "How do I preview this file without opening it? Point at Quick Look."
+                ),
+                NicheSuggestion(
+                    id: "finder-tags",
+                    prompt: "How do I tag these files? Point at the tags control."
+                ),
+                NicheSuggestion(
+                    id: "finder-path-bar",
+                    prompt: "How do I copy the path to this folder? Point at the path bar."
+                )
+            ]
+        ),
+        "com.notion.id": AppSuggestionEntry(
+            niche: .student,
+            appDisplayName: "Notion",
+            suggestions: [
+                NicheSuggestion(
+                    id: "notion-template",
+                    prompt: "How do I duplicate this page as a template? Point at the menu."
+                ),
+                NicheSuggestion(
+                    id: "notion-toggle",
+                    prompt: "How do I collapse this section? Point at the toggle."
+                ),
+                NicheSuggestion(
+                    id: "notion-share",
+                    prompt: "How do I share this page with my team? Point at share."
+                )
+            ]
+        ),
+        "com.spotify.client": AppSuggestionEntry(
+            niche: .other,
+            appDisplayName: "Spotify",
+            suggestions: [
+                NicheSuggestion(
+                    id: "spotify-queue",
+                    prompt: "How do I add this song to my queue? Point at the menu."
+                ),
+                NicheSuggestion(
+                    id: "spotify-playlist",
+                    prompt: "How do I save this to a playlist? Point at the plus button."
+                ),
+                NicheSuggestion(
+                    id: "spotify-lyrics",
+                    prompt: "Where do I see lyrics for this track? Point at the lyrics button."
+                )
+            ]
+        )
+    ]
+
+    static func appSpecificSuggestions(
+        bundleId: String,
+        selectedNiche: NicheDiscoveryManager.Niche
+    ) -> [NicheSuggestion]? {
+        guard let entry = entriesByBundleId[bundleId], entry.niche == selectedNiche else {
+            return nil
+        }
+        return entry.suggestions
+    }
+
+    static func contextLabel(
+        bundleId: String,
+        selectedNiche: NicheDiscoveryManager.Niche
+    ) -> String? {
+        guard let entry = entriesByBundleId[bundleId], entry.niche == selectedNiche else {
+            return nil
+        }
+        return "While you're in \(entry.appDisplayName), try saying one of these:"
+    }
+}

--- a/leanring-buddy/NicheDiscoveryManager.swift
+++ b/leanring-buddy/NicheDiscoveryManager.swift
@@ -70,9 +70,28 @@ final class NicheDiscoveryManager {
         return loaded
     }
 
-    func suggestionsForCurrentNiche() -> [NicheSuggestion] {
+    func suggestions(for niche: Niche, frontmostBundleId: String?) -> [NicheSuggestion] {
+        if let frontmostBundleId,
+           let appSpecificSuggestions = NicheAppSuggestionMapping.appSpecificSuggestions(
+               bundleId: frontmostBundleId,
+               selectedNiche: niche
+           ) {
+            return appSpecificSuggestions
+        }
+        return suggestions(for: niche)
+    }
+
+    func contextLabel(for niche: Niche, frontmostBundleId: String?) -> String? {
+        guard let frontmostBundleId else { return nil }
+        return NicheAppSuggestionMapping.contextLabel(
+            bundleId: frontmostBundleId,
+            selectedNiche: niche
+        )
+    }
+
+    func suggestionsForCurrentNiche(frontmostBundleId: String? = nil) -> [NicheSuggestion] {
         guard let selectedNiche else { return [] }
-        return suggestions(for: selectedNiche)
+        return suggestions(for: selectedNiche, frontmostBundleId: frontmostBundleId)
     }
 
     /// Short clause appended to the voice system prompt when a niche is set.

--- a/leanring-buddy/NicheDiscoveryManager.swift
+++ b/leanring-buddy/NicheDiscoveryManager.swift
@@ -1,0 +1,116 @@
+//
+//  NicheDiscoveryManager.swift
+//  leanring-buddy
+//
+//  Loads niche-specific example prompts from bundled JSON and persists the
+//  user's selected niche in UserDefaults.
+//
+
+import Foundation
+
+struct NicheSuggestion: Identifiable, Equatable, Codable {
+    let id: String
+    let prompt: String
+}
+
+struct NicheSuggestionsFile: Codable {
+    let suggestions: [NicheSuggestion]
+}
+
+final class NicheDiscoveryManager {
+    static let selectedUserNicheUserDefaultsKey = "selectedUserNiche"
+
+    enum Niche: String, CaseIterable, Identifiable, Codable {
+        case contentCreator = "content-creator"
+        case developer
+        case student
+        case designer
+        case other
+
+        var id: String { rawValue }
+
+        var displayName: String {
+            switch self {
+            case .contentCreator: return "Creator"
+            case .developer: return "Developer"
+            case .student: return "Student"
+            case .designer: return "Designer"
+            case .other: return "Other"
+            }
+        }
+    }
+
+    private let bundle: Bundle
+    private let userDefaults: UserDefaults
+    private var cachedSuggestionsByNiche: [Niche: [NicheSuggestion]] = [:]
+
+    init(bundle: Bundle = .main, userDefaults: UserDefaults = .standard) {
+        self.bundle = bundle
+        self.userDefaults = userDefaults
+    }
+
+    var selectedNiche: Niche? {
+        guard let rawValue = userDefaults.string(forKey: Self.selectedUserNicheUserDefaultsKey) else {
+            return nil
+        }
+        return Niche(rawValue: rawValue)
+    }
+
+    func setNiche(_ niche: Niche) {
+        userDefaults.set(niche.rawValue, forKey: Self.selectedUserNicheUserDefaultsKey)
+    }
+
+    func suggestions(for niche: Niche) -> [NicheSuggestion] {
+        if let cached = cachedSuggestionsByNiche[niche] {
+            return cached
+        }
+
+        let loaded = loadSuggestionsFromBundle(for: niche)
+        cachedSuggestionsByNiche[niche] = loaded
+        return loaded
+    }
+
+    func suggestionsForCurrentNiche() -> [NicheSuggestion] {
+        guard let selectedNiche else { return [] }
+        return suggestions(for: selectedNiche)
+    }
+
+    /// Short clause appended to the voice system prompt when a niche is set.
+    func voiceSystemPromptClause(for niche: Niche) -> String {
+        switch niche {
+        case .contentCreator:
+            return "the user is a content creator. prioritize help with video editing, captions, exports, color, and timeline navigation on screen. point at specific ui when teaching workflows."
+        case .developer:
+            return "the user is a developer. prioritize help with code editors, terminals, git, builds, and debugging on screen. point at specific ui when teaching workflows."
+        case .student:
+            return "the user is a student. prioritize help with assignments, notes, research, and study apps on screen. point at specific ui when teaching workflows."
+        case .designer:
+            return "the user is a designer. prioritize help with design tools, layers, assets, and export settings on screen. point at specific ui when teaching workflows."
+        case .other:
+            return "the user works across many apps. prioritize concrete on-screen guidance and pointing when it helps them complete a task."
+        }
+    }
+
+    private func loadSuggestionsFromBundle(for niche: Niche) -> [NicheSuggestion] {
+        // Xcode may copy `Resources/niches/*.json` flat into the bundle root.
+        let fileURL = bundle.url(
+            forResource: niche.rawValue,
+            withExtension: "json",
+            subdirectory: "niches"
+        ) ?? bundle.url(forResource: niche.rawValue, withExtension: "json")
+
+        guard let fileURL else {
+            print("⚠️ NicheDiscovery: missing bundled examples for \(niche.rawValue)")
+            return []
+        }
+
+        do {
+            let data = try Data(contentsOf: fileURL)
+            let decoded = try JSONDecoder().decode(NicheSuggestionsFile.self, from: data)
+            return decoded.suggestions
+        } catch {
+            print("⚠️ NicheDiscovery: failed to load \(niche.rawValue).json: \(error)")
+            return []
+        }
+    }
+}

--- a/leanring-buddy/Resources/niches/content-creator.json
+++ b/leanring-buddy/Resources/niches/content-creator.json
@@ -1,0 +1,24 @@
+{
+  "suggestions": [
+    {
+      "id": "captions-timeline",
+      "prompt": "Show me where to add captions on this timeline — point at the control."
+    },
+    {
+      "id": "export-youtube",
+      "prompt": "Walk me through export settings for YouTube on this screen."
+    },
+    {
+      "id": "color-grade-clip",
+      "prompt": "How do I color grade this clip? Point at where I should start."
+    },
+    {
+      "id": "transition-menu",
+      "prompt": "Where is the transition menu in this app?"
+    },
+    {
+      "id": "audio-levels",
+      "prompt": "Help me fix the audio levels here — show me the mixer or levels control."
+    }
+  ]
+}

--- a/leanring-buddy/Resources/niches/designer.json
+++ b/leanring-buddy/Resources/niches/designer.json
@@ -1,0 +1,24 @@
+{
+  "suggestions": [
+    {
+      "id": "export-assets",
+      "prompt": "Walk me through exporting assets from this file — point at export."
+    },
+    {
+      "id": "align-layers",
+      "prompt": "How do I align these layers? Show me the alignment controls."
+    },
+    {
+      "id": "color-style",
+      "prompt": "Where do I change the color style for this selection?"
+    },
+    {
+      "id": "component-variant",
+      "prompt": "Point at where I edit this component or variant."
+    },
+    {
+      "id": "share-prototype",
+      "prompt": "How do I share or preview this prototype? Point at the right button."
+    }
+  ]
+}

--- a/leanring-buddy/Resources/niches/developer.json
+++ b/leanring-buddy/Resources/niches/developer.json
@@ -1,0 +1,24 @@
+{
+  "suggestions": [
+    {
+      "id": "commit-changes",
+      "prompt": "How do I commit these changes? Point at the right button or menu."
+    },
+    {
+      "id": "run-tests",
+      "prompt": "Where do I run tests in this project? Show me on screen."
+    },
+    {
+      "id": "debug-breakpoint",
+      "prompt": "Walk me through setting a breakpoint here — point at what to click."
+    },
+    {
+      "id": "terminal-command",
+      "prompt": "What should I run in the terminal for this? Point at the terminal if it's on screen."
+    },
+    {
+      "id": "find-setting",
+      "prompt": "Where is the setting I need in this editor? Point at it."
+    }
+  ]
+}

--- a/leanring-buddy/Resources/niches/other.json
+++ b/leanring-buddy/Resources/niches/other.json
@@ -1,0 +1,24 @@
+{
+  "suggestions": [
+    {
+      "id": "find-button",
+      "prompt": "Where is the button I need on this screen? Point at it."
+    },
+    {
+      "id": "explain-panel",
+      "prompt": "Explain what this panel does and point at the important parts."
+    },
+    {
+      "id": "next-step",
+      "prompt": "What should I click next to finish this task? Point at it."
+    },
+    {
+      "id": "settings-location",
+      "prompt": "Show me where the setting I need is in this app."
+    },
+    {
+      "id": "shortcut-hint",
+      "prompt": "Is there a keyboard shortcut for what I'm trying to do here?"
+    }
+  ]
+}

--- a/leanring-buddy/Resources/niches/student.json
+++ b/leanring-buddy/Resources/niches/student.json
@@ -1,0 +1,24 @@
+{
+  "suggestions": [
+    {
+      "id": "save-document",
+      "prompt": "How do I save this document? Point at save or the menu path."
+    },
+    {
+      "id": "export-pdf",
+      "prompt": "Walk me through exporting this as a PDF — show me where to click."
+    },
+    {
+      "id": "citation-tool",
+      "prompt": "Where do I add a citation or reference in this app?"
+    },
+    {
+      "id": "slide-layout",
+      "prompt": "Help me fix this slide layout — point at the control I should use."
+    },
+    {
+      "id": "highlight-notes",
+      "prompt": "Show me how to highlight or annotate this section on screen."
+    }
+  ]
+}

--- a/leanring-buddy/leanring_buddyApp.swift
+++ b/leanring-buddy/leanring_buddyApp.swift
@@ -41,9 +41,12 @@ final class CompanionAppDelegate: NSObject, NSApplicationDelegate {
 
         ClickyAnalytics.configure()
         ClickyAnalytics.trackAppOpened()
+        ClickyE2EConfiguration.applyLaunchOverrides()
 
         menuBarPanelManager = MenuBarPanelManager(companionManager: companionManager)
         companionManager.start()
+        companionManager.runE2ENicheDiscoveryChecksIfNeeded()
+        companionManager.runE2EInjectSequenceIfNeeded()
         // Auto-open the panel if the user still needs to do something:
         // either they haven't onboarded yet, or permissions were revoked.
         if !companionManager.hasCompletedOnboarding || !companionManager.allPermissionsGranted {

--- a/leanring-buddyTests/NicheDiscoveryTests.swift
+++ b/leanring-buddyTests/NicheDiscoveryTests.swift
@@ -60,27 +60,34 @@ struct NicheDiscoveryTests {
         }
     }
 
-    @Test func nicheClauseIncludedInVoicePromptWithoutBreakingSkills() {
-        let skill = TeachingSkill(
-            id: "teach-test",
-            name: "Test Skill",
-            description: "Test",
-            bundleIds: [],
-            status: .active,
-            lastUsed: Date(),
-            usageCount: 1,
-            isPinned: false,
-            body: "step one"
-        )
+    @Test func xcodeBundleIdReturnsAppSpecificDeveloperSuggestions() {
         let manager = NicheDiscoveryManager()
-        let prompt = TeachingPromptBuilder.buildVoiceResponsePrompt(
-            basePrompt: "base",
-            matchedSkills: [skill],
-            nicheClause: manager.voiceSystemPromptClause(for: .developer)
+        let suggestions = manager.suggestions(
+            for: .developer,
+            frontmostBundleId: "com.apple.dt.Xcode"
         )
-        #expect(prompt.contains("base"))
-        #expect(prompt.contains("the user is a developer"))
-        #expect(prompt.contains("teaching skills:"))
-        #expect(prompt.contains("step one"))
+        #expect(!suggestions.isEmpty)
+        #expect(suggestions.first?.id == "xcode-source-control")
+        #expect(suggestions.allSatisfy { $0.id.hasPrefix("xcode-") })
+    }
+
+    @Test func unknownBundleIdFallsBackToBundledDeveloperSuggestions() {
+        let manager = NicheDiscoveryManager()
+        let bundledSuggestions = manager.suggestions(for: .developer)
+        let suggestions = manager.suggestions(
+            for: .developer,
+            frontmostBundleId: "com.unknown.app"
+        )
+        #expect(suggestions.map(\.id) == bundledSuggestions.map(\.id))
+        #expect(suggestions.first?.id == "commit-changes")
+    }
+
+    @Test func contextLabelMentionsXcodeForDeveloperNiche() {
+        let manager = NicheDiscoveryManager()
+        let label = manager.contextLabel(
+            for: .developer,
+            frontmostBundleId: "com.apple.dt.Xcode"
+        )
+        #expect(label?.contains("Xcode") == true)
     }
 }

--- a/leanring-buddyTests/NicheDiscoveryTests.swift
+++ b/leanring-buddyTests/NicheDiscoveryTests.swift
@@ -1,0 +1,86 @@
+//
+//  NicheDiscoveryTests.swift
+//  leanring-buddyTests
+//
+
+import Foundation
+import Testing
+@testable import leanring_buddy
+
+struct NicheDiscoveryTests {
+    @Test func loadsBundledSuggestionsForEachNiche() throws {
+        let manager = NicheDiscoveryManager()
+
+        for niche in NicheDiscoveryManager.Niche.allCases {
+            let suggestions = manager.suggestions(for: niche)
+            #expect(suggestions.count >= 3, "Expected at least 3 suggestions for \(niche.rawValue)")
+            #expect(suggestions.count <= 5, "Expected at most 5 suggestions for \(niche.rawValue)")
+            #expect(suggestions.allSatisfy { !$0.id.isEmpty && !$0.prompt.isEmpty })
+        }
+    }
+
+    @Test func contentCreatorSuggestionsDifferFromDeveloper() {
+        let manager = NicheDiscoveryManager()
+        let creatorPrompts = Set(manager.suggestions(for: .contentCreator).map(\.prompt))
+        let developerPrompts = Set(manager.suggestions(for: .developer).map(\.prompt))
+        #expect(creatorPrompts != developerPrompts)
+    }
+
+    @Test func persistsSelectedNicheAcrossInstances() {
+        let userDefaults = UserDefaults(suiteName: "NicheDiscoveryTests")!
+        userDefaults.removePersistentDomain(forName: "NicheDiscoveryTests")
+
+        let firstManager = NicheDiscoveryManager(userDefaults: userDefaults)
+        firstManager.setNiche(.designer)
+        #expect(firstManager.selectedNiche == .designer)
+
+        let secondManager = NicheDiscoveryManager(userDefaults: userDefaults)
+        #expect(secondManager.selectedNiche == .designer)
+        #expect(secondManager.suggestionsForCurrentNiche().count >= 3)
+
+        userDefaults.removePersistentDomain(forName: "NicheDiscoveryTests")
+    }
+
+    @Test func suggestionsForCurrentNicheEmptyWhenUnset() {
+        let userDefaults = UserDefaults(suiteName: "NicheDiscoveryTests.unset")!
+        userDefaults.removePersistentDomain(forName: "NicheDiscoveryTests.unset")
+
+        let manager = NicheDiscoveryManager(userDefaults: userDefaults)
+        #expect(manager.selectedNiche == nil)
+        #expect(manager.suggestionsForCurrentNiche().isEmpty)
+
+        userDefaults.removePersistentDomain(forName: "NicheDiscoveryTests.unset")
+    }
+
+    @Test func voicePromptClausePresentForEachNiche() {
+        let manager = NicheDiscoveryManager()
+        for niche in NicheDiscoveryManager.Niche.allCases {
+            let clause = manager.voiceSystemPromptClause(for: niche)
+            #expect(!clause.isEmpty)
+        }
+    }
+
+    @Test func nicheClauseIncludedInVoicePromptWithoutBreakingSkills() {
+        let skill = TeachingSkill(
+            id: "teach-test",
+            name: "Test Skill",
+            description: "Test",
+            bundleIds: [],
+            status: .active,
+            lastUsed: Date(),
+            usageCount: 1,
+            isPinned: false,
+            body: "step one"
+        )
+        let manager = NicheDiscoveryManager()
+        let prompt = TeachingPromptBuilder.buildVoiceResponsePrompt(
+            basePrompt: "base",
+            matchedSkills: [skill],
+            nicheClause: manager.voiceSystemPromptClause(for: .developer)
+        )
+        #expect(prompt.contains("base"))
+        #expect(prompt.contains("the user is a developer"))
+        #expect(prompt.contains("teaching skills:"))
+        #expect(prompt.contains("step one"))
+    }
+}

--- a/tests/e2e/mock-worker.mjs
+++ b/tests/e2e/mock-worker.mjs
@@ -1,0 +1,95 @@
+#!/usr/bin/env node
+import http from "node:http";
+
+const PORT = Number(process.env.MOCK_WORKER_PORT ?? 8787);
+
+function jsonResponse(res, status, body) {
+  res.writeHead(status, { "content-type": "application/json" });
+  res.end(JSON.stringify(body));
+}
+
+function streamVoiceResponse(res) {
+  const text =
+    "click file then save, or use command s. [POINT:120,40:file menu]";
+  const chunks = text.match(/.{1,12}/g) ?? [text];
+
+  res.writeHead(200, {
+    "content-type": "text/event-stream",
+    "cache-control": "no-cache",
+  });
+
+  for (const chunk of chunks) {
+    const payload = {
+      type: "content_block_delta",
+      delta: { type: "text_delta", text: chunk },
+    };
+    res.write(`data: ${JSON.stringify(payload)}\n\n`);
+  }
+  res.write("data: [DONE]\n\n");
+  res.end();
+}
+
+function synthesisResponse(res) {
+  jsonResponse(res, 200, {
+    content: [
+      {
+        type: "text",
+        text: [
+          "workflow: save a document in textedit",
+          "step one: click file in the menu bar",
+          "step two: choose save or press command s",
+          "pointing: start at the file menu near the top left",
+          "common mistake: looking for a floppy disk icon instead of file > save",
+          "completion: user says got it or thanks that worked",
+        ].join("\n"),
+      },
+    ],
+  });
+}
+
+const server = http.createServer(async (req, res) => {
+  if (req.method !== "POST") {
+    res.writeHead(405);
+    res.end("Method not allowed");
+    return;
+  }
+
+  const body = await new Promise((resolve, reject) => {
+    const chunks = [];
+    req.on("data", (chunk) => chunks.push(chunk));
+    req.on("end", () => resolve(Buffer.concat(chunks).toString("utf8")));
+    req.on("error", reject);
+  });
+
+  if (req.url === "/tts") {
+    res.writeHead(200, { "content-type": "audio/mpeg" });
+    res.end(Buffer.from([0xff, 0xfb, 0x90, 0x00]));
+    return;
+  }
+
+  if (req.url === "/chat") {
+    let parsed = {};
+    try {
+      parsed = JSON.parse(body);
+    } catch {
+      res.writeHead(400);
+      res.end("invalid json");
+      return;
+    }
+
+    if (parsed.stream === true) {
+      streamVoiceResponse(res);
+      return;
+    }
+
+    synthesisResponse(res);
+    return;
+  }
+
+  res.writeHead(404);
+  res.end("Not found");
+});
+
+server.listen(PORT, "127.0.0.1", () => {
+  console.log(`mock worker listening on http://127.0.0.1:${PORT}`);
+});

--- a/tests/e2e/niche-discovery.sh
+++ b/tests/e2e/niche-discovery.sh
@@ -194,3 +194,51 @@ fi
 
 echo ""
 echo "E2E PASS: Phase A (niche set) + Phase B (persistence) succeeded (+ Phase C niche clause in prompt)"
+
+kill "$CLICKY_PID" 2>/dev/null || true
+CLICKY_PID=""
+if [[ -n "$MOCK_WORKER_PID" ]]; then
+  kill "$MOCK_WORKER_PID" 2>/dev/null || true
+  MOCK_WORKER_PID=""
+fi
+sleep 1
+
+echo "Phase D: verify app-aware Xcode suggestions..."
+rm -f "$NICHE_JSON"
+defaults delete "$BUNDLE_ID" selectedUserNiche 2>/dev/null || true
+
+"$CLICKY_APP/Contents/MacOS/Clicky" \
+  -CLICKY_E2E=1 \
+  -CLICKY_E2E_SET_NICHE=developer \
+  -CLICKY_E2E_FRONTMOST_BUNDLE_ID=com.apple.dt.Xcode >/tmp/clicky-e2e-niche-app-aware.log 2>&1 &
+CLICKY_PID=$!
+
+PHASE_D_OK=0
+for _ in $(seq 1 15); do
+  if [[ -f "$NICHE_JSON" ]]; then
+    is_app_aware="$(read_niche_json_field isAppAware)"
+    suggestion_context="$(python3 -c "import json,sys; print(json.load(open(sys.argv[1])).get('suggestionContext') or '')" "$NICHE_JSON")"
+    first_id="$(read_niche_json_field firstSuggestionId)"
+
+    if [[ "$is_app_aware" == "True" ]] && [[ "$suggestion_context" == *"Xcode"* ]] && [[ "$first_id" == xcode-* ]]; then
+      echo "PASS: app-aware Xcode suggestions — context='$suggestion_context' first=$first_id"
+      PHASE_D_OK=1
+      break
+    fi
+  fi
+  sleep 1
+done
+
+if [[ "$PHASE_D_OK" -ne 1 ]]; then
+  echo "FAIL: Phase D app-aware check failed within 15s"
+  echo "--- app log ---"
+  tail -40 /tmp/clicky-e2e-niche-app-aware.log || true
+  if [[ -f "$NICHE_JSON" ]]; then
+    echo "--- niche json ---"
+    cat "$NICHE_JSON" || true
+  fi
+  exit 1
+fi
+
+echo ""
+echo "E2E PASS: Phase A + B + C + D (app-aware) succeeded"

--- a/tests/e2e/niche-discovery.sh
+++ b/tests/e2e/niche-discovery.sh
@@ -1,0 +1,196 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="$(cd "$(dirname "$0")/../.." && pwd)"
+CLICKY_APP="${CLICKY_APP:-$ROOT_DIR/build/E2E/Clicky.app}"
+WORKER_URL="${CLICKY_WORKER_URL:-http://127.0.0.1:8787}"
+NICHE_JSON="$HOME/.clicky/e2e-niche-discovery.json"
+PROMPT_FILE="$HOME/.clicky/e2e-last-system-prompt.txt"
+BUNDLE_ID="com.yourcompany.leanring-buddy"
+MOCK_WORKER_PID=""
+CLICKY_PID=""
+
+cleanup() {
+  if [[ -n "$MOCK_WORKER_PID" ]]; then
+    kill "$MOCK_WORKER_PID" 2>/dev/null || true
+  fi
+  if [[ -n "$CLICKY_PID" ]]; then
+    kill "$CLICKY_PID" 2>/dev/null || true
+  fi
+}
+trap cleanup EXIT
+
+read_niche_json_field() {
+  local field="$1"
+  python3 -c "import json,sys; print(json.load(open(sys.argv[1]))[sys.argv[2]])" "$NICHE_JSON" "$field"
+}
+
+assert_phase_a_json() {
+  if [[ ! -f "$NICHE_JSON" ]]; then
+    echo "FAIL: $NICHE_JSON missing"
+    return 1
+  fi
+
+  local selected_niche suggestion_count first_id clause_token
+  selected_niche="$(read_niche_json_field selectedNiche)"
+  suggestion_count="$(read_niche_json_field suggestionCount)"
+  first_id="$(read_niche_json_field firstSuggestionId)"
+  clause_token="$(read_niche_json_field voicePromptClauseContains)"
+
+  if [[ "$selected_niche" != "developer" ]]; then
+    echo "FAIL: selectedNiche is '$selected_niche', expected developer"
+    return 1
+  fi
+
+  if [[ "$suggestion_count" -lt 3 ]]; then
+    echo "FAIL: suggestionCount is $suggestion_count, expected >= 3"
+    return 1
+  fi
+
+  if [[ "$clause_token" != "developer" ]]; then
+    echo "FAIL: voicePromptClauseContains is '$clause_token', expected developer"
+    return 1
+  fi
+
+  case "$first_id" in
+    commit-changes|run-tests|debug-breakpoint|terminal-command|find-setting) ;;
+    *)
+      echo "FAIL: firstSuggestionId '$first_id' is not a developer.json id"
+      return 1
+      ;;
+  esac
+
+  echo "PASS: niche discovery JSON — niche=$selected_niche count=$suggestion_count first=$first_id"
+  return 0
+}
+
+echo "Building Clicky for E2E..."
+mkdir -p "$ROOT_DIR/build/E2E"
+xcodebuild \
+  -project "$ROOT_DIR/leanring-buddy.xcodeproj" \
+  -scheme leanring-buddy \
+  -destination 'platform=macOS' \
+  -derivedDataPath "$ROOT_DIR/build/E2E/DerivedData" \
+  CODE_SIGN_IDENTITY="-" \
+  CODE_SIGNING_ALLOWED=NO \
+  build >/tmp/clicky-e2e-niche-build.log 2>&1
+
+BUILT_APP="$ROOT_DIR/build/E2E/DerivedData/Build/Products/Debug/Clicky.app"
+rm -rf "$CLICKY_APP"
+ditto "$BUILT_APP" "$CLICKY_APP"
+
+echo "Phase A: set developer niche and load bundled suggestions..."
+defaults delete "$BUNDLE_ID" selectedUserNiche 2>/dev/null || true
+rm -f "$NICHE_JSON"
+
+"$CLICKY_APP/Contents/MacOS/Clicky" \
+  -CLICKY_E2E=1 \
+  -CLICKY_E2E_SET_NICHE=developer >/tmp/clicky-e2e-niche-app.log 2>&1 &
+CLICKY_PID=$!
+
+PHASE_A_OK=0
+for _ in $(seq 1 15); do
+  if [[ -f "$NICHE_JSON" ]] && assert_phase_a_json; then
+    PHASE_A_OK=1
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$PHASE_A_OK" -ne 1 ]]; then
+  echo "FAIL: Phase A did not produce valid niche discovery JSON within 15s"
+  echo "--- app log ---"
+  tail -40 /tmp/clicky-e2e-niche-app.log || true
+  if [[ -f "$NICHE_JSON" ]]; then
+    echo "--- niche json ---"
+    cat "$NICHE_JSON" || true
+  fi
+  exit 1
+fi
+
+echo "--- niche json preview ---"
+head -20 "$NICHE_JSON"
+
+kill "$CLICKY_PID" 2>/dev/null || true
+CLICKY_PID=""
+sleep 1
+
+echo "Phase B: verify developer niche persists across relaunch..."
+rm -f "$NICHE_JSON"
+
+"$CLICKY_APP/Contents/MacOS/Clicky" \
+  -CLICKY_E2E=1 >/tmp/clicky-e2e-niche-persist.log 2>&1 &
+CLICKY_PID=$!
+
+PHASE_B_OK=0
+for _ in $(seq 1 15); do
+  if [[ -f "$NICHE_JSON" ]]; then
+    selected_niche="$(read_niche_json_field selectedNiche)"
+    if [[ "$selected_niche" == "developer" ]]; then
+      echo "PASS: developer niche persisted after relaunch"
+      PHASE_B_OK=1
+      break
+    fi
+  fi
+  sleep 1
+done
+
+if [[ "$PHASE_B_OK" -ne 1 ]]; then
+  echo "FAIL: Phase B persistence check failed within 15s"
+  echo "--- app log ---"
+  tail -40 /tmp/clicky-e2e-niche-persist.log || true
+  if [[ -f "$NICHE_JSON" ]]; then
+    cat "$NICHE_JSON" || true
+  else
+    echo "niche json missing: $NICHE_JSON"
+  fi
+  exit 1
+fi
+
+kill "$CLICKY_PID" 2>/dev/null || true
+CLICKY_PID=""
+sleep 1
+
+echo "Phase C: verify content-creator niche clause in composed system prompt..."
+rm -f "$PROMPT_FILE" "$NICHE_JSON"
+defaults delete "$BUNDLE_ID" selectedUserNiche 2>/dev/null || true
+
+echo "Starting mock worker on $WORKER_URL..."
+node "$ROOT_DIR/tests/e2e/mock-worker.mjs" >/tmp/clicky-e2e-niche-worker.log 2>&1 &
+MOCK_WORKER_PID=$!
+sleep 1
+
+"$CLICKY_APP/Contents/MacOS/Clicky" \
+  -CLICKY_E2E=1 \
+  -CLICKY_WORKER_URL="$WORKER_URL" \
+  -CLICKY_E2E_SET_NICHE=content-creator \
+  -CLICKY_INJECT_TRANSCRIPT_3="how do I export this video?" >/tmp/clicky-e2e-niche-prompt.log 2>&1 &
+CLICKY_PID=$!
+
+PHASE_C_OK=0
+for _ in $(seq 1 30); do
+  if [[ -f "$PROMPT_FILE" ]] && grep -qi "content creator" "$PROMPT_FILE"; then
+    echo "PASS: content-creator niche clause found in composed system prompt"
+    echo "--- prompt excerpt ---"
+    grep -i "content creator" "$PROMPT_FILE" | head -3
+    PHASE_C_OK=1
+    break
+  fi
+  sleep 1
+done
+
+if [[ "$PHASE_C_OK" -ne 1 ]]; then
+  echo "FAIL: Phase C did not include content-creator niche clause within 30s"
+  echo "--- app log ---"
+  tail -40 /tmp/clicky-e2e-niche-prompt.log || true
+  if [[ -f "$PROMPT_FILE" ]]; then
+    echo "--- prompt file ---"
+    head -40 "$PROMPT_FILE" || true
+  else
+    echo "prompt file missing: $PROMPT_FILE"
+  fi
+  exit 1
+fi
+
+echo ""
+echo "E2E PASS: Phase A (niche set) + Phase B (persistence) succeeded (+ Phase C niche clause in prompt)"

--- a/tests/e2e/run-all.sh
+++ b/tests/e2e/run-all.sh
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
+
+echo "Running Clicky niche-discovery E2E..."
+echo ""
+
+exec "$SCRIPT_DIR/niche-discovery.sh" "$@"


### PR DESCRIPTION
## Summary

- Adds niche discovery onboarding: picker (Creator, Developer, Student, Designer, Other), bundled example prompts, copy-to-clipboard suggestion cards, and niche-specific voice prompt clauses
- Adds app-aware suggestions that swap example prompts based on the frontmost app (e.g. Xcode-specific prompts when Developer niche is selected)
- Adds headless E2E (Phases A–D: niche set, persistence, prompt clause, app-aware) with mock worker and GitHub Actions CI

## Test plan

- [x] `./tests/e2e/run-all.sh` passes locally (Phases A–D)
- [ ] Run `NicheDiscoveryTests` from Xcode
- [ ] Manual: pick a niche in menu bar panel, confirm suggestions appear
- [ ] Manual: open Xcode with Developer niche selected, confirm app-aware suggestion label and Xcode-specific prompts
- [ ] Manual: hold Control+Option and ask a question, confirm niche clause affects response tone