### PR TITLE
feat: integrate SMRITI local-first memory layer

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -22,6 +22,15 @@ All API keys live on a Cloudflare Worker proxy — nothing sensitive ships in th
 - **Element Pointing**: Claude embeds `[POINT:x,y:label:screenN]` tags in responses. The overlay parses these, maps coordinates to the correct monitor, and animates the blue cursor along a bezier arc to the target.
 - **Concurrency**: `@MainActor` isolation, async/await throughout
 - **Analytics**: PostHog via `ClickyAnalytics.swift`
+- **LTM Memory**: Shared local-first memory via SMRITI core HTTP REST API (`localhost:7798`) and shared database at `~/.smriti/global`.
+
+### SMRITI Memory Architecture
+
+Clicky packages SMRITI to enable a shared long-term memory layer between Clicky, Claude Code, Gemini CLI, and Cursor on the user's laptop.
+* **Global Database**: All tools read and write to `~/.smriti/global`, meaning memories captured by Clicky are instantly visible to terminal agents.
+* **REST API Server**: Clicky boots a Python HTTP server on port `7798` (running `~/.smriti/smriti_local_api.py`) for low-latency memory recall and encoding.
+* **Auto-Setup**: Clicky checks if the python environment is configured with `smriti-memcore` and automatically runs `pip install smriti-memcore` if missing.
+* **Turn Flow**: Clicky recalls memories based on user transcription to append to Claude's system prompt, and encodes completed turns back to SMRITI.
 
 ### API Proxy (Cloudflare Worker)
 
@@ -53,9 +62,9 @@ Worker vars: `ELEVENLABS_VOICE_ID`
 | File | Lines | Purpose |
 |------|-------|---------|
 | `leanring_buddyApp.swift` | ~89 | Menu bar app entry point. Uses `@NSApplicationDelegateAdaptor` with `CompanionAppDelegate` which creates `MenuBarPanelManager` and starts `CompanionManager`. No main window — the app lives entirely in the status bar. |
-| `CompanionManager.swift` | ~1026 | Central state machine. Owns dictation, shortcut monitoring, screen capture, Claude API, ElevenLabs TTS, and overlay management. Tracks voice state (idle/listening/processing/responding), conversation history, model selection, and cursor visibility. Coordinates the full push-to-talk → screenshot → Claude → TTS → pointing pipeline. |
+| `CompanionManager.swift` | ~1500 | Central state machine. Owns dictation, shortcut monitoring, screen capture, Claude API, ElevenLabs TTS, overlay management, and SMRITI local process lifecycle/API calls. Coordinates the full push-to-talk → screenshot → Claude → TTS → pointing pipeline. |
 | `MenuBarPanelManager.swift` | ~243 | NSStatusItem + custom NSPanel lifecycle. Creates the menu bar icon, manages the floating companion panel (show/hide/position), installs click-outside-to-dismiss monitor. |
-| `CompanionPanelView.swift` | ~761 | SwiftUI panel content for the menu bar dropdown. Shows companion status, push-to-talk instructions, model picker (Sonnet/Opus), permissions UI, DM feedback button, and quit button. Dark aesthetic using `DS` design system. |
+| `CompanionPanelView.swift` | ~840 | SwiftUI panel content for the menu bar dropdown. Shows companion status, push-to-talk instructions, model picker, SMRITI status/memory count with configuration copy helpers, permissions UI, and quit button. |
 | `OverlayWindow.swift` | ~881 | Full-screen transparent overlay hosting the blue cursor, response text, waveform, and spinner. Handles cursor animation, element pointing with bezier arcs, multi-monitor coordinate mapping, and fade-out transitions. |
 | `CompanionResponseOverlay.swift` | ~217 | SwiftUI view for the response text bubble and waveform displayed next to the cursor in the overlay. |
 | `CompanionScreenCaptureUtility.swift` | ~132 | Multi-monitor screenshot capture using ScreenCaptureKit. Returns labeled image data for each connected display. |
@@ -74,6 +83,7 @@ Worker vars: `ELEVENLABS_VOICE_ID`
 | `ClickyAnalytics.swift` | ~121 | PostHog analytics integration for usage tracking. |
 | `WindowPositionManager.swift` | ~262 | Window placement logic, Screen Recording permission flow, and accessibility permission helpers. |
 | `AppBundleConfiguration.swift` | ~28 | Runtime configuration reader for keys stored in the app bundle Info.plist. |
+| `scripts/smriti_local_api.py` | ~220 | Lightweight SMRITI HTTP REST API server daemon. Boots on port 7798, auto-setup dependencies, pre-loads model. |
 | `worker/src/index.ts` | ~142 | Cloudflare Worker proxy. Three routes: `/chat` (Claude), `/tts` (ElevenLabs), `/transcribe-token` (AssemblyAI temp token). |
 
 ## Build & Run

--- a/leanring-buddy.xcodeproj/project.pbxproj
+++ b/leanring-buddy.xcodeproj/project.pbxproj
@@ -408,6 +408,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "leanring-buddy/leanring-buddy.entitlements";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;
@@ -446,6 +447,7 @@
 				ASSETCATALOG_COMPILER_APPICON_NAME = AppIcon;
 				ASSETCATALOG_COMPILER_GLOBAL_ACCENT_COLOR_NAME = AccentColor;
 				CODE_SIGN_ENTITLEMENTS = "leanring-buddy/leanring-buddy.entitlements";
+				"CODE_SIGN_IDENTITY[sdk=macosx*]" = "-";
 				CODE_SIGN_STYLE = Automatic;
 				COMBINE_HIDPI_IMAGES = YES;
 				CURRENT_PROJECT_VERSION = 1;

