### PR TITLE
Fix: Preserve user's response language (#7)

### DIFF
--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -551,6 +551,7 @@ final class CompanionManager: ObservableObject {
     - don't use abbreviations or symbols that sound weird read aloud. write "for example" not "e.g.", spell out small numbers.
     - if the user's question relates to what's on their screen, reference specific things you see.
     - if the screenshot doesn't seem relevant to their question, just answer the question directly.
+    - reply in the same natural language the user used in their latest message. if the user speaks russian, answer in russian; if they use another non-english language, stay in that language unless they explicitly ask you to translate or switch languages.
     - you can help with anything — coding, writing, general knowledge, brainstorming.
     - never say "simply" or "just".
     - don't read out code verbatim. describe what the code does or what needs to change conversationally.


### PR DESCRIPTION
## Summary
- Updates Clicky's companion response prompt to answer in the same natural language as the user's latest message.
- Explicitly covers Russian and other non-English inputs so responses do not randomly switch to Spanish, Italian, or English.
- Keeps translation and language switching available when the user explicitly asks for it.

## Problem
Issue #7 reports that Clicky can reply in the wrong language when the user speaks or writes in Russian or another non-English language. The response prompt did not directly instruct the model to preserve the user's current language, so multilingual interactions could drift into unrelated languages.

## Fix
Added a focused language-preservation rule to the companion voice response system prompt in `CompanionManager.swift`. The rule tells Clicky to respond in the same natural language as the user's latest message, while still allowing explicit translation or language-switch requests.

## Verification
- Ran `swiftc -parse leanring-buddy/*.swift` successfully.
- Reviewed the prompt flow to confirm the new instruction is included in every companion voice response request.
- Tested locally and confirmed the fix works as expected.

Closes #7