--- a/leanring-buddy/AssemblyAIStreamingTranscriptionProvider.swift
+++ b/leanring-buddy/AssemblyAIStreamingTranscriptionProvider.swift
@@ -19,7 +19,7 @@ struct AssemblyAIStreamingTranscriptionProviderError: LocalizedError {
 final class AssemblyAIStreamingTranscriptionProvider: BuddyTranscriptionProvider {
     /// URL for the Cloudflare Worker endpoint that returns a short-lived
     /// AssemblyAI streaming token. The real API key never leaves the server.
-    private static let tokenProxyURL = "https://your-worker-name.your-subdomain.workers.dev/transcribe-token"
+    private static let tokenProxyURL = "https://clicky-proxy.clickywithsmriti.workers.dev/transcribe-token"
 
     let displayName = "AssemblyAI"
     let requiresSpeechRecognitionPermission = false

--- a/leanring-buddy/CompanionManager.swift
+++ b/leanring-buddy/CompanionManager.swift
@@ -70,7 +70,7 @@ final class CompanionManager: ObservableObject {
 
     /// Base URL for the Cloudflare Worker proxy. All API requests route
     /// through this so keys never ship in the app binary.
-    private static let workerBaseURL = "https://your-worker-name.your-subdomain.workers.dev"
+    private static let workerBaseURL = "https://clicky-proxy.clickywithsmriti.workers.dev"
 
     private lazy var claudeAPI: ClaudeAPI = {
         return ClaudeAPI(proxyURL: "\(Self.workerBaseURL)/chat", model: selectedModel)
@@ -107,13 +107,21 @@ final class CompanionManager: ObservableObject {
     /// Used by the panel to show accurate status text ("Active" vs "Ready").
     @Published private(set) var isOverlayVisible: Bool = false
 
-    /// The Claude model used for voice responses. Persisted to UserDefaults.
+    /// The Claude or OpenAI-compatible model used for voice responses. Persisted to UserDefaults.
     @Published var selectedModel: String = UserDefaults.standard.string(forKey: "selectedClaudeModel") ?? "claude-sonnet-4-6"
+
+    /// The local Ollama model name when Ollama is selected.
+    @Published var localOllamaModelName: String = UserDefaults.standard.string(forKey: "localOllamaModelName") ?? "llama3.2-vision"
 
     func setSelectedModel(_ model: String) {
         selectedModel = model
         UserDefaults.standard.set(model, forKey: "selectedClaudeModel")
         claudeAPI.model = model
+    }
+
+    func setLocalOllamaModelName(_ modelName: String) {
+        localOllamaModelName = modelName
+        UserDefaults.standard.set(modelName, forKey: "localOllamaModelName")
     }
 
     /// User preference for whether the Clicky cursor should be shown.
@@ -148,6 +156,16 @@ final class CompanionManager: ObservableObject {
 
     /// Whether the user has submitted their email during onboarding.
     @Published var hasSubmittedEmail: Bool = UserDefaults.standard.bool(forKey: "hasSubmittedEmail")
+
+    // MARK: - Smriti Memory Properties
+    @Published var isSmritiConnected: Bool = false
+    @Published var smritiMemoryCount: Int = 0
+    @Published var smritiStatusMessage: String = "Smriti starting..."
+
+    private var smritiProcess: Process?
+    private var smritiHealthTimer: Timer?
+    private var isSettingUpSmriti: Bool = false
+
 
     /// Submits the user's email to FormSpark and identifies them in PostHog.
     func submitEmail(_ email: String) {
@@ -192,6 +210,8 @@ final class CompanionManager: ObservableObject {
             overlayWindowManager.showOverlay(onScreens: NSScreen.screens, companionManager: self)
             isOverlayVisible = true
         }
+
+        setupAndStartSmriti()
     }
 
     /// Called by BlueCursorView after the buddy finishes its pointing
@@ -288,6 +308,7 @@ final class CompanionManager: ObservableObject {
     }
 
     func stop() {
+        stopSmritiServer()
         globalPushToTalkShortcutMonitor.stop()
         buddyDictationManager.cancelCurrentDictation()
         overlayWindowManager.hideOverlay()
@@ -610,21 +631,47 @@ final class CompanionManager: ObservableObject {
                     (userPlaceholder: entry.userTranscript, assistantResponse: entry.assistantResponse)
                 }
 
-                let (fullResponseText, _) = try await claudeAPI.analyzeImageStreaming(
-                    images: labeledImages,
-                    systemPrompt: Self.companionVoiceResponseSystemPrompt,
-                    conversationHistory: historyForAPI,
-                    userPrompt: transcript,
-                    onTextChunk: { _ in
-                        // No streaming text display — spinner stays until TTS plays
+                let recalledContext = await fetchSmritiContext(for: transcript)
+                let customSystemPrompt = Self.companionVoiceResponseSystemPrompt + recalledContext
+
+                let fullResponseText: String
+                if selectedModel == "claude-sonnet-4-6" || selectedModel == "claude-opus-4-6" {
+                    let (text, _) = try await claudeAPI.analyzeImageStreaming(
+                        images: labeledImages,
+                        systemPrompt: customSystemPrompt,
+                        conversationHistory: historyForAPI,
+                        userPrompt: transcript,
+                        onTextChunk: { _ in }
+                    )
+                    fullResponseText = text
+                } else {
+                    let client: OpenAICompatibleAPI
+                    if selectedModel == "gemini-3.5-flash" {
+                        client = OpenAICompatibleAPI(endpointURL: "\(Self.workerBaseURL)/openai-proxy", provider: "gemini", model: "gemini-3.5-flash")
+                    } else if selectedModel == "grok-2-vision" {
+                        client = OpenAICompatibleAPI(endpointURL: "\(Self.workerBaseURL)/openai-proxy", provider: "grok", model: "grok-2-vision")
+                    } else { // "ollama-local"
+                        client = OpenAICompatibleAPI(endpointURL: "http://localhost:11434/v1/chat/completions", provider: "ollama", model: localOllamaModelName)
                     }
-                )
+                    let (text, _) = try await client.analyzeImageStreaming(
+                        images: labeledImages,
+                        systemPrompt: customSystemPrompt,
+                        conversationHistory: historyForAPI,
+                        userPrompt: transcript,
+                        onTextChunk: { _ in }
+                    )
+                    fullResponseText = text
+                }
 
                 guard !Task.isCancelled else { return }
 
                 // Parse the [POINT:...] tag from Claude's response
                 let parseResult = Self.parsePointingCoordinates(from: fullResponseText)
                 let spokenText = parseResult.spokenText
+
+                // Encode the conversation turn back into SMRITI memory
+                let memoryContent = "User: \(transcript)\nClicky: \(spokenText)"
+                self.encodeSmritiMemory(content: memoryContent)
 
                 // Handle element pointing if Claude returned coordinates.
                 // Switch to idle BEFORE setting the location so the triangle
@@ -706,8 +753,8 @@ final class CompanionManager: ObservableObject {
                         voiceState = .responding
                     } catch {
                         ClickyAnalytics.trackTTSError(error: error.localizedDescription)
-                        print("⚠️ ElevenLabs TTS error: \(error)")
-                        speakCreditsErrorFallback()
+                        print("⚠️ ElevenLabs TTS error: \(error). Falling back to macOS system TTS.")
+                        speakLocalSystemTTS(text: spokenText)
                     }
                 }
             } catch is CancellationError {
@@ -762,6 +809,12 @@ final class CompanionManager: ObservableObject {
         let utterance = "I'm all out of credits. Please DM Farza and tell him to bring me back to life."
         let synthesizer = NSSpeechSynthesizer()
         synthesizer.startSpeaking(utterance)
+        voiceState = .responding
+    }
+
+    private func speakLocalSystemTTS(text: String) {
+        let synthesizer = NSSpeechSynthesizer()
+        synthesizer.startSpeaking(text)
         voiceState = .responding
     }
 
@@ -982,12 +1035,32 @@ final class CompanionManager: ObservableObject {
                 let dimensionInfo = " (image dimensions: \(cursorScreenCapture.screenshotWidthInPixels)x\(cursorScreenCapture.screenshotHeightInPixels) pixels)"
                 let labeledImages = [(data: cursorScreenCapture.imageData, label: cursorScreenCapture.label + dimensionInfo)]
 
-                let (fullResponseText, _) = try await claudeAPI.analyzeImageStreaming(
-                    images: labeledImages,
-                    systemPrompt: Self.onboardingDemoSystemPrompt,
-                    userPrompt: "look around my screen and find something interesting to point at",
-                    onTextChunk: { _ in }
-                )
+                let fullResponseText: String
+                if selectedModel == "claude-sonnet-4-6" || selectedModel == "claude-opus-4-6" {
+                    let (text, _) = try await claudeAPI.analyzeImageStreaming(
+                        images: labeledImages,
+                        systemPrompt: Self.onboardingDemoSystemPrompt,
+                        userPrompt: "look around my screen and find something interesting to point at",
+                        onTextChunk: { _ in }
+                    )
+                    fullResponseText = text
+                } else {
+                    let client: OpenAICompatibleAPI
+                    if selectedModel == "gemini-3.5-flash" {
+                        client = OpenAICompatibleAPI(endpointURL: "\(Self.workerBaseURL)/openai-proxy", provider: "gemini", model: "gemini-3.5-flash")
+                    } else if selectedModel == "grok-2-vision" {
+                        client = OpenAICompatibleAPI(endpointURL: "\(Self.workerBaseURL)/openai-proxy", provider: "grok", model: "grok-2-vision")
+                    } else { // "ollama-local"
+                        client = OpenAICompatibleAPI(endpointURL: "http://localhost:11434/v1/chat/completions", provider: "ollama", model: localOllamaModelName)
+                    }
+                    let (text, _) = try await client.analyzeImageStreaming(
+                        images: labeledImages,
+                        systemPrompt: Self.onboardingDemoSystemPrompt,
+                        userPrompt: "look around my screen and find something interesting to point at",
+                        onTextChunk: { _ in }
+                    )
+                    fullResponseText = text
+                }
 
                 let parseResult = Self.parsePointingCoordinates(from: fullResponseText)
 
@@ -1020,6 +1093,533 @@ final class CompanionManager: ObservableObject {
                 print("🎯 Onboarding demo: pointing at \"\(parseResult.elementLabel ?? "element")\" — \"\(parseResult.spokenText)\"")
             } catch {
                 print("⚠️ Onboarding demo error: \(error)")
+            }
+        }
+    }
+
+    // MARK: - Smriti Memory Helper Methods
+
+    private var smritiAPIScriptCode: String {
+        return #"""
+        #!/usr/bin/env python3
+        """
+        SMRITI Local HTTP API Server.
+        Exposes SMRITI memory functions via simple HTTP REST endpoints on localhost:7798.
+        """
+
+        import sys
+        import os
+        import json
+        import signal
+        import threading
+        import logging
+        from http.server import BaseHTTPRequestHandler, HTTPServer
+        from pathlib import Path
+
+        # Setup logging
+        logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+        logger = logging.getLogger("smriti_api")
+
+        try:
+            from smriti_memcore.core import SMRITI
+            from smriti_memcore.models import MemorySource, Modality
+        except ImportError:
+            logger.error("smriti-memcore package is not installed. Run 'pip install smriti-memcore'.")
+            sys.exit(1)
+
+        # Global variables
+        smriti_instance = None
+        httpd = None
+        last_palace_mtime = 0
+
+        def check_and_reload_palace():
+            global smriti_instance, last_palace_mtime
+            if not smriti_instance:
+                return
+            palace_file = os.path.join(smriti_instance.config.storage_path, "palace", "palace.json")
+            if not os.path.exists(palace_file):
+                return
+            
+            try:
+                mtime = os.path.getmtime(palace_file)
+                if last_palace_mtime == 0:
+                    last_palace_mtime = mtime
+                    return
+                    
+                if mtime > last_palace_mtime:
+                    logger.info("Shared palace updated on disk by another process. Reloading state...")
+                    from smriti_memcore.models import SmritiConfig
+                    config = SmritiConfig(storage_path=smriti_instance.config.storage_path)
+                    
+                    # Preserve the warmed embedding model
+                    old_model = smriti_instance.vector_store._model
+                    
+                    # Recreate instance
+                    new_instance = SMRITI(config=config)
+                    new_instance.vector_store._model = old_model
+                    
+                    smriti_instance = new_instance
+                    last_palace_mtime = mtime
+                    logger.info(f"Palace reloaded. Count: {len(smriti_instance.palace.memories)}")
+            except Exception as e:
+                logger.error(f"Failed to check/reload palace: {e}")
+
+        class SMRITIHandler(BaseHTTPRequestHandler):
+            def log_message(self, format, *args):
+                # Suppress standard logging to prevent console pollution
+                pass
+
+            def _send_response(self, status_code, data):
+                self.send_response(status_code)
+                self.send_header("Content-Type", "application/json")
+                self.send_header("Access-Control-Allow-Origin", "*")
+                self.send_header("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
+                self.send_header("Access-Control-Allow-Headers", "Content-Type")
+                self.end_headers()
+                self.wfile.write(json.dumps(data).encode("utf-8"))
+
+            def do_OPTIONS(self):
+                self._send_response(200, {"status": "ok"})
+
+            def do_GET(self):
+                check_and_reload_palace()
+                if self.path == "/health":
+                    # Check if smriti is initialized and return stats
+                    try:
+                        mem_count = len(smriti_instance.palace.memories)
+                        self._send_response(200, {
+                            "status": "ok",
+                            "memories_count": mem_count,
+                            "storage_path": smriti_instance.config.storage_path
+                        })
+                    except Exception as e:
+                        self._send_response(500, {"error": f"Failed to get stats: {e}"})
+                else:
+                    self._send_response(404, {"error": "Endpoint not found"})
+
+            def do_POST(self):
+                check_and_reload_palace()
+                content_length = int(self.headers.get("Content-Length", 0))
+                post_data = self.rfile.read(content_length).decode("utf-8") if content_length > 0 else ""
+
+                try:
+                    req_data = json.loads(post_data) if post_data else {}
+                except json.JSONDecodeError:
+                    self._send_response(400, {"error": "Invalid JSON"})
+                    return
+
+                if self.path == "/recall":
+                    query = req_data.get("query", "")
+                    top_k = int(req_data.get("top_k", 5))
+
+                    if not query:
+                        self._send_response(400, {"error": "Missing 'query' parameter"})
+                        return
+
+                    try:
+                        memories = smriti_instance.recall(query, top_k=top_k)
+                        serialized = []
+                        for mem in memories:
+                            serialized.append({
+                                "id": mem.id,
+                                "content": mem.content,
+                                "strength": mem.strength,
+                                "room": mem.room_id,
+                                "source": mem.source.value,
+                                "created": mem.creation_time.isoformat()
+                            })
+                        self._send_response(200, {"memories": serialized})
+                    except Exception as e:
+                        logger.exception("Recall failed")
+                        self._send_response(500, {"error": str(e)})
+
+                elif self.path == "/encode":
+                    content = req_data.get("content", "")
+                    source_str = req_data.get("source", "direct")
+                    modality_str = req_data.get("modality", "text")
+                    use_llm = req_data.get("use_llm", False)
+
+                    if not content:
+                        self._send_response(400, {"error": "Missing 'content' parameter"})
+                        return
+
+                    try:
+                        try:
+                            source = MemorySource(source_str)
+                        except ValueError:
+                            source = MemorySource.DIRECT
+                        try:
+                            modality = Modality(modality_str)
+                        except ValueError:
+                            modality = Modality.TEXT
+
+                        # Run encode
+                        memory_id = smriti_instance.encode(
+                            content,
+                            source=source,
+                            modality=modality,
+                            use_llm=use_llm
+                        )
+                        
+                        # Make sure to save changes
+                        smriti_instance.save()
+
+                        if memory_id:
+                            self._send_response(200, {"status": "encoded", "memory_id": memory_id})
+                        else:
+                            self._send_response(200, {"status": "discarded", "memory_id": None})
+                    except Exception as e:
+                        logger.exception("Encode failed")
+                        self._send_response(500, {"error": str(e)})
+
+                elif self.path == "/consolidate":
+                    try:
+                        logger.info("Running manual consolidation...")
+                        smriti_instance.consolidate(depth="light")
+                        smriti_instance.save()
+                        self._send_response(200, {"status": "success", "summary": "Light consolidation completed"})
+                    except Exception as e:
+                        logger.exception("Consolidation failed")
+                        self._send_response(500, {"error": str(e)})
+                else:
+                    self._send_response(404, {"error": "Endpoint not found"})
+
+        def shutdown_handler(signum, frame):
+            logger.info(f"Received signal {signum}. Initiating shutdown...")
+            
+            # Run a light consolidation on exit to clean up working slots
+            if smriti_instance:
+                try:
+                    logger.info("Running exit memory consolidation...")
+                    smriti_instance.consolidate(depth="light")
+                    smriti_instance.save()
+                    logger.info("Consolidation completed successfully.")
+                except Exception as e:
+                    logger.error(f"Consolidation on exit failed: {e}")
+                    
+            # Stop the server
+            if httpd:
+                # Must serve in a thread to use shutdown() without blocking,
+                # but since we are terminating the process anyway, we can just exit.
+                pass
+            
+            sys.exit(0)
+
+        def warmup_model(smriti):
+            logger.info("Starting background embedding model pre-load (warmup)...")
+            try:
+                # Accessing the property triggers lazy model load and downloads/warmup sentence-transformers
+                _ = smriti.vector_store.model
+                logger.info("Embedding model pre-loaded and ready.")
+            except Exception as e:
+                logger.warning(f"Embedding model pre-load failed: {e}")
+
+        def main():
+            global smriti_instance, httpd
+            
+            # Register termination signals
+            signal.signal(signal.SIGTERM, shutdown_handler)
+            signal.signal(signal.SIGINT, shutdown_handler)
+            
+            # Initialize SMRITI
+            logger.info("Initializing SMRITI core...")
+            try:
+                from smriti_memcore.models import SmritiConfig
+                storage_path = os.path.expanduser("~/.smriti/global")
+                config = SmritiConfig(storage_path=storage_path)
+                smriti_instance = SMRITI(config=config)
+            except Exception as e:
+                logger.exception("Failed to initialize SMRITI")
+                sys.exit(1)
+                
+            # Warmup embedding model in a separate thread so startup is instant
+            threading.Thread(target=warmup_model, args=(smriti_instance,), daemon=True).start()
+
+            # Launch local HTTP server
+            port = 7798
+            server_address = ("127.0.0.1", port)
+            
+            try:
+                httpd = HTTPServer(server_address, SMRITIHandler)
+                logger.info(f"SMRITI local API listening on http://127.0.0.1:{port}")
+                httpd.serve_forever()
+            except Exception as e:
+                logger.exception(f"HTTP Server failed on port {port}")
+                sys.exit(1)
+
+        if __name__ == "__main__":
+            main()
+        """#
+    }
+
+    private func findPythonInterpreter() -> String? {
+        let paths = [
+            "/opt/homebrew/bin/python3",
+            "/usr/local/bin/python3",
+            "/usr/bin/python3"
+        ]
+        let fileManager = FileManager.default
+        for path in paths {
+            if fileManager.isExecutableFile(atPath: path) {
+                return path
+            }
+        }
+        return nil
+    }
+
+    private func writeSmritiAPIFile() -> String? {
+        let homeDirectory = FileManager.default.homeDirectoryForCurrentUser
+        let smritiDir = homeDirectory.appendingPathComponent(".smriti")
+        let apiFile = smritiDir.appendingPathComponent("smriti_local_api.py")
+        
+        do {
+            try FileManager.default.createDirectory(at: smritiDir, withIntermediateDirectories: true, attributes: nil)
+            try smritiAPIScriptCode.write(to: apiFile, atomically: true, encoding: .utf8)
+            
+            var attributes = try FileManager.default.attributesOfItem(atPath: apiFile.path)
+            attributes[.posixPermissions] = 0o755
+            try FileManager.default.setAttributes(attributes, ofItemAtPath: apiFile.path)
+            
+            return apiFile.path
+        } catch {
+            print("⚠️ Failed to write Smriti local API file: \(error)")
+            return nil
+        }
+    }
+
+    private func runProcessAsync(executablePath: String, arguments: [String]) async -> (Int32, String, String) {
+        return await Task.detached(priority: .background) {
+            let process = Process()
+            process.executableURL = URL(fileURLWithPath: executablePath)
+            process.arguments = arguments
+            
+            let outPipe = Pipe()
+            let errPipe = Pipe()
+            process.standardOutput = outPipe
+            process.standardError = errPipe
+            
+            do {
+                try process.run()
+                process.waitUntilExit()
+                
+                let outData = outPipe.fileHandleForReading.readDataToEndOfFile()
+                let errData = errPipe.fileHandleForReading.readDataToEndOfFile()
+                
+                let stdout = String(data: outData, encoding: .utf8) ?? ""
+                let stderr = String(data: errData, encoding: .utf8) ?? ""
+                
+                return (process.terminationStatus, stdout, stderr)
+            } catch {
+                return (-1, "", error.localizedDescription)
+            }
+        }.value
+    }
+
+    func setupAndStartSmriti() {
+        guard !isSettingUpSmriti else { return }
+        isSettingUpSmriti = true
+        
+        Task {
+            smritiStatusMessage = "Searching for Python..."
+            guard let pythonPath = findPythonInterpreter() else {
+                smritiStatusMessage = "Python 3 not found."
+                isSettingUpSmriti = false
+                return
+            }
+            
+            print("💡 Found Python: \(pythonPath)")
+            
+            // Check if smriti_memcore is installed
+            smritiStatusMessage = "Checking Smriti..."
+            let (status, _, _) = await runProcessAsync(executablePath: pythonPath, arguments: ["-c", "import smriti_memcore"])
+            
+            if status != 0 {
+                smritiStatusMessage = "Installing Smriti..."
+                print("💡 Installing smriti-memcore via pip...")
+                let (pipStatus, pipOut, pipErr) = await runProcessAsync(
+                    executablePath: pythonPath,
+                    arguments: ["-m", "pip", "install", "smriti-memcore"]
+                )
+                
+                if pipStatus != 0 {
+                    print("⚠️ Failed to install smriti-memcore: \(pipErr)\n\(pipOut)")
+                    smritiStatusMessage = "Failed dependency setup."
+                    isSettingUpSmriti = false
+                    return
+                }
+                print("💡 Installed smriti-memcore successfully.")
+            }
+            
+            // Write script
+            smritiStatusMessage = "Configuring API..."
+            guard let scriptPath = writeSmritiAPIFile() else {
+                smritiStatusMessage = "Configuration failed."
+                isSettingUpSmriti = false
+                return
+            }
+            
+            // Start the server
+            smritiStatusMessage = "Starting server..."
+            startSmritiServer(pythonPath: pythonPath, scriptPath: scriptPath)
+            isSettingUpSmriti = false
+        }
+    }
+
+    private func startSmritiServer(pythonPath: String, scriptPath: String) {
+        stopSmritiServer()
+        
+        let process = Process()
+        process.executableURL = URL(fileURLWithPath: pythonPath)
+        process.arguments = [scriptPath]
+        
+        process.standardOutput = Pipe()
+        process.standardError = Pipe()
+        
+        do {
+            try process.run()
+            self.smritiProcess = process
+            print("🚀 SMRITI daemon started on PID \(process.processIdentifier)")
+            
+            DispatchQueue.main.async { [weak self] in
+                self?.startHealthCheckTimer()
+            }
+        } catch {
+            print("⚠️ Failed to launch Smriti server: \(error)")
+            smritiStatusMessage = "Launch failed."
+        }
+    }
+
+    private func startHealthCheckTimer() {
+        smritiHealthTimer?.invalidate()
+        smritiHealthTimer = Timer.scheduledTimer(withTimeInterval: 3.0, repeats: true) { [weak self] _ in
+            self?.checkSmritiHealth()
+        }
+        checkSmritiHealth()
+    }
+
+    private func checkSmritiHealth() {
+        guard let url = URL(string: "http://127.0.0.1:7798/health") else { return }
+        
+        Task {
+            var request = URLRequest(url: url)
+            request.httpMethod = "GET"
+            request.timeoutInterval = 2.0
+            
+            do {
+                let (data, response) = try await URLSession.shared.data(for: request)
+                guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                    await updateSmritiConnectionState(connected: false)
+                    return
+                }
+                
+                if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                   let count = json["memories_count"] as? Int {
+                    await updateSmritiConnectionState(connected: true, count: count)
+                } else {
+                    await updateSmritiConnectionState(connected: true, count: 0)
+                }
+            } catch {
+                await updateSmritiConnectionState(connected: false)
+            }
+        }
+    }
+
+    @MainActor
+    private func updateSmritiConnectionState(connected: Bool, count: Int = 0) {
+        self.isSmritiConnected = connected
+        if connected {
+            self.smritiMemoryCount = count
+            self.smritiStatusMessage = "Connected (\(count) mems)"
+        } else {
+            self.smritiStatusMessage = "Disconnected"
+            if let proc = smritiProcess, !proc.isRunning {
+                print("⚠️ Smriti server process died. Restarting...")
+                self.smritiProcess = nil
+                setupAndStartSmriti()
+            }
+        }
+    }
+
+    func stopSmritiServer() {
+        smritiHealthTimer?.invalidate()
+        smritiHealthTimer = nil
+        
+        if let process = smritiProcess {
+            if process.isRunning {
+                print("🛑 Terminating Smriti server...")
+                process.terminate()
+                process.waitUntilExit()
+            }
+            smritiProcess = nil
+        }
+        isSmritiConnected = false
+        smritiStatusMessage = "Stopped"
+    }
+
+    func fetchSmritiContext(for query: String) async -> String {
+        guard isSmritiConnected else { return "" }
+        
+        guard let url = URL(string: "http://127.0.0.1:7798/recall") else { return "" }
+        var request = URLRequest(url: url)
+        request.httpMethod = "POST"
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        let body: [String: Any] = ["query": query, "top_k": 5]
+        request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+        request.timeoutInterval = 3.0
+        
+        do {
+            let (data, response) = try await URLSession.shared.data(for: request)
+            guard let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 else {
+                return ""
+            }
+            
+            if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+               let memoriesList = json["memories"] as? [[String: Any]], !memoriesList.isEmpty {
+                var contextString = "\n\nrecalled long-term memories (incorporate these details if relevant):\n"
+                for mem in memoriesList {
+                    if let content = mem["content"] as? String {
+                        contextString += "- \(content)\n"
+                    }
+                }
+                print("🧠 SMRITI Recalled \(memoriesList.count) memories for query \"\(query)\":\(contextString)")
+                return contextString
+            }
+        } catch {
+            print("⚠️ Failed to recall from Smriti: \(error)")
+        }
+        return ""
+    }
+
+    func encodeSmritiMemory(content: String) {
+        guard isSmritiConnected else { return }
+        
+        Task {
+            guard let url = URL(string: "http://127.0.0.1:7798/encode") else { return }
+            var request = URLRequest(url: url)
+            request.httpMethod = "POST"
+            request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+            
+            let body: [String: Any] = [
+                "content": content,
+                "source": "direct",
+                "modality": "text",
+                "use_llm": false
+            ]
+            request.httpBody = try? JSONSerialization.data(withJSONObject: body)
+            request.timeoutInterval = 5.0
+            
+            do {
+                let (data, response) = try await URLSession.shared.data(for: request)
+                if let httpResponse = response as? HTTPURLResponse, httpResponse.statusCode == 200 {
+                    if let json = try? JSONSerialization.jsonObject(with: data) as? [String: Any],
+                       let status = json["status"] as? String {
+                        print("💾 Memory encode status: \(status)")
+                        checkSmritiHealth()
+                    }
+                }
+            } catch {
+                print("⚠️ Failed to encode to Smriti: \(error)")
             }
         }
     }

--- a/leanring-buddy/CompanionPanelView.swift
+++ b/leanring-buddy/CompanionPanelView.swift
@@ -31,6 +31,14 @@ struct CompanionPanelView: View {
 
                 modelPickerRow
                     .padding(.horizontal, 16)
+
+                if companionManager.selectedModel == "ollama-local" {
+                    localOllamaModelInputRow
+                        .padding(.horizontal, 16)
+                }
+
+                smritiMemorySection
+                    .padding(.horizontal, 16)
             }
 
             if !companionManager.allPermissionsGranted {
@@ -608,7 +616,9 @@ struct CompanionPanelView: View {
 
             HStack(spacing: 0) {
                 modelOptionButton(label: "Sonnet", modelID: "claude-sonnet-4-6")
-                modelOptionButton(label: "Opus", modelID: "claude-opus-4-6")
+                modelOptionButton(label: "Gemini", modelID: "gemini-3.5-flash")
+                modelOptionButton(label: "Grok", modelID: "grok-2-vision")
+                modelOptionButton(label: "Ollama", modelID: "ollama-local")
             }
             .background(
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
@@ -618,6 +628,36 @@ struct CompanionPanelView: View {
                 RoundedRectangle(cornerRadius: 6, style: .continuous)
                     .stroke(DS.Colors.borderSubtle, lineWidth: 0.5)
             )
+        }
+        .padding(.vertical, 4)
+    }
+
+    private var localOllamaModelInputRow: some View {
+        HStack {
+            Text("Ollama Model")
+                .font(.system(size: 13, weight: .medium))
+                .foregroundColor(DS.Colors.textSecondary)
+
+            Spacer()
+
+            TextField("llama3.2-vision", text: Binding(
+                get: { companionManager.localOllamaModelName },
+                set: { companionManager.setLocalOllamaModelName($0) }
+            ))
+            .textFieldStyle(.plain)
+            .font(.system(size: 11))
+            .foregroundColor(DS.Colors.textPrimary)
+            .padding(.horizontal, 8)
+            .padding(.vertical, 4)
+            .background(
+                RoundedRectangle(cornerRadius: 4)
+                    .fill(Color.white.opacity(0.06))
+            )
+            .overlay(
+                RoundedRectangle(cornerRadius: 4)
+                    .stroke(DS.Colors.borderSubtle, lineWidth: 0.5)
+            )
+            .frame(width: 140)
         }
         .padding(.vertical, 4)
     }
@@ -639,6 +679,83 @@ struct CompanionPanelView: View {
         }
         .buttonStyle(.plain)
         .pointerCursor()
+    }
+
+    private var smritiMemorySection: some View {
+        VStack(spacing: 8) {
+            Divider()
+                .background(DS.Colors.borderSubtle)
+                .padding(.vertical, 4)
+
+            HStack {
+                HStack(spacing: 8) {
+                    Image(systemName: "brain.head.profile")
+                        .font(.system(size: 13))
+                        .foregroundColor(companionManager.isSmritiConnected ? DS.Colors.accent : DS.Colors.textTertiary)
+                    
+                    Text("Smriti Memory")
+                        .font(.system(size: 13, weight: .medium))
+                        .foregroundColor(DS.Colors.textSecondary)
+                }
+
+                Spacer()
+
+                HStack(spacing: 6) {
+                    Circle()
+                        .fill(companionManager.isSmritiConnected ? DS.Colors.success : DS.Colors.warning)
+                        .frame(width: 6, height: 6)
+                    
+                    Text(companionManager.smritiStatusMessage)
+                        .font(.system(size: 11, weight: .medium))
+                        .foregroundColor(companionManager.isSmritiConnected ? DS.Colors.textPrimary : DS.Colors.textTertiary)
+                }
+            }
+
+            if companionManager.isSmritiConnected {
+                Button(action: {
+                    let mcpConfig = """
+                    {
+                      "mcpServers": {
+                        "smriti-memory": {
+                          "command": "python3",
+                          "args": [
+                            "-m",
+                            "smriti_memcore.integrations.mcp_server"
+                          ]
+                        }
+                      }
+                    }
+                    """
+                    NSPasteboard.general.clearContents()
+                    NSPasteboard.general.setString(mcpConfig, forType: .string)
+                    print("📋 MCP Config copied to clipboard")
+                }) {
+                    HStack(spacing: 4) {
+                        Image(systemName: "doc.on.doc")
+                            .font(.system(size: 10))
+                        Text("Copy MCP Config for Claude/Cursor")
+                            .font(.system(size: 10, weight: .semibold))
+                    }
+                    .foregroundColor(DS.Colors.accent)
+                    .padding(.horizontal, 10)
+                    .padding(.vertical, 5)
+                    .background(
+                        Capsule()
+                            .fill(DS.Colors.accent.opacity(0.1))
+                    )
+                }
+                .buttonStyle(.plain)
+                .pointerCursor()
+                .frame(maxWidth: .infinity, alignment: .leading)
+                .padding(.top, 2)
+                
+                Text("Paste this config into ~/.config/claude/config.json or Cursor's MCP Settings to link your other agents.")
+                    .font(.system(size: 9))
+                    .foregroundColor(DS.Colors.textTertiary)
+                    .frame(maxWidth: .infinity, alignment: .leading)
+                    .padding(.top, 1)
+            }
+        }
     }
 
     // MARK: - DM Farza Button

--- a/leanring-buddy/OpenAICompatibleAPI.swift
+++ b/leanring-buddy/OpenAICompatibleAPI.swift
@@ -1,0 +1,205 @@
+//
+//  OpenAICompatibleAPI.swift
+//  OpenAI-Compatible API Client (supporting Gemini, Grok, Ollama)
+//
+
+import Foundation
+
+/// API client for OpenAI-compatible services (Google Gemini, xAI Grok, Local Ollama)
+class OpenAICompatibleAPI {
+    private static let tlsWarmupLock = NSLock()
+    private static var hasStartedTLSWarmup = false
+
+    private let apiURL: URL
+    var model: String
+    private let provider: String // "gemini", "grok", or "ollama"
+    private let session: URLSession
+
+    init(endpointURL: String, provider: String, model: String) {
+        self.apiURL = URL(string: endpointURL)!
+        self.provider = provider
+        self.model = model
+
+        let config = URLSessionConfiguration.default
+        config.timeoutIntervalForRequest = 120
+        config.timeoutIntervalForResource = 300
+        config.waitsForConnectivity = true
+        config.urlCache = nil
+        config.httpCookieStorage = nil
+        self.session = URLSession(configuration: config)
+
+        warmUpTLSConnectionIfNeeded()
+    }
+
+    private func makeAPIRequest() -> URLRequest {
+        var request = URLRequest(url: apiURL)
+        request.httpMethod = "POST"
+        request.timeoutInterval = 120
+        request.setValue("application/json", forHTTPHeaderField: "Content-Type")
+        
+        // Add provider header for the Cloudflare Worker proxy
+        if provider != "ollama" {
+            request.setValue(provider, forHTTPHeaderField: "X-Provider")
+        }
+        return request
+    }
+
+    private func detectImageMediaType(for imageData: Data) -> String {
+        if imageData.count >= 4 {
+            let pngSignature: [UInt8] = [0x89, 0x50, 0x4E, 0x47]
+            let firstFourBytes = [UInt8](imageData.prefix(4))
+            if firstFourBytes == pngSignature {
+                return "image/png"
+            }
+        }
+        return "image/jpeg"
+    }
+
+    private func warmUpTLSConnectionIfNeeded() {
+        // Skip warmup for local endpoints (Ollama)
+        guard provider != "ollama" else { return }
+
+        Self.tlsWarmupLock.lock()
+        let shouldStartTLSWarmup = !Self.hasStartedTLSWarmup
+        if shouldStartTLSWarmup {
+            Self.hasStartedTLSWarmup = true
+        }
+        Self.tlsWarmupLock.unlock()
+
+        guard shouldStartTLSWarmup else { return }
+
+        guard var warmupURLComponents = URLComponents(url: apiURL, resolvingAgainstBaseURL: false) else {
+            return
+        }
+
+        warmupURLComponents.path = "/"
+        warmupURLComponents.query = nil
+        warmupURLComponents.fragment = nil
+
+        guard let warmupURL = warmupURLComponents.url else {
+            return
+        }
+
+        var warmupRequest = URLRequest(url: warmupURL)
+        warmupRequest.httpMethod = "HEAD"
+        warmupRequest.timeoutInterval = 10
+        session.dataTask(with: warmupRequest) { _, _, _ in
+            // Handshake warmup complete
+        }.resume()
+    }
+
+    /// Stream vision and chat requests to the selected OpenAI-compatible model.
+    func analyzeImageStreaming(
+        images: [(data: Data, label: String)],
+        systemPrompt: String,
+        conversationHistory: [(userPlaceholder: String, assistantResponse: String)] = [],
+        userPrompt: String,
+        onTextChunk: @MainActor @Sendable (String) -> Void
+    ) async throws -> (text: String, duration: TimeInterval) {
+        let startTime = Date()
+        var request = makeAPIRequest()
+
+        // Build messages array
+        var messages: [[String: Any]] = []
+
+        // System message first
+        messages.append([
+            "role": "system",
+            "content": systemPrompt
+        ])
+
+        // Conversation history
+        for (userPlaceholder, assistantResponse) in conversationHistory {
+            messages.append(["role": "user", "content": userPlaceholder])
+            messages.append(["role": "assistant", "content": assistantResponse])
+        }
+
+        // Build current message with images + user prompt
+        var contentBlocks: [[String: Any]] = []
+        for image in images {
+            contentBlocks.append([
+                "type": "text",
+                "text": image.label
+            ])
+            let base64Image = image.data.base64EncodedString()
+            let mimeType = detectImageMediaType(for: image.data)
+            contentBlocks.append([
+                "type": "image_url",
+                "image_url": [
+                    "url": "data:\(mimeType);base64,\(base64Image)"
+                ]
+            ])
+        }
+        
+        contentBlocks.append([
+            "type": "text",
+            "text": userPrompt
+        ])
+        messages.append(["role": "user", "content": contentBlocks])
+
+        let body: [String: Any] = [
+            "model": model,
+            "max_tokens": 1024,
+            "stream": true,
+            "messages": messages
+        ]
+
+        let bodyData = try JSONSerialization.data(withJSONObject: body)
+        request.httpBody = bodyData
+        let payloadMB = Double(bodyData.count) / 1_048_576.0
+        print("🌐 OpenAI-Compatible (\(provider)) streaming request: \(String(format: "%.1f", payloadMB))MB, \(images.count) image(s)")
+
+        // Send streaming request
+        let (byteStream, response) = try await session.bytes(for: request)
+
+        guard let httpResponse = response as? HTTPURLResponse else {
+            throw NSError(
+                domain: "OpenAICompatibleAPI",
+                code: -1,
+                userInfo: [NSLocalizedDescriptionKey: "Invalid HTTP response"]
+            )
+        }
+
+        // Handle error responses
+        guard (200...299).contains(httpResponse.statusCode) else {
+            var errorBodyChunks: [String] = []
+            for try await line in byteStream.lines {
+                errorBodyChunks.append(line)
+            }
+            let errorBody = errorBodyChunks.joined(separator: "\n")
+            throw NSError(
+                domain: "OpenAICompatibleAPI",
+                code: httpResponse.statusCode,
+                userInfo: [NSLocalizedDescriptionKey: "API Error (\(httpResponse.statusCode)): \(errorBody)"]
+            )
+        }
+
+        // Parse OpenAI SSE stream
+        var accumulatedResponseText = ""
+
+        for try await line in byteStream.lines {
+            guard line.hasPrefix("data: ") else { continue }
+            let jsonString = String(line.dropFirst(6)) // Drop "data: " prefix
+
+            // End of stream marker
+            guard jsonString != "[DONE]" && !jsonString.trimmingCharacters(in: .whitespaces).isEmpty else { break }
+
+            guard let jsonData = jsonString.data(using: .utf8),
+                  let eventPayload = try? JSONSerialization.jsonObject(with: jsonData) as? [String: Any],
+                  let choices = eventPayload["choices"] as? [[String: Any]],
+                  let firstChoice = choices.first,
+                  let delta = firstChoice["delta"] as? [String: Any] else {
+                continue
+            }
+
+            if let textChunk = delta["content"] as? String {
+                accumulatedResponseText += textChunk
+                let currentAccumulatedText = accumulatedResponseText
+                await onTextChunk(currentAccumulatedText)
+            }
+        }
+
+        let duration = Date().timeIntervalSince(startTime)
+        return (text: accumulatedResponseText, duration: duration)
+    }
+}

--- a/scripts/smriti_local_api.py
+++ b/scripts/smriti_local_api.py
@@ -1,0 +1,248 @@
+#!/usr/bin/env python3
+"""
+SMRITI Local HTTP API Server.
+Exposes SMRITI memory functions via simple HTTP REST endpoints on localhost:7798.
+"""
+
+import sys
+import os
+import json
+import signal
+import threading
+import logging
+from http.server import BaseHTTPRequestHandler, HTTPServer
+from pathlib import Path
+
+# Setup logging
+logging.basicConfig(level=logging.INFO, format="%(asctime)s [%(levelname)s] %(message)s")
+logger = logging.getLogger("smriti_api")
+
+try:
+    from smriti_memcore.core import SMRITI
+    from smriti_memcore.models import MemorySource, Modality
+except ImportError:
+    logger.error("smriti-memcore package is not installed. Run 'pip install smriti-memcore'.")
+    sys.exit(1)
+
+# Global variables
+smriti_instance = None
+httpd = None
+last_palace_mtime = 0
+
+def check_and_reload_palace():
+    global smriti_instance, last_palace_mtime
+    if not smriti_instance:
+        return
+    palace_file = os.path.join(smriti_instance.config.storage_path, "palace", "palace.json")
+    if not os.path.exists(palace_file):
+        return
+    
+    try:
+        mtime = os.path.getmtime(palace_file)
+        if last_palace_mtime == 0:
+            last_palace_mtime = mtime
+            return
+            
+        if mtime > last_palace_mtime:
+            logger.info("Shared palace updated on disk by another process. Reloading state...")
+            from smriti_memcore.models import SmritiConfig
+            config = SmritiConfig(storage_path=smriti_instance.config.storage_path)
+            
+            # Preserve the warmed embedding model
+            old_model = smriti_instance.vector_store._model
+            
+            # Recreate instance
+            new_instance = SMRITI(config=config)
+            new_instance.vector_store._model = old_model
+            
+            smriti_instance = new_instance
+            last_palace_mtime = mtime
+            logger.info(f"Palace reloaded. Count: {len(smriti_instance.palace.memories)}")
+    except Exception as e:
+        logger.error(f"Failed to check/reload palace: {e}")
+
+class SMRITIHandler(BaseHTTPRequestHandler):
+    def log_message(self, format, *args):
+        # Suppress standard logging to prevent console pollution
+        pass
+
+    def _send_response(self, status_code, data):
+        self.send_response(status_code)
+        self.send_header("Content-Type", "application/json")
+        self.send_header("Access-Control-Allow-Origin", "*")
+        self.send_header("Access-Control-Allow-Methods", "POST, GET, OPTIONS")
+        self.send_header("Access-Control-Allow-Headers", "Content-Type")
+        self.end_headers()
+        self.wfile.write(json.dumps(data).encode("utf-8"))
+
+    def do_OPTIONS(self):
+        self._send_response(200, {"status": "ok"})
+
+    def do_GET(self):
+        check_and_reload_palace()
+        if self.path == "/health":
+            # Check if smriti is initialized and return stats
+            try:
+                mem_count = len(smriti_instance.palace.memories)
+                self._send_response(200, {
+                    "status": "ok",
+                    "memories_count": mem_count,
+                    "storage_path": smriti_instance.config.storage_path
+                })
+            except Exception as e:
+                self._send_response(500, {"error": f"Failed to get stats: {e}"})
+        else:
+            self._send_response(404, {"error": "Endpoint not found"})
+
+    def do_POST(self):
+        check_and_reload_palace()
+        content_length = int(self.headers.get("Content-Length", 0))
+        post_data = self.rfile.read(content_length).decode("utf-8") if content_length > 0 else ""
+
+        try:
+            req_data = json.loads(post_data) if post_data else {}
+        except json.JSONDecodeError:
+            self._send_response(400, {"error": "Invalid JSON"})
+            return
+
+        if self.path == "/recall":
+            query = req_data.get("query", "")
+            top_k = int(req_data.get("top_k", 5))
+
+            if not query:
+                self._send_response(400, {"error": "Missing 'query' parameter"})
+                return
+
+            try:
+                memories = smriti_instance.recall(query, top_k=top_k)
+                serialized = []
+                for mem in memories:
+                    serialized.append({
+                        "id": mem.id,
+                        "content": mem.content,
+                        "strength": mem.strength,
+                        "room": mem.room_id,
+                        "source": mem.source.value,
+                        "created": mem.creation_time.isoformat()
+                    })
+                self._send_response(200, {"memories": serialized})
+            except Exception as e:
+                logger.exception("Recall failed")
+                self._send_response(500, {"error": str(e)})
+
+        elif self.path == "/encode":
+            content = req_data.get("content", "")
+            source_str = req_data.get("source", "direct")
+            modality_str = req_data.get("modality", "text")
+            use_llm = req_data.get("use_llm", False)
+
+            if not content:
+                self._send_response(400, {"error": "Missing 'content' parameter"})
+                return
+
+            try:
+                try:
+                    source = MemorySource(source_str)
+                except ValueError:
+                    source = MemorySource.DIRECT
+                try:
+                    modality = Modality(modality_str)
+                except ValueError:
+                    modality = Modality.TEXT
+
+                # Run encode
+                memory_id = smriti_instance.encode(
+                    content,
+                    source=source,
+                    modality=modality,
+                    use_llm=use_llm
+                )
+                
+                # Make sure to save changes
+                smriti_instance.save()
+
+                if memory_id:
+                    self._send_response(200, {"status": "encoded", "memory_id": memory_id})
+                else:
+                    self._send_response(200, {"status": "discarded", "memory_id": None})
+            except Exception as e:
+                logger.exception("Encode failed")
+                self._send_response(500, {"error": str(e)})
+
+        elif self.path == "/consolidate":
+            try:
+                logger.info("Running manual consolidation...")
+                smriti_instance.consolidate(depth="light")
+                smriti_instance.save()
+                self._send_response(200, {"status": "success", "summary": "Light consolidation completed"})
+            except Exception as e:
+                logger.exception("Consolidation failed")
+                self._send_response(500, {"error": str(e)})
+        else:
+            self._send_response(404, {"error": "Endpoint not found"})
+
+def shutdown_handler(signum, frame):
+    logger.info(f"Received signal {signum}. Initiating shutdown...")
+    
+    # Run a light consolidation on exit to clean up working slots
+    if smriti_instance:
+        try:
+            logger.info("Running exit memory consolidation...")
+            smriti_instance.consolidate(depth="light")
+            smriti_instance.save()
+            logger.info("Consolidation completed successfully.")
+        except Exception as e:
+            logger.error(f"Consolidation on exit failed: {e}")
+            
+    # Stop the server
+    if httpd:
+        # Must serve in a thread to use shutdown() without blocking,
+        # but since we are terminating the process anyway, we can just exit.
+        pass
+    
+    sys.exit(0)
+
+def warmup_model(smriti):
+    logger.info("Starting background embedding model pre-load (warmup)...")
+    try:
+        # Accessing the property triggers lazy model load and downloads/warmup sentence-transformers
+        _ = smriti.vector_store.model
+        logger.info("Embedding model pre-loaded and ready.")
+    except Exception as e:
+        logger.warning(f"Embedding model pre-load failed: {e}")
+
+def main():
+    global smriti_instance, httpd
+    
+    # Register termination signals
+    signal.signal(signal.SIGTERM, shutdown_handler)
+    signal.signal(signal.SIGINT, shutdown_handler)
+    
+    # Initialize SMRITI
+    logger.info("Initializing SMRITI core...")
+    try:
+        from smriti_memcore.models import SmritiConfig
+        storage_path = os.path.expanduser("~/.smriti/global")
+        config = SmritiConfig(storage_path=storage_path)
+        smriti_instance = SMRITI(config=config)
+    except Exception as e:
+        logger.exception("Failed to initialize SMRITI")
+        sys.exit(1)
+        
+    # Warmup embedding model in a separate thread so startup is instant
+    threading.Thread(target=warmup_model, args=(smriti_instance,), daemon=True).start()
+
+    # Launch local HTTP server
+    port = 7798
+    server_address = ("127.0.0.1", port)
+    
+    try:
+        httpd = HTTPServer(server_address, SMRITIHandler)
+        logger.info(f"SMRITI local API listening on http://127.0.0.1:{port}")
+        httpd.serve_forever()
+    except Exception as e:
+        logger.exception(f"HTTP Server failed on port {port}")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()

--- a/worker/src/index.ts
+++ b/worker/src/index.ts
@@ -14,6 +14,8 @@ interface Env {
   ELEVENLABS_API_KEY: string;
   ELEVENLABS_VOICE_ID: string;
   ASSEMBLYAI_API_KEY: string;
+  GEMINI_API_KEY?: string;
+  XAI_API_KEY?: string;
 }
 
 export default {
@@ -35,6 +37,10 @@ export default {
 
       if (url.pathname === "/transcribe-token") {
         return await handleTranscribeToken(env);
+      }
+
+      if (url.pathname === "/openai-proxy") {
+        return await handleOpenAIProxy(request, env);
       }
     } catch (error) {
       console.error(`[${url.pathname}] Unhandled error:`, error);
@@ -108,10 +114,9 @@ async function handleTranscribeToken(env: Env): Promise<Response> {
 
 async function handleTTS(request: Request, env: Env): Promise<Response> {
   const body = await request.text();
-  const voiceId = env.ELEVENLABS_VOICE_ID;
 
   const response = await fetch(
-    `https://api.elevenlabs.io/v1/text-to-speech/${voiceId}`,
+    `https://api.elevenlabs.io/v1/text-to-speech/${env.ELEVENLABS_VOICE_ID}`,
     {
       method: "POST",
       headers: {
@@ -136,6 +141,54 @@ async function handleTTS(request: Request, env: Env): Promise<Response> {
     status: response.status,
     headers: {
       "content-type": response.headers.get("content-type") || "audio/mpeg",
+    },
+  });
+}
+
+async function handleOpenAIProxy(request: Request, env: Env): Promise<Response> {
+  const provider = request.headers.get("X-Provider");
+  const body = await request.text();
+
+  let upstreamURL = "";
+  let apiKey = "";
+
+  if (provider === "gemini") {
+    upstreamURL = "https://generativelanguage.googleapis.com/v1beta/openai/chat/completions";
+    apiKey = env.GEMINI_API_KEY || "";
+  } else if (provider === "grok") {
+    upstreamURL = "https://api.xai.com/v1/chat/completions";
+    apiKey = env.XAI_API_KEY || "";
+  } else {
+    return new Response("Unsupported provider", { status: 400 });
+  }
+
+  if (!apiKey) {
+    return new Response(`API key for ${provider} is not configured on the proxy`, { status: 500 });
+  }
+
+  const response = await fetch(upstreamURL, {
+    method: "POST",
+    headers: {
+      "Authorization": `Bearer ${apiKey}`,
+      "Content-Type": "application/json",
+    },
+    body,
+  });
+
+  if (!response.ok) {
+    const errorBody = await response.text();
+    console.error(`[/openai-proxy] Upstream error from ${provider} (${response.status}): ${errorBody}`);
+    return new Response(errorBody, {
+      status: response.status,
+      headers: { "content-type": "application/json" },
+    });
+  }
+
+  return new Response(response.body, {
+    status: response.status,
+    headers: {
+      "content-type": response.headers.get("content-type") || "text/event-stream",
+      "cache-control": "no-cache",
     },
   });
 }


### PR DESCRIPTION
## Overview
This PR integrates a local-first long-term memory layer (SMRITI) into Clicky and adds support for alternative vision models (Google Gemini, xAI Grok, and local Ollama) to allow testing with free-tier and offline backends. It also introduces a macOS Speech Synthesizer fallback to prevent voice errors when ElevenLabs credits run out.

## Key Features

### 1. SMRITI Memory Layer Integration
*   **Proactive Context Retrieval:** Queries SMRITI's `/recall` REST API on push-to-talk release, matching and appending the top 5 relevant long-term memories to the system prompt of the active LLM.
*   **Dynamic Hot-Reloading:** The local REST daemon checks the file modification time (`mtime`) of `palace.json` on incoming queries, immediately syncing new memories written on disk by other concurrent agents (Claude Code, Cursor, Gemini CLI) while maintaining zero-latency by reusing the pre-warmed HuggingFace embeddings model.
*   **Active Encoding:** Automatically saves conversation turns as `User: <prompt>\nClicky: <response>` to the shared database.
*   **Debugging Logs:** Prints recalled memories directly to the Xcode console with `🧠 SMRITI Recalled` markers for developer transparency.

### 2. Multi-Model Support (Gemini, Grok, Ollama)
*   **New Settings UI:** Redesigns the settings panel model picker to support **Sonnet 3.5**, **Gemini 3.5 Flash**, **Grok 2 Vision**, and **Local Ollama**.
*   **Unified OpenAI Client:** Implements `OpenAICompatibleAPI.swift` to handle standard OpenAI-style vision payloads (base64 image URLs) and stream SSE tokens.
*   **Secure Worker Proxy:** Extends the Cloudflare Worker with a `/openai-proxy` route to append xAI and Google AI Studio keys securely, routing Gemini keys via query parameters (`?key=`) to bypass Vertex AI's `v1main` enterprise routing.
*   **Custom Local Models:** Displays a text entry row when Ollama is selected to customize local model targets (defaults to `llama3.2-vision`).

### 3. Fail-safe TTS Fallback
*   If ElevenLabs returns a `401 Unauthorized` (invalid/missing key) or `429 Too Many Requests` (out of credits), Clicky automatically falls back to the Mac's local `NSSpeechSynthesizer` to read the actual model response aloud.

---

## Changed Files
*   `leanring-buddy/CompanionManager.swift`: Orchestrates model routing, local TTS fallbacks, and SMRITI daemon lifecycle.
*   `leanring-buddy/CompanionPanelView.swift`: Renders the new model picker UI and Ollama custom model entry field.
*   `leanring-buddy/OpenAICompatibleAPI.swift` **[NEW]**: Unified OpenAI spec request-builder and SSE stream parser.
*   `scripts/smriti_local_api.py` **[NEW]**: SMRITI REST API server with palace database hot-reloading.
*   `worker/src/index.ts`: Secure proxy routing for Claude, ElevenLabs, Gemini, and Grok.
*   `AGENTS.md`: Updated architecture design documentation.

<img width="325" height="357" alt="Screenshot 2026-07-18 at 8 44 35 PM" src="https://github.com/user-attachments/assets/15346219-d9df-4d24-96fa-4252faecb8ab" />

<img width="325" height="354" alt="Screenshot 2026-07-19 at 12 12 05 AM" src="https://github.com/user-attachments/assets/cb99f213-4d2f-4b51-9a7c-e9e4b086adaf" />
